### PR TITLE
Prepare to add translation Chinese(zh) into official repository

### DIFF
--- a/.github/workflows/rbe.yml
+++ b/.github/workflows/rbe.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 env:
   # Update the language picker in index.hbs to link new languages.
-  LANGUAGES: ja
+  LANGUAGES: ja zh
 
 jobs:
   test:

--- a/TRANSLATING_ZH.md
+++ b/TRANSLATING_ZH.md
@@ -1,0 +1,32 @@
+# Rust by Example 中文版翻译指南
+
+Rust by Example 中文版的翻译在 https://github.com/rust-lang-cn/rust-by-example 仓库进行审核和校对。
+
+如果您希望参与翻译，请按照以下流程操作：
+
+1. 复刻（fork）https://github.com/rust-lang/rust-by-example 仓库。
+
+2. 在 `po/zh.po` 文件中添加或修改译文。
+
+3. 向 https://github.com/rust-lang-cn/rust-by-example 仓库的 `zh` 分支提交 PR（Pull Request）。
+   - 先在 rust-lang-cn 仓库进行审校，而非直接向原始仓库提交 PR，这样可以更方便进行译文讨论。
+   - 中文社区仓库的默认分支为 `zh`，因此正常创建 PR 时会自动指向该分支。
+
+rust-lang-cn 翻译组成员的维护流程：
+
+1. 审核并校对提交的 PR，先合并到 `zh` 分支。
+
+2. 向 https://github.com/rust-lang/rust-by-example 原始仓库提交 PR。
+
+## 翻译规范
+
+### 总体原则
+
+* 文风应保持正式、清晰、简洁
+* 标点符号原则上使用全角（如括号"（）"和冒号"："等）
+
+### 术语翻译指南
+
+* 对于已经广泛接受的技术术语，保留英文或使用通用的中文翻译
+* 避免生硬的直译，优先考虑符合中文语境的自然表达
+* 保持术语翻译的一致性，可参考 [Rust 语言术语中英文对照表](https://github.com/rust-lang-cn/english-chinese-glossary-of-rust/blob/master/rust-glossary.md)

--- a/po/zh.po
+++ b/po/zh.po
@@ -3335,7 +3335,7 @@ msgid ""
 "But, explicit type conversion (casting) can be performed using the `as` "
 "keyword."
 msgstr ""
-"Rust 不提供原生类型之间的隐式类型转换（coercion, 强制转换）。但是，可以使用 `as` 关键字执行显式类型转换（casting）。"
+"Rust 不支持原始类型之间的隐式类型转换（强制转换）。但可以使用 `as` 关键字进行显式类型转换（转型）。"
 
 #: src/types/cast.md:6
 msgid ""
@@ -3343,15 +3343,15 @@ msgid ""
 "except in cases where C has undefined behavior. The behavior of all casts "
 "between integral types is well defined in Rust."
 msgstr ""
-"整型类型之间的转换规则通常遵循 C 语言的惯例，除了 C 语言中存在未定义行为的情况。在 Rust 中，所有整型类型之间的转换行为都是明确定义的。"
+"整数类型之间的转换规则通常遵循 C 语言惯例，但 C 中存在未定义行为的情况除外。在 Rust 中，所有整数类型之间的转换行为都有明确定义。"
 
 #: src/types/cast.md:11
 msgid "// Suppress all warnings from casts which overflow.\n"
-msgstr "// 抑制所有来自溢出转换的警告。\n"
+msgstr "// 抑制所有由溢出转换引起的警告。\n"
 
 #: src/types/cast.md:17
 msgid "// Error! No implicit conversion\n"
-msgstr "// 报错！没有隐式转换\n"
+msgstr "// 错误！不允许隐式转换\n"
 
 #: src/types/cast.md:21
 msgid "// Explicit conversion\n"
@@ -3362,12 +3362,12 @@ msgid ""
 "// Error! There are limitations in conversion rules.\n"
 "    // A float cannot be directly converted to a char.\n"
 msgstr ""
-"// 报错！转换规则有限制。\n"
+"// 错误！转换规则有限制。\n"
 "    // 浮点数不能直接转换为字符。\n"
 
 #: src/types/cast.md:30
 msgid "\"Casting: {} -> {} -> {}\""
-msgstr "\"转换：{} -> {} -> {}\""
+msgstr "\"类型转换：{} -> {} -> {}\""
 
 #: src/types/cast.md:32
 msgid ""
@@ -3376,7 +3376,7 @@ msgid ""
 "    // fits into the new type\n"
 msgstr ""
 "// 当将任何值转换为无符号类型 T 时，\n"
-"    // 会不断加上或减去 T::MAX + 1，直到该值\n"
+"    // 会反复加上或减去 T::MAX + 1，直到该值\n"
 "    // 适合新类型\n"
 
 #: src/types/cast.md:36
@@ -3385,7 +3385,7 @@ msgstr "// 1000 已经适合 u16\n"
 
 #: src/types/cast.md:37
 msgid "\"1000 as a u16 is: {}\""
-msgstr "\"1000 作为 u16 是：{}\""
+msgstr "\"1000 转换为 u16 是：{}\""
 
 #: src/types/cast.md:39
 msgid ""
@@ -3394,12 +3394,12 @@ msgid ""
 "    // while the rest towards the most significant bit (MSB) get truncated.\n"
 msgstr ""
 "// 1000 - 256 - 256 - 256 = 232\n"
-"    // 在底层，保留了最低有效位（LSB）的前 8 位，\n"
+"    // 实际上，保留了最低有效位（LSB）的前 8 位，\n"
 "    // 而朝最高有效位（MSB）方向的其余位被截断。\n"
 
 #: src/types/cast.md:42 src/types/cast.md:61
 msgid "\"1000 as a u8 is : {}\""
-msgstr "\"1000 作为 u8 是：{}\""
+msgstr "\"1000 转换为 u8 是：{}\""
 
 #: src/types/cast.md:43
 msgid "// -1 + 256 = 255\n"
@@ -3407,15 +3407,15 @@ msgstr "// -1 + 256 = 255\n"
 
 #: src/types/cast.md:44
 msgid "\"  -1 as a u8 is : {}\""
-msgstr "\"  -1 作为 u8 是：{}\""
+msgstr "\"  -1 转换为 u8 是：{}\""
 
 #: src/types/cast.md:46
 msgid "// For positive numbers, this is the same as the modulus\n"
-msgstr "// 对于正数，这与取模操作相同\n"
+msgstr "// 对于正数，这等同于取模运算\n"
 
 #: src/types/cast.md:47
 msgid "\"1000 mod 256 is : {}\""
-msgstr "\"1000 mod 256 是：{}\""
+msgstr "\"1000 对 256 取模是：{}\""
 
 #: src/types/cast.md:49
 msgid ""
@@ -3424,9 +3424,9 @@ msgid ""
 "significant\n"
 "    // bit of that value is 1, then the value is negative.\n"
 msgstr ""
-"// 当转换为有符号类型时，（按位）结果与\n"
-"    // 首先转换为相应的无符号类型相同。如果该值的最高有效位\n"
-"    // 是 1，那么该值为负数。\n"
+"// 当转换为有符号类型时，（按位）结果等同于\n"
+"    // 先转换为对应的无符号类型。如果该值的最高有效位\n"
+"    // 为 1，则该值为负数。\n"
 
 #: src/types/cast.md:53
 msgid "// Unless it already fits, of course.\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -4793,120 +4793,131 @@ msgstr ""
 msgid ""
 "For some use cases, when matching enums, `match` is awkward. For example:"
 msgstr ""
+"在某些场景中，当匹配枚举时，使用 `match` 会显得很奇怪。例如："
 
 #: src/flow_control/if_let.md:6 src/flow_control/while_let.md:7
 #: src/flow_control/while_let.md:35
 msgid "// Make `optional` of type `Option<i32>`\n"
-msgstr ""
+msgstr "// 创建 `Option<i32>` 类型的 `optional`\n"
 
 #: src/flow_control/if_let.md:10
 msgid "\"This is a really long string and `{:?}`\""
-msgstr ""
+msgstr "\"这是一个非常长的字符串和 `{:?}`\""
 
 #: src/flow_control/if_let.md:12
 msgid ""
 "// ^ Required because `match` is exhaustive. Doesn't it seem\n"
 "    // like wasted space?\n"
 msgstr ""
+"// ^ 这是必要的，因为 `match` 需要穷举。不觉得这行很多余吗？\n"
 
 #: src/flow_control/if_let.md:18
 msgid ""
 "`if let` is cleaner for this use case and in addition allows various failure "
 "options to be specified:"
 msgstr ""
+"`if let` 对于这种场景更加简洁，而且还允许指定各种失败的选项："
 
 #: src/flow_control/if_let.md:23
 msgid "// All have type `Option<i32>`\n"
-msgstr ""
+msgstr "// 全都是 `Option<i32>` 类型\n"
 
 #: src/flow_control/if_let.md:28
 msgid ""
 "// The `if let` construct reads: \"if `let` destructures `number` into\n"
 "    // `Some(i)`, evaluate the block (`{}`).\n"
 msgstr ""
+"// `if let` 结构读作：如果 `let` 将 `number` 解构成 `Some(i)`，\n"
+"    // 则执行语句块（`{}`）。\n"
 
 #: src/flow_control/if_let.md:31 src/flow_control/if_let.md:36
 #: src/flow_control/if_let.md:46
 msgid "\"Matched {:?}!\""
-msgstr ""
+msgstr "\"匹配 {:?}！\""
 
 #: src/flow_control/if_let.md:34
 msgid "// If you need to specify a failure, use an else:\n"
-msgstr ""
+msgstr "// 如果需要指定一个失败的情况，使用 else：\n"
 
 #: src/flow_control/if_let.md:38
 msgid "// Destructure failed. Change to the failure case.\n"
-msgstr ""
+msgstr "// 解构失败。切换到失败情况。\n"
 
 #: src/flow_control/if_let.md:39 src/flow_control/if_let.md:50
 msgid "\"Didn't match a number. Let's go with a letter!\""
-msgstr ""
+msgstr "\"没有匹配到数字。我们用一个字母吧！\""
 
 #: src/flow_control/if_let.md:42
 msgid "// Provide an altered failing condition.\n"
-msgstr ""
+msgstr "// 提供一个改变的失败条件。\n"
 
 #: src/flow_control/if_let.md:47
 msgid ""
 "// Destructure failed. Evaluate an `else if` condition to see if the\n"
 "    // alternate failure branch should be taken:\n"
 msgstr ""
+"// 解构失败。评估 `else if` 条件，看看是否应该执行\n"
+"    // 替代的失败分支：\n"
 
 #: src/flow_control/if_let.md:52
 msgid "// The condition evaluated false. This branch is the default:\n"
-msgstr ""
+msgstr "// 条件判断为假。这个分支是默认情况：\n"
 
 #: src/flow_control/if_let.md:53
 msgid "\"I don't like letters. Let's go with an emoticon :)!\""
-msgstr ""
+msgstr "\"我不喜欢字母。我们用个表情符号吧 :)！\""
 
 #: src/flow_control/if_let.md:58
 msgid "In the same way, `if let` can be used to match any enum value:"
-msgstr ""
+msgstr "同样地，`if let` 可以用来匹配任何枚举值："
 
 #: src/flow_control/if_let.md:61
 msgid "// Our example enum\n"
-msgstr ""
+msgstr "// 我们的示例枚举\n"
 
 #: src/flow_control/if_let.md:69
 msgid "// Create example variables\n"
-msgstr ""
+msgstr "// 创建示例变量\n"
 
 #: src/flow_control/if_let.md:74 src/flow_control/if_let.md:110
 msgid "// Variable a matches Foo::Bar\n"
-msgstr ""
+msgstr "// 变量 a 匹配 Foo::Bar\n"
 
 #: src/flow_control/if_let.md:76 src/flow_control/if_let.md:113
 msgid "\"a is foobar\""
-msgstr ""
+msgstr "\"a 是 foobar\""
 
 #: src/flow_control/if_let.md:79
 msgid ""
 "// Variable b does not match Foo::Bar\n"
 "    // So this will print nothing\n"
 msgstr ""
+"// 变量 b 不匹配 Foo::Bar\n"
+"    // 所以这里不会打印任何东西\n"
 
 #: src/flow_control/if_let.md:82
 msgid "\"b is foobar\""
-msgstr ""
+msgstr "\"b 是 foobar\""
 
 #: src/flow_control/if_let.md:85
 msgid ""
 "// Variable c matches Foo::Qux which has a value\n"
 "    // Similar to Some() in the previous example\n"
 msgstr ""
+"// 变量 c 匹配 Foo::Qux，它有一个值\n"
+"    // 类似于前面例子中的 Some()\n"
 
 #: src/flow_control/if_let.md:88
 msgid "\"c is {}\""
-msgstr ""
+msgstr "\"c 是 {}\""
 
 #: src/flow_control/if_let.md:91
 msgid "// Binding also works with `if let`\n"
-msgstr ""
+msgstr "// 绑定也可以用于 `if let`\n"
 
 #: src/flow_control/if_let.md:93
 msgid "\"c is one hundred\""
-msgstr ""
+msgstr "\"c 是一百\""
 
 #: src/flow_control/if_let.md:98
 msgid ""
@@ -4916,36 +4927,42 @@ msgid ""
 "because instances of the enum cannot be equated, however `if let` will "
 "continue to work."
 msgstr ""
+"`if let` 的另一个好处是它允许我们匹配非参数化的枚举变体。即使在枚举没有实现或派生 `PartialEq` 的情况下也是如此。在这种情况下，`if Foo::Bar == a` 将无法编译，因为枚举的实例无法进行相等比较，但 `if let` 仍然可以正常工作。"
 
 #: src/flow_control/if_let.md:100
 msgid "Would you like a challenge? Fix the following example to use `if let`:"
-msgstr ""
+msgstr "想要一个挑战吗？修复下面的例子，使用 `if let`："
 
 #: src/flow_control/if_let.md:103
 msgid ""
 "// This enum purposely neither implements nor derives PartialEq.\n"
 "// That is why comparing Foo::Bar == a fails below.\n"
 msgstr ""
+"// 这个枚举故意既不实现也不派生 PartialEq。\n"
+"// 这就是为什么下面比较 Foo::Bar == a 会失败。\n"
 
 #: src/flow_control/if_let.md:112
 msgid "// ^-- this causes a compile-time error. Use `if let` instead.\n"
-msgstr ""
+msgstr "// ^-- 这会导致编译时错误。使用 `if let` 来替代。\n"
 
 #: src/flow_control/if_let.md:120
 msgid ""
 "[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the [RFC]"
 "(https://github.com/rust-lang/rfcs/pull/160)"
 msgstr ""
+"[`枚举`](../custom_types/enum.md)，[`Option`](../std/option.md)，以及 [RFC]"
+"(https://github.com/rust-lang/rfcs/pull/160)"
 
 #: src/flow_control/let_else.md:4
 msgid "🛈 stable since: rust 1.65"
-msgstr ""
+msgstr "🛈 自 rust 1.65 版本起稳定"
 
 #: src/flow_control/let_else.md:6
 msgid ""
 "🛈 you can target specific edition by compiling like this `rustc --"
 "edition=2021 main.rs`"
 msgstr ""
+"🛈 你可以通过这样编译来指定特定版本 `rustc --edition=2021 main.rs`"
 
 #: src/flow_control/let_else.md:10
 msgid ""
@@ -4953,27 +4970,28 @@ msgid ""
 "surrounding scope like a normal `let`, or else diverge (e.g. `break`, "
 "`return`, `panic!`) when the pattern doesn't match."
 msgstr ""
+"使用 `let`\\-`else`，可反驳模式可以像普通的 `let` 一样匹配并绑定周围作用域中的变量，或者在模式不匹配时发散（例如 `break`、`return`、`panic!`）。"
 
 #: src/flow_control/let_else.md:18 src/flow_control/let_else.md:41
 #: src/std/str.md:41
 msgid "' '"
-msgstr ""
+msgstr "' '"
 
 #: src/flow_control/let_else.md:20 src/flow_control/let_else.md:44
 msgid "\"Can't segment count item pair: '{s}'\""
-msgstr ""
+msgstr "\"无法分割计数项对：'{s}'\""
 
 #: src/flow_control/let_else.md:23 src/flow_control/let_else.md:49
 msgid "\"Can't parse integer: '{count_str}'\""
-msgstr ""
+msgstr "\"无法解析整数：'{count_str}'\""
 
 #: src/flow_control/let_else.md:29 src/flow_control/let_else.md:54
 msgid "\"3 chairs\""
-msgstr ""
+msgstr "\"3 chairs\""
 
 #: src/flow_control/let_else.md:29 src/flow_control/let_else.md:54
 msgid "\"chairs\""
-msgstr ""
+msgstr "\"chairs\""
 
 #: src/flow_control/let_else.md:33
 msgid ""
@@ -4981,56 +4999,62 @@ msgid ""
 "`match` or `if let`\\-`else` expressions. You could previously approximate "
 "these patterns with an unfortunate bit of repetition and an outer `let`:"
 msgstr ""
+"名称绑定的作用域是使其与 `match` 或 `if let`\\-`else` 表达式不同的主要原因。你之前可以通过一些冗余的重复和外部的 `let` 来近似这些模式："
 
 #: src/flow_control/let_else.md:59
 msgid ""
 "[option](../std/option.md), [match](./match.md), [if let](./if_let.md) and "
 "the [let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
 msgstr ""
+"[option](../std/option.md)，[match](./match.md)，[if let](./if_let.md) 和 "
+"[let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)。"
 
 #: src/flow_control/while_let.md:3
 msgid ""
 "Similar to `if let`, `while let` can make awkward `match` sequences more "
 "tolerable. Consider the following sequence that increments `i`:"
 msgstr ""
+"与 `if let` 类似，`while let` 可以使别扭的 `match` 序列更易于处理。考虑下面这个递增 `i` 的序列："
 
 #: src/flow_control/while_let.md:9
 msgid "// Repeatedly try this test.\n"
-msgstr ""
+msgstr "// 重复尝试这个测试。\n"
 
 #: src/flow_control/while_let.md:13
 msgid "// If `optional` destructures, evaluate the block.\n"
-msgstr ""
+msgstr "// 如果 `optional` 解构成功，就执行语句块。\n"
 
 #: src/flow_control/while_let.md:16 src/flow_control/while_let.md:42
 msgid "\"Greater than 9, quit!\""
-msgstr ""
+msgstr "\"大于 9，退出！\""
 
 #: src/flow_control/while_let.md:19 src/flow_control/while_let.md:45
 msgid "\"`i` is `{:?}`. Try again.\""
-msgstr ""
+msgstr "\"`i` 是 `{:?}`。再试一次。\""
 
 #: src/flow_control/while_let.md:22
 msgid "// ^ Requires 3 indentations!\n"
-msgstr ""
+msgstr "// ^ 需要 3 层缩进！\n"
 
 #: src/flow_control/while_let.md:24
 msgid "// Quit the loop when the destructure fails:\n"
-msgstr ""
+msgstr "// 当解构失败时退出循环：\n"
 
 #: src/flow_control/while_let.md:26
 msgid "// ^ Why should this be required? There must be a better way!\n"
-msgstr ""
+msgstr "// ^ 为什么这是必需的？一定有更好的方法！\n"
 
 #: src/flow_control/while_let.md:31
 msgid "Using `while let` makes this sequence much nicer:"
-msgstr ""
+msgstr "使用 `while let` 使这个序列更加优雅："
 
 #: src/flow_control/while_let.md:38
 msgid ""
 "// This reads: \"while `let` destructures `optional` into\n"
 "    // `Some(i)`, evaluate the block (`{}`). Else `break`.\n"
 msgstr ""
+"// 这读作：当 `let` 把 `optional` 解构成 `Some(i)` 时，\n"
+"    // 执行语句块（`{}`）。否则 `break`。\n"
 
 #: src/flow_control/while_let.md:48
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -13788,7 +13788,7 @@ msgid ""
 "These, combined with Rust's concept of Ownership and aliasing rules, "
 "automatically prevent data races."
 msgstr ""
-"标准库提供了现成的优秀线程原语。这些原语结合 Rust 的所有权概念和别名规则，自动防止了数据竞争。"
+"标准库提供了开箱即用的出色线程原语，它们与 Rust 的所有权概念和别名规则相结合，可以自动防止数据竞争。。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:9
 msgid ""
@@ -13797,7 +13797,7 @@ msgid ""
 "threads. (Where synchronisation is needed, there are synchronisation "
 "primitives like `Mutex`es or `Channel`s.)"
 msgstr ""
-"别名规则（一个可写引用或多个可读引用）自动防止你操作对其他线程可见的状态。（在需要同步的地方，有像 `Mutex` 或 `Channel` 这样的同步原语。）"
+"别名规则（一个可写引用或多个可读引用）自动防止你操作对其他线程可见的状态。（在需要同步处理时，有像 `Mutex` 或 `Channel` 这样的同步原语。）"
 
 #: src/std_misc/threads/testcase_mapreduce.md:14
 msgid ""
@@ -13818,7 +13818,7 @@ msgid ""
 "data between threads, you can use a smart pointer like `Arc` to keep the data "
 "alive and avoid non-`static` lifetimes.)"
 msgstr ""
-"注意，尽管我们在线程边界之间传递引用，Rust 理解我们只是传递只读引用，因此不会发生不安全或数据竞争的情况。此外，因为我们传递的引用具有 `'static` 生命周期，Rust 理解我们的数据在这些线程仍在运行时不会被销毁。（当你需要在线程之间共享非 `static` 数据时，你可以使用像 `Arc` 这样的智能指针来保持数据的存活并避免非 `static` 生命周期。）"
+"注意，尽管我们在线程之间传递引用，但是 Rust 理解我们只是传递只读引用，因此不会造成不安全或数据竞争的情况。此外，因为我们传递的引用具有 `'static` 生命周期，Rust 会确保被引用的数据在这些线程仍在运行时不会被销毁。（当你需要在线程之间共享非 `static` 数据时，你可以使用像 `Arc` 这样的智能指针来确保数据的存活。）"
 
 #: src/std_misc/threads/testcase_mapreduce.md:32
 msgid ""
@@ -13934,31 +13934,31 @@ msgstr ""
 
 #: src/std_misc/threads/testcase_mapreduce.md:82
 msgid "// Calculate the intermediate sum of this segment:\n"
-msgstr ""
+msgstr "// 计算这个段的中间和：\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:84
 msgid "// iterate over the characters of our segment..\n"
-msgstr ""
+msgstr "// 遍历我们段中的字符..\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:86
 msgid "// .. convert text-characters to their number value..\n"
-msgstr ""
+msgstr "// .. 将文本字符转换为它们的数值..\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:87
 msgid "\"should be a digit\""
-msgstr ""
+msgstr "\"应该是一个数字\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:88
 msgid "// .. and sum the resulting iterator of numbers\n"
-msgstr ""
+msgstr "// .. 并对结果数字迭代器求和\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:91
 msgid "// println! locks stdout, so no text-interleaving occurs\n"
-msgstr ""
+msgstr "// println! 锁定 stdout，所以不会发生文本交错\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:92
 msgid "\"processed segment {}, result={}\""
-msgstr ""
+msgstr "\"处理段 {}，结果={}\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:94
 msgid ""
@@ -13966,6 +13966,8 @@ msgid ""
 "            // last evaluated expression in each block is automatically its "
 "value.\n"
 msgstr ""
+"// 不需要 \"return\"，因为 Rust 是一种 \"表达式语言\"，\n"
+"            // 每个块中最后求值的表达式自动成为其值。\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:102
 msgid ""
@@ -13976,6 +13978,11 @@ msgid ""
 "result\n"
 "     ************************************************************************/"
 msgstr ""
+"/*************************************************************************\n"
+"     * \"归约\"阶段\n"
+"     *\n"
+"     * 收集我们的中间结果，并将它们合并成最终结果\n"
+"     ************************************************************************/"
 
 #: src/std_misc/threads/testcase_mapreduce.md:108
 msgid ""
@@ -13986,14 +13993,20 @@ msgid ""
 "    // TODO: try without the turbofish, by instead explicitly\n"
 "    // specifying the type of final_result\n"
 msgstr ""
+"// 将每个线程的中间结果合并成一个最终总和。\n"
+"    //\n"
+"    // 我们使用 \"turbofish\" ::<> 为 sum() 提供类型提示。\n"
+"    //\n"
+"    // TODO：尝试不使用 turbofish，而是显式\n"
+"    // 指定 final_result 的类型\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:116
 msgid "\"Final sum result: {}\""
-msgstr ""
+msgstr "\"最终求和结果：{}\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:122
 msgid "Assignments"
-msgstr ""
+msgstr "练习"
 
 #: src/std_misc/threads/testcase_mapreduce.md:123
 msgid ""
@@ -14003,14 +14016,15 @@ msgid ""
 "into a limited number of chunks, defined by a static constant at the "
 "beginning of the program."
 msgstr ""
+"让线程数量依赖于用户输入的数据并不明智。如果用户决定插入大量空格怎么办？我们真的想要生成 2,000 个线程吗？修改程序，使数据始终被分割成有限数量的块，这个数量由程序开头的静态常量定义。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:129
 msgid "[Threads](../threads.md)"
-msgstr ""
+msgstr "[线程](../threads.md)"
 
 #: src/std_misc/threads/testcase_mapreduce.md:130
 msgid "[vectors](../../std/vec.md) and [iterators](../../trait/iter.md)"
-msgstr ""
+msgstr "[向量](../../std/vec.md)和[迭代器](../../trait/iter.md)"
 
 #: src/std_misc/threads/testcase_mapreduce.md:131
 msgid ""
@@ -14018,26 +14032,29 @@ msgid ""
 "[`move` closures](https://doc.rust-lang.org/book/ch13-01-closures."
 "html#closures-can-capture-their-environment)"
 msgstr ""
+"[闭包](../../fn/closures.md)、[move](../../scope/move.md) 语义和 [`move` 闭包](https://doc.rust-lang.org/book/ch13-01-closures.html#closures-can-capture-their-environment)"
 
 #: src/std_misc/threads/testcase_mapreduce.md:132
 msgid ""
 "[destructuring](https://doc.rust-lang.org/book/ch18-03-pattern-syntax."
 "html#destructuring-to-break-apart-values) assignments"
 msgstr ""
+"[解构](https://doc.rust-lang.org/book/ch18-03-pattern-syntax.html#destructuring-to-break-apart-values)赋值"
 
 #: src/std_misc/threads/testcase_mapreduce.md:133
 msgid ""
 "[turbofish notation](https://doc.rust-lang.org/book/appendix-02-operators."
 "html?highlight=turbofish) to help type inference"
 msgstr ""
+"[turbofish 符号](https://doc.rust-lang.org/book/appendix-02-operators.html?highlight=turbofish)以帮助类型推断"
 
 #: src/std_misc/threads/testcase_mapreduce.md:134
 msgid "[unwrap vs. expect](../../error/option_unwrap.md)"
-msgstr ""
+msgstr "[unwrap vs. expect](../../error/option_unwrap.md)"
 
 #: src/std_misc/threads/testcase_mapreduce.md:135
 msgid "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
-msgstr ""
+msgstr "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
 
 #: src/std_misc/channels.md:3
 msgid ""
@@ -14045,6 +14062,7 @@ msgid ""
 "Channels allow a unidirectional flow of information between two end-points: "
 "the `Sender` and the `Receiver`."
 msgstr ""
+"Rust 提供异步 `channels`（信道）用于线程间通信。信道允许信息在两个端点之间单向流动：`Sender`（发送端）和 `Receiver`（接收端）。"
 
 #: src/std_misc/channels.md:15
 msgid ""
@@ -14052,34 +14070,41 @@ msgid ""
 "    // where `T` is the type of the message to be transferred\n"
 "    // (type annotation is superfluous)\n"
 msgstr ""
+"// 信道有两个端点：`Sender<T>` 和 `Receiver<T>`，\n"
+"    // 其中 `T` 是要传输的消息的类型\n"
+"    // （类型标注是多余的）\n"
 
 #: src/std_misc/channels.md:22
 msgid "// The sender endpoint can be copied\n"
-msgstr ""
+msgstr "// 发送端可以被复制\n"
 
 #: src/std_misc/channels.md:25
 msgid "// Each thread will send its id via the channel\n"
-msgstr ""
+msgstr "// 每个线程将通过信道发送其 id\n"
 
 #: src/std_misc/channels.md:27
 msgid ""
 "// The thread takes ownership over `thread_tx`\n"
 "            // Each thread queues a message in the channel\n"
 msgstr ""
+"// 线程获取 `thread_tx` 的所有权\n"
+"            // 每个线程在信道中排队一条消息\n"
 
 #: src/std_misc/channels.md:31
 msgid ""
 "// Sending is a non-blocking operation, the thread will continue\n"
 "            // immediately after sending its message\n"
 msgstr ""
+"// 发送是非阻塞操作，线程将在发送消息后\n"
+"            // 立即继续执行\n"
 
 #: src/std_misc/channels.md:33
 msgid "\"thread {} finished\""
-msgstr ""
+msgstr "\"线程 {} 完成\""
 
 #: src/std_misc/channels.md:39
 msgid "// Here, all the messages are collected\n"
-msgstr ""
+msgstr "// 在这里，所有消息都被收集\n"
 
 #: src/std_misc/channels.md:42
 msgid ""
@@ -14087,18 +14112,20 @@ msgid ""
 "        // `recv` will block the current thread if there are no messages "
 "available\n"
 msgstr ""
+"// `recv` 方法从信道中获取一条消息\n"
+"        // 如果没有可用的消息，`recv` 将阻塞当前线程\n"
 
 #: src/std_misc/channels.md:47
 msgid "// Wait for the threads to complete any remaining work\n"
-msgstr ""
+msgstr "// 等待线程完成任何剩余工作\n"
 
 #: src/std_misc/channels.md:49
 msgid "\"oops! the child thread panicked\""
-msgstr ""
+msgstr "\"糟糕！子线程发生了 panic\""
 
 #: src/std_misc/channels.md:52
 msgid "// Show the order in which the messages were sent\n"
-msgstr ""
+msgstr "// 显示消息发送的顺序\n"
 
 #: src/std_misc/path.md:3
 msgid ""
@@ -14107,12 +14134,14 @@ msgid ""
 "`windows::Path`, for Windows. The prelude exports the appropriate platform-"
 "specific `Path` variant."
 msgstr ""
+"`Path` 结构体表示底层文件系统中的文件路径。`Path` 有两种风格：用于类 UNIX 系统的 `posix::Path` 和用于 Windows 的 `windows::Path`。prelude 导出了适合特定平台的 `Path` 变体。"
 
 #: src/std_misc/path.md:8
 msgid ""
 "A `Path` can be created from an `OsStr`, and provides several methods to get "
 "information from the file/directory the path points to."
 msgstr ""
+"`Path` 可以从 `OsStr` 创建，并提供几种方法来获取路径指向的文件/目录的信息。"
 
 #: src/std_misc/path.md:11
 msgid ""
@@ -14120,6 +14149,7 @@ msgid ""
 "between `Path` and `PathBuf` is similar to that of `str` and `String`: a "
 "`PathBuf` can be mutated in-place, and can be dereferenced to a `Path`."
 msgstr ""
+"`Path` 是不可变的。`Path` 的所有权版本是 `PathBuf`。`Path` 和 `PathBuf` 之间的关系类似于 `str` 和 `String`：`PathBuf` 可以就地修改，并且可以解引用为 `Path`。"
 
 #: src/std_misc/path.md:15
 msgid ""
@@ -14129,76 +14159,84 @@ msgid ""
 "`Path` can be freely converted to an `OsString` or `&OsStr` using "
 "`into_os_string` and `as_os_str`, respectively."
 msgstr ""
+"注意，`Path` 在内部**不是**表示为 UTF-8 字符串，而是存储为 `OsString`。因此，将 `Path` 转换为 `&str` **不是**免费的，并且可能失败（返回一个 `Option`）。然而，`Path` 可以自由地转换为 `OsString` 或 `&OsStr`，分别使用 `into_os_string` 和 `as_os_str`。"
 
 #: src/std_misc/path.md:25
 msgid "// Create a `Path` from an `&'static str`\n"
-msgstr ""
+msgstr "// 从 `&'static str` 创建一个 `Path`\n"
 
 #: src/std_misc/path.md:26
-msgid "\".\""
-msgstr ""
+msgid "\".\"" 
+msgstr "\".\"" 
 
 #: src/std_misc/path.md:28
 msgid "// The `display` method returns a `Display`able structure\n"
-msgstr ""
+msgstr "// `display` 方法返回一个可 `Display` 的结构体\n"
 
 #: src/std_misc/path.md:31
 msgid ""
 "// `join` merges a path with a byte container using the OS specific\n"
 "    // separator, and returns a `PathBuf`\n"
 msgstr ""
+"// `join` 使用操作系统特定的分隔符将路径与字节容器合并，\n"
+"    // 并返回一个 `PathBuf`\n"
 
 #: src/std_misc/path.md:35
 msgid "// `push` extends the `PathBuf` with a `&Path`\n"
-msgstr ""
+msgstr "// `push` 使用 `&Path` 扩展 `PathBuf`\n"
 
 #: src/std_misc/path.md:37
 msgid "\"myfile.tar.gz\""
-msgstr ""
+msgstr "\"myfile.tar.gz\""
 
 #: src/std_misc/path.md:39
 msgid "// `set_file_name` updates the file name of the `PathBuf`\n"
-msgstr ""
+msgstr "// `set_file_name` 更新 `PathBuf` 的文件名\n"
 
 #: src/std_misc/path.md:40
 msgid "\"package.tgz\""
-msgstr ""
+msgstr "\"package.tgz\""
 
 #: src/std_misc/path.md:42
 msgid "// Convert the `PathBuf` into a string slice\n"
-msgstr ""
+msgstr "// 将 `PathBuf` 转换为字符串切片\n"
 
 #: src/std_misc/path.md:44
 msgid "\"new path is not a valid UTF-8 sequence\""
-msgstr ""
+msgstr "\"新路径不是有效的 UTF-8 序列\""
 
 #: src/std_misc/path.md:45
 msgid "\"new path is {}\""
-msgstr ""
+msgstr "\"新路径是 {}\""
 
 #: src/std_misc/path.md:51
 msgid ""
 "Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) "
 "and the `Metadata` struct."
 msgstr ""
+"请务必查看其他 `Path` 方法（`posix::Path` 或 `windows::Path`）和 `Metadata` 结构体。"
 
 #: src/std_misc/path.md:56
 msgid ""
 "[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and [Metadata]"
 "(https://doc.rust-lang.org/std/fs/struct.Metadata.html)."
 msgstr ""
+"[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) 和 [Metadata]"
+"(https://doc.rust-lang.org/std/fs/struct.Metadata.html)。"
 
 #: src/std_misc/file.md:3
 msgid ""
 "The `File` struct represents a file that has been opened (it wraps a file "
 "descriptor), and gives read and/or write access to the underlying file."
 msgstr ""
+"`File` 结构体表示一个已打开的文件（它包装了一个文件描述符），并提供对底层文件的读取和/或写入访问。"
 
 #: src/std_misc/file.md:6
 msgid ""
 "Since many things can go wrong when doing file I/O, all the `File` methods "
 "return the `io::Result<T>` type, which is an alias for `Result<T, io::Error>`."
 msgstr ""
+"由于在进行文件 I/O 时可能会出现许多问题，所有的 `File` 方法都返回 `io::Result<T>` 类型，这是 `Result<T, io::Error>` 的别名。"
 
 #: src/std_misc/file.md:9
 msgid ""
@@ -14206,53 +14244,55 @@ msgid ""
 "programmer can see all the failure paths, and is encouraged to handle them in "
 "a proactive manner."
 msgstr ""
+"这使得所有 I/O 操作的失败变得**明确**。得益于此，程序员可以看到所有的失败路径，并被鼓励以主动的方式处理它们。"
 
 #: src/std_misc/file/open.md:3
 msgid "The `open` function can be used to open a file in read-only mode."
-msgstr ""
+msgstr "`open` 函数可用于以只读模式打开文件。"
 
 #: src/std_misc/file/open.md:5
 msgid ""
 "A `File` owns a resource, the file descriptor and takes care of closing the "
 "file when it is `drop`ed."
 msgstr ""
+"`File` 拥有一个资源，即文件描述符，并在被 `drop` 时负责关闭文件。"
 
 #: src/std_misc/file/open.md:14
 msgid "// Create a path to the desired file\n"
-msgstr ""
+msgstr "// 创建指向所需文件的路径\n"
 
 #: src/std_misc/file/open.md:15
 msgid "\"hello.txt\""
-msgstr ""
+msgstr "\"hello.txt\""
 
 #: src/std_misc/file/open.md:18
 msgid "// Open the path in read-only mode, returns `io::Result<File>`\n"
-msgstr ""
+msgstr "// 以只读模式打开路径，返回 `io::Result<File>`\n"
 
 #: src/std_misc/file/open.md:20
 msgid "\"couldn't open {}: {}\""
-msgstr ""
+msgstr "\"无法打开 {}: {}\""
 
 #: src/std_misc/file/open.md:24
 msgid "// Read the file contents into a string, returns `io::Result<usize>`\n"
-msgstr ""
+msgstr "// 将文件内容读入字符串，返回 `io::Result<usize>`\n"
 
 #: src/std_misc/file/open.md:27
 msgid "\"couldn't read {}: {}\""
-msgstr ""
+msgstr "\"无法读取 {}: {}\""
 
 #: src/std_misc/file/open.md:28
 msgid "\"{} contains:\\n{}\""
-msgstr ""
+msgstr "\"{} 包含：\\n{}\""
 
 #: src/std_misc/file/open.md:31
 msgid "// `file` goes out of scope, and the \"hello.txt\" file gets closed\n"
-msgstr ""
+msgstr "// `file` 超出作用域，\"hello.txt\" 文件被关闭\n"
 
 #: src/std_misc/file/open.md:35 src/std_misc/file/create.md:39
 #: src/std_misc/fs.md:109
 msgid "Here's the expected successful output:"
-msgstr ""
+msgstr "这是预期的成功输出："
 
 #: src/std_misc/file/open.md:37
 msgid ""
@@ -14263,18 +14303,26 @@ msgid ""
 "Hello World!\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ echo \"Hello World!\" > hello.txt\n"
+"$ rustc open.rs && ./open\n"
+"hello.txt 包含：\n"
+"Hello World!\n"
+"```"
 
 #: src/std_misc/file/open.md:44
 msgid ""
 "(You are encouraged to test the previous example under different failure "
 "conditions: `hello.txt` doesn't exist, or `hello.txt` is not readable, etc.)"
 msgstr ""
+"（我们鼓励你在不同的失败条件下测试前面的例子：`hello.txt` 不存在，或 `hello.txt` 不可读等。）"
 
 #: src/std_misc/file/create.md:3
 msgid ""
 "The `create` function opens a file in write-only mode. If the file already "
 "existed, the old content is destroyed. Otherwise, a new file is created."
 msgstr ""
+"`create` 函数以只写模式打开文件。如果文件已经存在，旧内容会被销毁。否则，会创建一个新文件。"
 
 #: src/std_misc/file/create.md:9
 msgid ""
@@ -14287,52 +14335,64 @@ msgid ""
 "proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
 "\""
 msgstr ""
+"\"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n"
+"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
+"non\n"
+"proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+"\""
 
 #: src/std_misc/file/create.md:22
 msgid "\"lorem_ipsum.txt\""
-msgstr ""
+msgstr "\"lorem_ipsum.txt\""
 
 #: src/std_misc/file/create.md:25
 msgid "// Open a file in write-only mode, returns `io::Result<File>`\n"
-msgstr ""
+msgstr "// 以只写模式打开文件，返回 `io::Result<File>`\n"
 
 #: src/std_misc/file/create.md:27
 msgid "\"couldn't create {}: {}\""
-msgstr ""
+msgstr "\"无法创建 {}: {}\""
 
 #: src/std_misc/file/create.md:31
 msgid "// Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`\n"
-msgstr ""
+msgstr "// 将 `LOREM_IPSUM` 字符串写入 `file`，返回 `io::Result<()>`\n"
 
 #: src/std_misc/file/create.md:33
 msgid "\"couldn't write to {}: {}\""
-msgstr ""
+msgstr "\"无法写入 {}: {}\""
 
 #: src/std_misc/file/create.md:34
 msgid "\"successfully wrote to {}\""
-msgstr ""
+msgstr "\"成功写入 {}\""
 
 #: src/std_misc/file/create.md:53
 msgid ""
 "(As in the previous example, you are encouraged to test this example under "
 "failure conditions.)"
 msgstr ""
+"（和前面的例子一样，我们鼓励你在失败条件下测试这个例子。）"
 
 #: src/std_misc/file/create.md:56
 msgid ""
 "The [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) "
 "struct can be used to configure how a file is opened."
 msgstr ""
+"[`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) "
+"结构体可用于配置如何打开文件。"
 
 #: src/std_misc/file/read_lines.md:3
 msgid "A naive approach"
-msgstr ""
+msgstr "一种简单的方法"
 
 #: src/std_misc/file/read_lines.md:5
 msgid ""
 "This might be a reasonable first attempt for a beginner's first "
 "implementation for reading lines from a file."
 msgstr ""
+"对于初学者来说，这可能是从文件中读取行的第一个合理尝试。"
 
 #: src/std_misc/file/read_lines.md:22
 msgid ""
@@ -14340,22 +14400,23 @@ msgid ""
 "can also perform a map inline and collect the results, yielding a more "
 "concise and fluent expression."
 msgstr ""
+"由于 `lines()` 方法返回文件中各行的迭代器，我们也可以内联执行 map 并收集结果，从而得到一个更简洁流畅的表达式。"
 
 #: src/std_misc/file/read_lines.md:31
 msgid "// panic on possible file-reading errors\n"
-msgstr ""
+msgstr "// 在可能的文件读取错误时 panic\n"
 
 #: src/std_misc/file/read_lines.md:32
 msgid "// split the string into an iterator of string slices\n"
-msgstr ""
+msgstr "// 将字符串分割成字符串切片的迭代器\n"
 
 #: src/std_misc/file/read_lines.md:33
 msgid "// make each slice into a string\n"
-msgstr ""
+msgstr "// 将每个切片转换成字符串\n"
 
 #: src/std_misc/file/read_lines.md:34
 msgid "// gather them together into a vector\n"
-msgstr ""
+msgstr "// 将它们收集到一个向量中\n"
 
 #: src/std_misc/file/read_lines.md:38
 msgid ""
@@ -14363,44 +14424,49 @@ msgid ""
 "returned from `lines()` to the owned type `String`, using `.to_string()` and "
 "`String::from` respectively."
 msgstr ""
+"注意，在上面的两个例子中，我们都必须将 `lines()` 返回的 `&str` 引用转换为拥有所有权的 `String` 类型，分别使用 `.to_string()` 和 `String::from`。"
 
 #: src/std_misc/file/read_lines.md:42
 msgid "A more efficient approach"
-msgstr ""
+msgstr "一种更高效的方法"
 
 #: src/std_misc/file/read_lines.md:44
 msgid ""
 "Here we pass ownership of the open `File` to a `BufReader` struct. "
 "`BufReader` uses an internal buffer to reduce intermediate allocations."
 msgstr ""
+"这里我们将打开的 `File` 的所有权传递给 `BufReader` 结构体。`BufReader` 使用内部缓冲区来减少中间分配。"
 
 #: src/std_misc/file/read_lines.md:47
 msgid ""
 "We also update `read_lines` to return an iterator instead of allocating new "
 "`String` objects in memory for each line."
 msgstr ""
+"我们还更新了 `read_lines` 函数，使其返回一个迭代器，而不是为每一行在内存中分配新的 `String` 对象。"
 
 #: src/std_misc/file/read_lines.md:56
 msgid "// File hosts.txt must exist in the current path\n"
-msgstr ""
+msgstr "// 文件 hosts.txt 必须存在于当前路径\n"
 
 #: src/std_misc/file/read_lines.md:57
 msgid "\"./hosts.txt\""
-msgstr ""
+msgstr "\"./hosts.txt\""
 
 #: src/std_misc/file/read_lines.md:58
 msgid "// Consumes the iterator, returns an (Optional) String\n"
-msgstr ""
+msgstr "// 消耗迭代器，返回一个（可选的）String\n"
 
 #: src/std_misc/file/read_lines.md:64
 msgid ""
 "// The output is wrapped in a Result to allow matching on errors.\n"
 "// Returns an Iterator to the Reader of the lines of the file.\n"
 msgstr ""
+"// 输出被包装在一个 Result 中以允许匹配错误。\n"
+"// 返回一个指向文件行的 Reader 的迭代器。\n"
 
 #: src/std_misc/file/read_lines.md:74
 msgid "Running this program simply prints the lines individually."
-msgstr ""
+msgstr "运行这个程序只是简单地逐行打印。"
 
 #: src/std_misc/file/read_lines.md:75
 msgid ""
@@ -14411,6 +14477,12 @@ msgid ""
 "192.168.0.1\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ echo -e \"127.0.0.1\\n192.168.0.1\\n\" > hosts.txt\n"
+"$ rustc read_lines.rs && ./read_lines\n"
+"127.0.0.1\n"
+"192.168.0.1\n"
+"```"
 
 #: src/std_misc/file/read_lines.md:82
 msgid ""
@@ -14418,6 +14490,7 @@ msgid ""
 "define our generic `read_lines()` method with the same generic constraint, "
 "using the `where` keyword.)"
 msgstr ""
+"（注意，由于 `File::open` 期望一个泛型 `AsRef<Path>` 作为参数，我们使用 `where` 关键字定义了具有相同泛型约束的 `read_lines()` 方法。）"
 
 #: src/std_misc/file/read_lines.md:85
 msgid ""
@@ -14425,38 +14498,41 @@ msgid ""
 "the file's contents. This can especially cause performance issues when "
 "working with larger files."
 msgstr ""
+"这个过程比在内存中创建包含文件所有内容的 `String` 更高效。特别是在处理较大的文件时，这可以避免性能问题。"
 
 #: src/std_misc/process.md:3
 msgid ""
 "The `process::Output` struct represents the output of a finished child "
 "process, and the `process::Command` struct is a process builder."
 msgstr ""
+"`process::Output` 结构体表示已完成的子进程的输出，而 `process::Command` 结构体是一个进程构建器。"
 
 #: src/std_misc/process.md:10
 msgid "\"rustc\""
-msgstr ""
+msgstr "\"rustc\""
 
 #: src/std_misc/process.md:11
 msgid "\"--version\""
-msgstr ""
+msgstr "\"--version\""
 
 #: src/std_misc/process.md:13
 msgid "\"failed to execute process: {}\""
-msgstr ""
+msgstr "\"执行进程失败：{}\""
 
 #: src/std_misc/process.md:19
 msgid "\"rustc succeeded and stdout was:\\n{}\""
-msgstr ""
+msgstr "\"rustc 成功执行，stdout 输出为：\\n{}\""
 
 #: src/std_misc/process.md:23
 msgid "\"rustc failed and stderr was:\\n{}\""
-msgstr ""
+msgstr "\"rustc 执行失败，stderr 输出为：\\n{}\""
 
 #: src/std_misc/process.md:28
 msgid ""
 "(You are encouraged to try the previous example with an incorrect flag passed "
 "to `rustc`)"
 msgstr ""
+"（我们鼓励你尝试在前面的例子中向 `rustc` 传递一个错误的标志）"
 
 #: src/std_misc/process/pipe.md:3
 msgid ""
@@ -14464,39 +14540,40 @@ msgid ""
 "`stdin`, `stdout` and `stderr` handles for interaction with the underlying "
 "process via pipes."
 msgstr ""
+"`std::Child` 结构体表示一个正在运行的子进程，并暴露 `stdin`、`stdout` 和 `stderr` 句柄，以通过管道与底层进程进行交互。"
 
 #: src/std_misc/process/pipe.md:11
 msgid "\"the quick brown fox jumps over the lazy dog\\n\""
-msgstr ""
+msgstr "\"the quick brown fox jumps over the lazy dog\\n\""
 
 #: src/std_misc/process/pipe.md:15
 msgid "// Spawn the `wc` command\n"
-msgstr ""
+msgstr "// 生成 `wc` 命令\n"
 
 #: src/std_misc/process/pipe.md:16 src/std_misc/fs.md:12 src/std_misc/fs.md:73
 #: src/std_misc/ffi.md:11
 msgid "\"windows\""
-msgstr ""
+msgstr "\"windows\""
 
 #: src/std_misc/process/pipe.md:17
 msgid "\"powershell\""
-msgstr ""
+msgstr "\"powershell\""
 
 #: src/std_misc/process/pipe.md:18
 msgid "\"-Command\""
-msgstr ""
+msgstr "\"-Command\""
 
 #: src/std_misc/process/pipe.md:18
 msgid "\"$input | Measure-Object -Line -Word -Character\""
-msgstr ""
+msgstr "\"$input | Measure-Object -Line -Word -Character\""
 
 #: src/std_misc/process/pipe.md:21
 msgid "\"wc\""
-msgstr ""
+msgstr "\"wc\""
 
 #: src/std_misc/process/pipe.md:27
 msgid "\"couldn't spawn wc: {}\""
-msgstr ""
+msgstr "\"无法生成 wc：{}\""
 
 #: src/std_misc/process/pipe.md:31
 msgid ""
@@ -14506,14 +14583,18 @@ msgid ""
 "instance\n"
 "    // must have one, we can directly `unwrap` it.\n"
 msgstr ""
+"// 向 `wc` 的 `stdin` 写入一个字符串。\n"
+"    //\n"
+"    // `stdin` 的类型是 `Option<ChildStdin>`，但由于我们知道这个实例\n"
+"    // 必定有一个，我们可以直接 `unwrap` 它。\n"
 
 #: src/std_misc/process/pipe.md:36
 msgid "\"couldn't write to wc stdin: {}\""
-msgstr ""
+msgstr "\"无法写入 wc 的 stdin：{}\""
 
 #: src/std_misc/process/pipe.md:37
 msgid "\"sent pangram to wc\""
-msgstr ""
+msgstr "\"已发送 pangram 到 wc\""
 
 #: src/std_misc/process/pipe.md:40
 msgid ""
@@ -14523,16 +14604,22 @@ msgid ""
 "    // This is very important, otherwise `wc` wouldn't start processing the\n"
 "    // input we just sent.\n"
 msgstr ""
+"// 因为 `stdin` 在上述调用后不再存活，它被 `drop` 了，\n"
+"    // 管道也被关闭。\n"
+"    //\n"
+"    // 这非常重要，否则 `wc` 不会开始处理\n"
+"    // 我们刚刚发送的输入。\n"
 
 #: src/std_misc/process/pipe.md:46
 msgid ""
 "// The `stdout` field also has type `Option<ChildStdout>` so must be "
 "unwrapped.\n"
 msgstr ""
+"// `stdout` 字段的类型也是 `Option<ChildStdout>`，所以必须被解包。\n"
 
 #: src/std_misc/process/pipe.md:49
 msgid "\"couldn't read wc stdout: {}\""
-msgstr ""
+msgstr "\"无法读取 wc 的 stdout：{}\""
 
 #: src/std_misc/process/pipe.md:50
 msgid "\"wc responded with:\\n{}\""

--- a/po/zh.po
+++ b/po/zh.po
@@ -14159,7 +14159,7 @@ msgid ""
 "`Path` can be freely converted to an `OsString` or `&OsStr` using "
 "`into_os_string` and `as_os_str`, respectively."
 msgstr ""
-"注意，`Path` 在内部**不是**表示为 UTF-8 字符串，而是存储为 `OsString`。因此，将 `Path` 转换为 `&str` **不是**免费的，并且可能失败（返回一个 `Option`）。然而，`Path` 可以自由地转换为 `OsString` 或 `&OsStr`，分别使用 `into_os_string` 和 `as_os_str`。"
+"注意，`Path` 在内部**不是**表示为 UTF-8 字符串，而是存储为 `OsString`。因此，将 `Path` 转换为 `&str` **不是**零开销的，并且可能失败（返回一个 `Option`）。然而，`Path` 可以自由地转换为 `OsString` 或 `&OsStr`，分别使用 `into_os_string` 和 `as_os_str`。"
 
 #: src/std_misc/path.md:25
 msgid "// Create a `Path` from an `&'static str`\n"
@@ -14214,7 +14214,7 @@ msgid ""
 "Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) "
 "and the `Metadata` struct."
 msgstr ""
-"请务必查看其他 `Path` 方法（`posix::Path` 或 `windows::Path`）和 `Metadata` 结构体。"
+"记得看看其他 `Path` 方法（`posix::Path` 或 `windows::Path`）和 `Metadata` 结构体。"
 
 #: src/std_misc/path.md:56
 msgid ""
@@ -14236,7 +14236,7 @@ msgid ""
 "Since many things can go wrong when doing file I/O, all the `File` methods "
 "return the `io::Result<T>` type, which is an alias for `Result<T, io::Error>`."
 msgstr ""
-"由于在进行文件 I/O 时可能会出现许多问题，所有的 `File` 方法都返回 `io::Result<T>` 类型，这是 `Result<T, io::Error>` 的别名。"
+"由于在进行文件 I/O 时可能会出现各种错误，因此所有的 `File` 方法都返回 `io::Result<T>` 类型，这是 `Result<T, io::Error>` 的别名。"
 
 #: src/std_misc/file.md:9
 msgid ""
@@ -14244,7 +14244,7 @@ msgid ""
 "programmer can see all the failure paths, and is encouraged to handle them in "
 "a proactive manner."
 msgstr ""
-"这使得所有 I/O 操作的失败变得**明确**。得益于此，程序员可以看到所有的失败路径，并被鼓励以主动的方式处理它们。"
+"这让所有 I/O 操作的失败都是**显性的**。得益于此，程序员可以看到所有的失败路径，并被鼓励主动处理它们。"
 
 #: src/std_misc/file/open.md:3
 msgid "The `open` function can be used to open a file in read-only mode."
@@ -14623,139 +14623,143 @@ msgstr "\"无法读取 wc 的 stdout：{}\""
 
 #: src/std_misc/process/pipe.md:50
 msgid "\"wc responded with:\\n{}\""
-msgstr ""
+msgstr "\"wc 响应为：\\n{}\""
 
 #: src/std_misc/process/wait.md:3
 msgid ""
 "If you'd like to wait for a `process::Child` to finish, you must call `Child::"
 "wait`, which will return a `process::ExitStatus`."
 msgstr ""
+"如果你想等待一个 `process::Child` 完成，你必须调用 `Child::wait`，它将返回一个 `process::ExitStatus`。"
 
 #: src/std_misc/process/wait.md:10
 msgid "\"sleep\""
-msgstr ""
+msgstr "\"sleep\""
 
 #: src/std_misc/process/wait.md:13
 msgid "\"reached end of main\""
-msgstr ""
+msgstr "\"到达 main 的末尾\""
 
 #: src/std_misc/process/wait.md:18
 msgid ""
 "# `wait` keeps running for 5 seconds until the `sleep 5` command finishes\n"
 msgstr ""
+"# `wait` 持续运行 5 秒，直到 `sleep 5` 命令完成\n"
 
 #: src/std_misc/fs.md:3
 msgid ""
 "The `std::fs` module contains several functions that deal with the filesystem."
 msgstr ""
+"`std::fs` 模块包含几个处理文件系统的函数。"
 
 #: src/std_misc/fs.md:10 src/std_misc/fs.md:68 src/std_misc/ffi.md:20
 msgid "\"unix\""
-msgstr ""
+msgstr "\"unix\""
 
 #: src/std_misc/fs.md:15
 msgid "// A simple implementation of `% cat path`\n"
-msgstr ""
+msgstr "// `% cat path` 的简单实现\n"
 
 #: src/std_misc/fs.md:25
 msgid "// A simple implementation of `% echo s > path`\n"
-msgstr ""
+msgstr "// `% echo s > path` 的简单实现\n"
 
 #: src/std_misc/fs.md:32
 msgid "// A simple implementation of `% touch path` (ignores existing files)\n"
-msgstr ""
+msgstr "// `% touch path` 的简单实现（忽略已存在的文件）\n"
 
 #: src/std_misc/fs.md:42
 msgid "\"`mkdir a`\""
-msgstr ""
+msgstr "\"`mkdir a`\""
 
 #: src/std_misc/fs.md:43
 msgid "// Create a directory, returns `io::Result<()>`\n"
-msgstr ""
+msgstr "// 创建一个目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:45 src/std_misc/fs.md:52 src/std_misc/fs.md:58
 #: src/std_misc/fs.md:63 src/std_misc/fs.md:70 src/std_misc/fs.md:75
 #: src/std_misc/fs.md:81 src/std_misc/fs.md:88 src/std_misc/fs.md:97
 #: src/std_misc/fs.md:103
 msgid "\"! {:?}\""
-msgstr ""
+msgstr "\"! {:?}\""
 
 #: src/std_misc/fs.md:49
 msgid "\"`echo hello > a/b.txt`\""
-msgstr ""
+msgstr "\"`echo hello > a/b.txt`\""
 
 #: src/std_misc/fs.md:50
 msgid ""
 "// The previous match can be simplified using the `unwrap_or_else` method\n"
 msgstr ""
+"// 前面的匹配可以使用 `unwrap_or_else` 方法简化\n"
 
 #: src/std_misc/fs.md:51
 msgid "\"a/b.txt\""
-msgstr ""
+msgstr "\"a/b.txt\""
 
 #: src/std_misc/fs.md:55
 msgid "\"`mkdir -p a/c/d`\""
-msgstr ""
+msgstr "\"`mkdir -p a/c/d`\""
 
 #: src/std_misc/fs.md:56
 msgid "// Recursively create a directory, returns `io::Result<()>`\n"
-msgstr ""
+msgstr "// 递归创建目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:57 src/std_misc/fs.md:102
 msgid "\"a/c/d\""
-msgstr ""
+msgstr "\"a/c/d\""
 
 #: src/std_misc/fs.md:61
 msgid "\"`touch a/c/e.txt`\""
-msgstr ""
+msgstr "\"`touch a/c/e.txt`\""
 
 #: src/std_misc/fs.md:62 src/std_misc/fs.md:96
 msgid "\"a/c/e.txt\""
-msgstr ""
+msgstr "\"a/c/e.txt\""
 
 #: src/std_misc/fs.md:66
 msgid "\"`ln -s ../b.txt a/c/b.txt`\""
-msgstr ""
+msgstr "\"`ln -s ../b.txt a/c/b.txt`\""
 
 #: src/std_misc/fs.md:67
 msgid "// Create a symbolic link, returns `io::Result<()>`\n"
-msgstr ""
+msgstr "// 创建一个符号链接，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:69 src/std_misc/fs.md:74
 msgid "\"../b.txt\""
-msgstr ""
+msgstr "\"../b.txt\""
 
 #: src/std_misc/fs.md:69 src/std_misc/fs.md:74 src/std_misc/fs.md:80
 msgid "\"a/c/b.txt\""
-msgstr ""
+msgstr "\"a/c/b.txt\""
 
 #: src/std_misc/fs.md:79
 msgid "\"`cat a/c/b.txt`\""
-msgstr ""
+msgstr "\"`cat a/c/b.txt`\""
 
 #: src/std_misc/fs.md:85
 msgid "\"`ls a`\""
-msgstr ""
+msgstr "\"`ls a`\""
 
 #: src/std_misc/fs.md:86
 msgid "// Read the contents of a directory, returns `io::Result<Vec<Path>>`\n"
-msgstr ""
+msgstr "// 读取目录的内容，返回 `io::Result<Vec<Path>>`\n"
 
 #: src/std_misc/fs.md:94
 msgid "\"`rm a/c/e.txt`\""
-msgstr ""
+msgstr "\"`rm a/c/e.txt`\""
 
 #: src/std_misc/fs.md:95
 msgid "// Remove a file, returns `io::Result<()>`\n"
-msgstr ""
+msgstr "// 删除一个文件，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:100
 msgid "\"`rmdir a/c/d`\""
-msgstr ""
+msgstr "\"`rmdir a/c/d`\""
 
 #: src/std_misc/fs.md:101
 msgid "// Remove an empty directory, returns `io::Result<()>`\n"
-msgstr ""
+msgstr "// 删除一个空目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:111
 msgid ""
@@ -14775,36 +14779,52 @@ msgid ""
 "`rmdir a/c/d`\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ rustc fs.rs && ./fs\n"
+"`mkdir a`\n"
+"`echo hello > a/b.txt`\n"
+"`mkdir -p a/c/d`\n"
+"`touch a/c/e.txt`\n"
+"`ln -s ../b.txt a/c/b.txt`\n"
+"`cat a/c/b.txt`\n"
+"> hello\n"
+"`ls a`\n"
+"> \"a/b.txt\"\n"
+"> \"a/c\"\n"
+"`rm a/c/e.txt`\n"
+"`rmdir a/c/d`\n"
+"```"
 
 #: src/std_misc/fs.md:127
 msgid "And the final state of the `a` directory is:"
-msgstr ""
+msgstr "最终 `a` 目录的状态是："
 
 #: src/std_misc/fs.md:139
 msgid "An alternative way to define the function `cat` is with `?` notation:"
-msgstr ""
+msgstr "定义 `cat` 函数的另一种方式是使用 `?` 符号："
 
 #: src/std_misc/fs.md:152
 msgid "[`cfg!`](../attribute/cfg.md)"
-msgstr ""
+msgstr "[`cfg!`](../attribute/cfg.md)"
 
 #: src/std_misc/arg.md:3
 msgid "Standard Library"
-msgstr ""
+msgstr "标准库"
 
 #: src/std_misc/arg.md:5
 msgid ""
 "The command line arguments can be accessed using `std::env::args`, which "
 "returns an iterator that yields a `String` for each argument:"
 msgstr ""
+"命令行参数可以使用 `std::env::args` 访问，它返回一个迭代器，为每个参数生成一个 `String`："
 
 #: src/std_misc/arg.md:14
 msgid "// The first argument is the path that was used to call the program.\n"
-msgstr ""
+msgstr "// 第一个参数是用于调用程序的路径。\n"
 
 #: src/std_misc/arg.md:15
 msgid "\"My path is {}.\""
-msgstr ""
+msgstr "\"我的路径是 {}。\""
 
 #: src/std_misc/arg.md:17
 msgid ""
@@ -14812,10 +14832,13 @@ msgid ""
 "    // Call the program like this:\n"
 "    //   $ ./args arg1 arg2\n"
 msgstr ""
+"// 剩余的参数是传递的命令行参数。\n"
+"    // 像这样调用程序：\n"
+"    //   $ ./args arg1 arg2\n"
 
 #: src/std_misc/arg.md:20
 msgid "\"I got {:?} arguments: {:?}.\""
-msgstr ""
+msgstr "\"我得到了 {:?} 个参数：{:?}。\""
 
 #: src/std_misc/arg.md:24
 msgid ""
@@ -14825,6 +14848,11 @@ msgid ""
 "I got 3 arguments: [\"1\", \"2\", \"3\"].\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ ./args 1 2 3\n"
+"我的路径是 ./args。\n"
+"我得到了 3 个参数：[\"1\", \"2\", \"3\"]。\n"
+"```"
 
 #: src/std_misc/arg.md:32
 msgid ""
@@ -14833,10 +14861,11 @@ msgid ""
 "argument crates being [`clap`](https://rust-cli.github.io/book/tutorial/cli-"
 "args.html#parsing-cli-arguments-with-clap)."
 msgstr ""
+"另外，在创建命令行应用程序时，有许多 crate 可以提供额外的功能。其中一个比较流行的命令行参数 crate 是 [`clap`](https://rust-cli.github.io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap)。"
 
 #: src/std_misc/arg/matching.md:3
 msgid "Matching can be used to parse simple arguments:"
-msgstr ""
+msgstr "匹配可以用于解析简单的参数："
 
 #: src/std_misc/arg/matching.md:17
 msgid ""
@@ -14846,68 +14875,74 @@ msgid ""
 "match_args {{increase|decrease}} <integer>\n"
 "    Increase or decrease given integer by one.\""
 msgstr ""
+"\"用法：\n"
+"match_args <字符串>\n"
+"    检查给定的字符串是否是答案。\n"
+"match_args {{increase|decrease}} <整数>\n"
+"    将给定的整数增加或减少一。\""
 
 #: src/std_misc/arg/matching.md:28
 msgid "// no arguments passed\n"
-msgstr ""
+msgstr "// 没有传递参数\n"
 
 #: src/std_misc/arg/matching.md:30
 msgid "\"My name is 'match_args'. Try passing some arguments!\""
-msgstr ""
+msgstr "\"我的名字是 'match_args'。试试传递一些参数！\""
 
 #: src/std_misc/arg/matching.md:32
 msgid "// one argument passed\n"
-msgstr ""
+msgstr "// 传递了一个参数\n"
 
 #: src/std_misc/arg/matching.md:35
 msgid "\"This is the answer!\""
-msgstr ""
+msgstr "\"这就是答案！\""
 
 #: src/std_misc/arg/matching.md:36
 msgid "\"This is not the answer.\""
-msgstr ""
+msgstr "\"这不是答案。\""
 
 #: src/std_misc/arg/matching.md:39
 msgid "// one command and one argument passed\n"
-msgstr ""
+msgstr "// 传递了一个命令和一个参数\n"
 
 #: src/std_misc/arg/matching.md:43
 msgid "// parse the number\n"
-msgstr ""
+msgstr "// 解析数字\n"
 
 #: src/std_misc/arg/matching.md:49
 msgid "\"error: second argument not an integer\""
-msgstr ""
+msgstr "\"错误：第二个参数不是整数\""
 
 #: src/std_misc/arg/matching.md:54
 msgid "// parse the command\n"
-msgstr ""
+msgstr "// 解析命令\n"
 
 #: src/std_misc/arg/matching.md:56
 msgid "\"increase\""
-msgstr ""
+msgstr "\"increase\""
 
 #: src/std_misc/arg/matching.md:57
 msgid "\"decrease\""
-msgstr ""
+msgstr "\"decrease\""
 
 #: src/std_misc/arg/matching.md:59
 msgid "\"error: invalid command\""
-msgstr ""
+msgstr "\"错误：无效的命令\""
 
 #: src/std_misc/arg/matching.md:64
 msgid "// all the other cases\n"
-msgstr ""
+msgstr "// 所有其他情况\n"
 
 #: src/std_misc/arg/matching.md:66
 msgid "// show a help message\n"
-msgstr ""
+msgstr "// 显示帮助信息\n"
 
 #: src/std_misc/arg/matching.md:73
 msgid ""
 "If you named your program `match_args.rs` and compile it like this `rustc "
 "match_args.rs`, you can execute it as follows:"
 msgstr ""
+"如果你将程序命名为 `match_args.rs` 并像这样编译它 `rustc match_args.rs`，你可以按如下方式执行它："
 
 #: src/std_misc/ffi.md:3
 msgid ""
@@ -14915,104 +14950,112 @@ msgid ""
 "functions must be declared inside an `extern` block annotated with a "
 "`#[link]` attribute containing the name of the foreign library."
 msgstr ""
+"Rust 为 C 库提供了外部函数接口（FFI）。外部函数必须在 `extern` 块内声明，并使用 `#[link]` 属性注解，其中包含外部库的名称。"
 
 #: src/std_misc/ffi.md:9
 msgid "// this extern block links to the libm library\n"
-msgstr ""
+msgstr "// 这个 extern 块链接到 libm 库\n"
 
 #: src/std_misc/ffi.md:12
 msgid "\"msvcrt\""
-msgstr ""
+msgstr "\"msvcrt\""
 
 #: src/std_misc/ffi.md:14 src/std_misc/ffi.md:23
 msgid ""
 "// this is a foreign function\n"
 "    // that computes the square root of a single precision complex number\n"
 msgstr ""
+"// 这是一个外部函数\n"
+"    // 用于计算单精度复数的平方根\n"
 
 #: src/std_misc/ffi.md:21
 msgid "\"m\""
-msgstr ""
+msgstr "\"m\""
 
 #: src/std_misc/ffi.md:29
 msgid ""
 "// Since calling foreign functions is considered unsafe,\n"
 "// it's common to write safe wrappers around them.\n"
 msgstr ""
+"// 由于调用外部函数被认为是不安全的，\n"
+"// 通常会编写安全的包装函数。\n"
 
 #: src/std_misc/ffi.md:37
 msgid "// z = -1 + 0i\n"
-msgstr ""
+msgstr "// z = -1 + 0i\n"
 
 #: src/std_misc/ffi.md:40
 msgid "// calling a foreign function is an unsafe operation\n"
-msgstr ""
+msgstr "// 调用外部函数是一个不安全的操作\n"
 
 #: src/std_misc/ffi.md:43
 msgid "\"the square root of {:?} is {:?}\""
-msgstr ""
+msgstr "\"{:?} 的平方根是 {:?}\""
 
 #: src/std_misc/ffi.md:45
 msgid "// calling safe API wrapped around unsafe operation\n"
-msgstr ""
+msgstr "// 调用包装了不安全操作的安全 API\n"
 
 #: src/std_misc/ffi.md:46
 msgid "\"cos({:?}) = {:?}\""
-msgstr ""
+msgstr "\"cos({:?}) = {:?}\""
 
 #: src/std_misc/ffi.md:48
 msgid "// Minimal implementation of single precision complex numbers\n"
-msgstr ""
+msgstr "// 单精度复数的最小实现\n"
 
 #: src/std_misc/ffi.md:60
 msgid "\"{}-{}i\""
-msgstr ""
+msgstr "\"{}-{}i\""
 
 #: src/std_misc/ffi.md:62
 msgid "\"{}+{}i\""
-msgstr ""
+msgstr "\"{}+{}i\""
 
 #: src/testing.md:3
 msgid ""
 "Rust is a programming language that cares a lot about correctness and it "
 "includes support for writing software tests within the language itself."
 msgstr ""
+"Rust 是一种非常注重正确性的编程语言，它包含了在语言本身中编写软件测试的支持。"
 
 #: src/testing.md:6
 msgid "Testing comes in three styles:"
-msgstr ""
+msgstr "测试有三种风格："
 
 #: src/testing.md:8
 msgid "[Unit](testing/unit_testing.md) testing."
-msgstr ""
+msgstr "[单元](testing/unit_testing.md)测试。"
 
 #: src/testing.md:9
 msgid "[Doc](testing/doc_testing.md) testing."
-msgstr ""
+msgstr "[文档](testing/doc_testing.md)测试。"
 
 #: src/testing.md:10
 msgid "[Integration](testing/integration_testing.md) testing."
-msgstr ""
+msgstr "[集成](testing/integration_testing.md)测试。"
 
 #: src/testing.md:12
 msgid "Also Rust has support for specifying additional dependencies for tests:"
-msgstr ""
+msgstr "Rust 还支持为测试指定额外的依赖项："
 
 #: src/testing.md:14
 msgid "[Dev-dependencies](testing/dev_dependencies.md)"
-msgstr ""
+msgstr "[开发依赖](testing/dev_dependencies.md)"
 
 #: src/testing.md:18
 msgid ""
 "[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) chapter on "
 "testing"
 msgstr ""
+"[《Rust 程序设计语言》](https://doc.rust-lang.org/book/ch11-00-testing.html)中关于测试的章节"
 
 #: src/testing.md:19
 msgid ""
 "[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
 "documentation.html) on doc-testing"
 msgstr ""
+"[API 指南](https://rust-lang-nursery.github.io/api-guidelines/documentation.html)中关于文档测试的内容"
 
 #: src/testing/unit_testing.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2127,7 +2127,7 @@ msgstr "// 可变的 `i32`\n"
 
 #: src/primitives.md:47
 msgid "// Error! The type of a variable can't be changed.\n"
-msgstr "// 错误！变量的类型不能改变。\n"
+msgstr "// 报错！变量的类型不能改变。\n"
 
 #: src/primitives.md:50
 msgid "// Variables can be overwritten with shadowing.\n"
@@ -3081,7 +3081,7 @@ msgstr "\"小的\""
 
 #: src/custom_types/constants.md:29
 msgid "// Error! Cannot modify a `const`.\n"
-msgstr "// 错误！不能修改 `const`。\n"
+msgstr "// 报错！不能修改 `const`。\n"
 
 #: src/custom_types/constants.md:31 src/variable_bindings/scope.md:21
 #: src/variable_bindings/declare.md:25 src/variable_bindings/freeze.md:16
@@ -3169,7 +3169,7 @@ msgstr "\"修改后：{}\""
 
 #: src/variable_bindings/mut.md:18
 msgid "// Error! Cannot assign a new value to an immutable variable\n"
-msgstr "// 错误！不能对不可变变量赋新值\n"
+msgstr "// 报错！不能对不可变变量赋新值\n"
 
 #: src/variable_bindings/mut.md:23
 msgid "The compiler will throw a detailed diagnostic about mutability errors."
@@ -3204,7 +3204,7 @@ msgstr "// 代码块结束\n"
 
 #: src/variable_bindings/scope.md:19
 msgid "// Error! `short_lived_binding` doesn't exist in this scope\n"
-msgstr "// 错误！`short_lived_binding` 在这个作用域中不存在\n"
+msgstr "// 报错！`short_lived_binding` 在这个作用域中不存在\n"
 
 #: src/variable_bindings/scope.md:20
 msgid "\"outer short: {}\""
@@ -3271,7 +3271,7 @@ msgstr "\"一个绑定：{}\""
 
 #: src/variable_bindings/declare.md:23
 msgid "// Error! Use of uninitialized binding\n"
-msgstr "// 错误！使用未初始化的绑定\n"
+msgstr "// 报错！使用未初始化的绑定\n"
 
 #: src/variable_bindings/declare.md:24 src/variable_bindings/declare.md:29
 msgid "\"another binding: {}\""
@@ -3297,7 +3297,7 @@ msgstr "// 通过不可变的 `_mutable_integer` 进行遮蔽\n"
 
 #: src/variable_bindings/freeze.md:14
 msgid "// Error! `_mutable_integer` is frozen in this scope\n"
-msgstr "// 错误！`_mutable_integer` 在这个作用域中被冻结\n"
+msgstr "// 报错！`_mutable_integer` 在这个作用域中被冻结\n"
 
 #: src/variable_bindings/freeze.md:18
 msgid "// `_mutable_integer` goes out of scope\n"
@@ -3352,7 +3352,7 @@ msgstr "// 抑制所有来自溢出转换的警告。\n"
 
 #: src/types/cast.md:17
 msgid "// Error! No implicit conversion\n"
-msgstr "// 错误！没有隐式转换\n"
+msgstr "// 报错！没有隐式转换\n"
 
 #: src/types/cast.md:21
 msgid "// Explicit conversion\n"
@@ -3363,7 +3363,7 @@ msgid ""
 "// Error! There are limitations in conversion rules.\n"
 "    // A float cannot be directly converted to a char.\n"
 msgstr ""
-"// 错误！转换规则有限制。\n"
+"// 报错！转换规则有限制。\n"
 "    // 浮点数不能直接转换为字符。\n"
 
 #: src/types/cast.md:30
@@ -5265,7 +5265,7 @@ msgid ""
 "    //rectangle.translate(1.0, 0.0);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 错误！`rectangle` 是不可变的，但这个方法需要一个可变对象\n"
+"// 报错！`rectangle` 是不可变的，但这个方法需要一个可变对象\n"
 "    //rectangle.translate(1.0, 0.0);\n"
 "    // TODO ^ 尝试取消注释这一行\n"
 
@@ -5279,7 +5279,7 @@ msgid ""
 "    //pair.destroy();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 错误！之前的 `destroy` 调用已经"消耗"了 `pair`\n"
+"// 报错！之前的 `destroy` 调用已经"消耗"了 `pair`\n"
 "    //pair.destroy();\n"
 "    // TODO ^ 尝试取消注释这一行\n"
 
@@ -6293,12 +6293,14 @@ msgid ""
 "split code in logical units (modules), and manage visibility (public/private) "
 "between them."
 msgstr ""
+"Rust 提供了一个强大的模块系统，可以用来将代码分层地拆分成逻辑单元（模块），并管理它们之间的可见性（公有/私有）。"
 
 #: src/mod.md:7
 msgid ""
 "A module is a collection of items: functions, structs, traits, `impl` blocks, "
 "and even other modules."
 msgstr ""
+"一个模块是一系列项的集合：函数、结构体、trait、`impl` 块，甚至其他模块。"
 
 #: src/mod/visibility.md:3
 msgid ""
@@ -6306,131 +6308,143 @@ msgid ""
 "overridden with the `pub` modifier. Only the public items of a module can be "
 "accessed from outside the module scope."
 msgstr ""
+"默认情况下，模块中的项具有私有可见性，但可以使用 `pub` 修饰符来覆盖这一默认行为。只有模块中的公有项可以从模块作用域外部访问。"
 
 #: src/mod/visibility.md:8
 msgid "// A module named `my_mod`\n"
-msgstr ""
+msgstr "// 一个名为 `my_mod` 的模块\n"
 
 #: src/mod/visibility.md:10
 msgid "// Items in modules default to private visibility.\n"
-msgstr ""
+msgstr "// 模块中的项默认为私有可见性。\n"
 
 #: src/mod/visibility.md:12
 msgid "\"called `my_mod::private_function()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::private_function()`\""
 
 #: src/mod/visibility.md:15
 msgid "// Use the `pub` modifier to override default visibility.\n"
-msgstr ""
+msgstr "// 使用 `pub` 修饰符来覆盖默认的可见性。\n"
 
 #: src/mod/visibility.md:17
 msgid "\"called `my_mod::function()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::function()`\""
 
 #: src/mod/visibility.md:20
 msgid ""
 "// Items can access other items in the same module,\n"
 "    // even when private.\n"
 msgstr ""
+"// 项可以访问同一模块中的其他项，即使是私有的。\n"
 
 #: src/mod/visibility.md:23
 msgid "\"called `my_mod::indirect_access()`, that\\n> \""
-msgstr ""
+msgstr "\"调用了 `my_mod::indirect_access()`，它\\n> \""
 
 #: src/mod/visibility.md:27
 msgid "// Modules can also be nested\n"
-msgstr ""
+msgstr "// 模块也可以嵌套\n"
 
 #: src/mod/visibility.md:30
 msgid "\"called `my_mod::nested::function()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::nested::function()`\""
 
 #: src/mod/visibility.md:35
 msgid "\"called `my_mod::nested::private_function()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::nested::private_function()`\""
 
 #: src/mod/visibility.md:38
 msgid ""
 "// Functions declared using `pub(in path)` syntax are only visible\n"
 "        // within the given path. `path` must be a parent or ancestor module\n"
 msgstr ""
+"// 使用 `pub(in path)` 语法声明的函数只在给定的路径中可见\n"
+"        // `path` 必须是父模块或祖先模块\n"
 
 #: src/mod/visibility.md:41
 msgid "\"called `my_mod::nested::public_function_in_my_mod()`, that\\n> \""
-msgstr ""
+msgstr "\"调用了 `my_mod::nested::public_function_in_my_mod()`，它\\n> \""
 
 #: src/mod/visibility.md:45
 msgid ""
 "// Functions declared using `pub(self)` syntax are only visible within\n"
 "        // the current module, which is the same as leaving them private\n"
 msgstr ""
+"// 使用 `pub(self)` 语法声明的函数只在当前模块中可见\n"
+"        // 这与将它们保持为私有是一样的\n"
 
 #: src/mod/visibility.md:48
 msgid "\"called `my_mod::nested::public_function_in_nested()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::nested::public_function_in_nested()`\""
 
 #: src/mod/visibility.md:51
 msgid ""
 "// Functions declared using `pub(super)` syntax are only visible within\n"
 "        // the parent module\n"
 msgstr ""
+"// 使用 `pub(super)` 语法声明的函数只在父模块中可见\n"
+"        \n"
 
 #: src/mod/visibility.md:54
 msgid "\"called `my_mod::nested::public_function_in_super_mod()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::nested::public_function_in_super_mod()`\""
 
 #: src/mod/visibility.md:59
 msgid "\"called `my_mod::call_public_function_in_my_mod()`, that\\n> \""
-msgstr ""
+msgstr "\"调用了 `my_mod::call_public_function_in_my_mod()`，它\\n> \""
 
 #: src/mod/visibility.md:61
 msgid "\"> \""
-msgstr ""
+msgstr "\"> \""
 
 #: src/mod/visibility.md:65
 msgid "// pub(crate) makes functions visible only within the current crate\n"
-msgstr ""
+msgstr "// pub(crate) 使函数只在当前 crate 中可见\n"
 
 #: src/mod/visibility.md:67
 msgid "\"called `my_mod::public_function_in_crate()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::public_function_in_crate()`\""
 
 #: src/mod/visibility.md:70
 msgid "// Nested modules follow the same rules for visibility\n"
-msgstr ""
+msgstr "// 嵌套模块遵循相同的可见性规则\n"
 
 #: src/mod/visibility.md:74
 msgid "\"called `my_mod::private_nested::function()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::private_nested::function()`\""
 
 #: src/mod/visibility.md:77
 msgid ""
 "// Private parent items will still restrict the visibility of a child item,\n"
 "        // even if it is declared as visible within a bigger scope.\n"
 msgstr ""
+"// 私有的父项仍然会限制子项的可见性，\n"
+"        // 即使它被声明为在更大范围内可见。\n"
 
 #: src/mod/visibility.md:81
 msgid "\"called `my_mod::private_nested::restricted_function()`\""
-msgstr ""
+msgstr "\"调用了 `my_mod::private_nested::restricted_function()`\""
 
 #: src/mod/visibility.md:87 src/mod/use.md:25 src/mod/super.md:8
 #: src/mod/split.md:24
 msgid "\"called `function()`\""
-msgstr ""
+msgstr "\"调用了 `function()`\""
 
 #: src/mod/visibility.md:91
 msgid "// Modules allow disambiguation between items that have the same name.\n"
-msgstr ""
+msgstr "// 模块允许消除具有相同名称的项之间的歧义。\n"
 
 #: src/mod/visibility.md:95
 msgid ""
 "// Public items, including those inside nested modules, can be\n"
 "    // accessed from outside the parent module.\n"
 msgstr ""
+"// 公有项，包括那些在嵌套模块内的，可以\n"
+"    // 从父模块外部访问。\n"
 
 #: src/mod/visibility.md:101
 msgid "// pub(crate) items can be called from anywhere in the same crate\n"
-msgstr ""
+msgstr "// pub(crate) 项可以从同一个 crate 中的任何地方调用\n"
 
 #: src/mod/visibility.md:104
 msgid ""
@@ -6439,12 +6453,17 @@ msgid ""
 "    //my_mod::nested::public_function_in_my_mod();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// pub(in path) 条目只能从指定的模块内部调用\n"
+"    // 报错！函数 `public_function_in_my_mod` 是私有的\n"
+"    //my_mod::nested::public_function_in_my_mod();\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/visibility.md:109
 msgid ""
 "// Private items of a module cannot be directly accessed, even if\n"
 "    // nested in a public module:\n"
 msgstr ""
+"// 模块的私有条目不能被直接访问，即使嵌套在一个公有模块中：\n"
 
 #: src/mod/visibility.md:112
 msgid ""
@@ -6452,6 +6471,9 @@ msgid ""
 "    //my_mod::private_function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 报错！`private_function` 是私有的\n"
+"    //my_mod::private_function();\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/visibility.md:116
 msgid ""
@@ -6459,6 +6481,9 @@ msgid ""
 "    //my_mod::nested::private_function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 报错！`private_function` 是私有的\n"
+"    //my_mod::nested::private_function();\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/visibility.md:120
 msgid ""
@@ -6466,6 +6491,9 @@ msgid ""
 "    //my_mod::private_nested::function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 报错！`private_nested` 是一个私有模块\n"
+"    //my_mod::private_nested::function();\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/visibility.md:124
 msgid ""
@@ -6473,6 +6501,9 @@ msgid ""
 "    //my_mod::private_nested::restricted_function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 报错！`private_nested` 是一个私有模块\n"
+"    //my_mod::private_nested::restricted_function();\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/struct_visibility.md:3
 msgid ""
@@ -6481,34 +6512,35 @@ msgid ""
 "visibility only matters when a struct is accessed from outside the module "
 "where it is defined, and has the goal of hiding information (encapsulation)."
 msgstr ""
+"结构体的字段有额外的可见性级别。可见性默认为私有，可以使用 `pub` 修饰符来覆盖。这种可见性只在从定义结构体的模块外部访问结构体时才有意义，其目的是隐藏信息（封装）。"
 
 #: src/mod/struct_visibility.md:10
 msgid "// A public struct with a public field of generic type `T`\n"
-msgstr ""
+msgstr "// 一个带有泛型类型 `T` 的公有字段的公有结构体\n"
 
 #: src/mod/struct_visibility.md:15
 msgid "// A public struct with a private field of generic type `T`\n"
-msgstr ""
+msgstr "// 一个带有泛型类型 `T` 的私有字段的公有结构体\n"
 
 #: src/mod/struct_visibility.md:21
 msgid "// A public constructor method\n"
-msgstr ""
+msgstr "// 一个公有的构造方法\n"
 
 #: src/mod/struct_visibility.md:31
 msgid "// Public structs with public fields can be constructed as usual\n"
-msgstr ""
+msgstr "// 带有公有字段的公有结构体可以像往常一样构造\n"
 
 #: src/mod/struct_visibility.md:32
 msgid "\"public information\""
-msgstr ""
+msgstr "\"公开信息\""
 
 #: src/mod/struct_visibility.md:34
 msgid "// and their fields can be normally accessed.\n"
-msgstr ""
+msgstr "// 并且可以正常访问它们的字段。\n"
 
 #: src/mod/struct_visibility.md:35
 msgid "\"The open box contains: {}\""
-msgstr ""
+msgstr "\"打开的盒子包含：{}\""
 
 #: src/mod/struct_visibility.md:37
 msgid ""
@@ -6519,16 +6551,21 @@ msgid ""
 "information\" };\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 带有私有字段的公有结构体不能使用字段名来构造。\n"
+"    // 报错！`ClosedBox` 有私有字段\n"
+"    //let closed_box = my::ClosedBox { contents: \"机密信息\" };\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/struct_visibility.md:42
 msgid ""
 "// However, structs with private fields can be created using\n"
 "    // public constructors\n"
 msgstr ""
+"// 然而，带有私有字段的结构体可以使用公有构造函数来创建\n"
 
 #: src/mod/struct_visibility.md:44
 msgid "\"classified information\""
-msgstr ""
+msgstr "\"机密信息\""
 
 #: src/mod/struct_visibility.md:46
 msgid ""
@@ -6537,122 +6574,135 @@ msgid ""
 "    //println!(\"The closed box contains: {}\", _closed_box.contents);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 并且不能访问公有结构体的私有字段。\n"
+"    // 错误！`contents` 字段是私有的\n"
+"    //println!(\"封闭的盒子包含：{}\", _closed_box.contents);\n"
+"    // TODO ^ 尝试取消这一行的注释\n"
 
 #: src/mod/struct_visibility.md:55
 msgid "[generics](../generics.md) and [methods](../fn/methods.md)"
-msgstr ""
+msgstr "[泛型](../generics.md)和[方法](../fn/methods.md)"
 
 #: src/mod/use.md:3
 msgid ""
 "The `use` declaration can be used to bind a full path to a new name, for "
 "easier access. It is often used like this:"
-msgstr ""
+msgstr "`use` 声明可以将完整路径绑定到一个新的名称，以便更容易访问。它通常像这样使用："
 
 #: src/mod/use.md:18
 msgid "You can use the `as` keyword to bind imports to a different name:"
-msgstr ""
+msgstr "你可以使用 `as` 关键字将导入绑定到不同的名称："
 
 #: src/mod/use.md:21
 msgid "// Bind the `deeply::nested::function` path to `other_function`.\n"
-msgstr ""
+msgstr "// 将 `deeply::nested::function` 路径绑定到 `other_function`。\n"
 
 #: src/mod/use.md:31
 msgid "\"called `deeply::nested::function()`\""
-msgstr ""
+msgstr "\"调用 `deeply::nested::function()`\""
 
 #: src/mod/use.md:37
 msgid "// Easier access to `deeply::nested::function`\n"
-msgstr ""
+msgstr "// 更容易访问 `deeply::nested::function`\n"
 
 #: src/mod/use.md:40
 msgid "\"Entering block\""
-msgstr ""
+msgstr "\"进入块\""
 
 #: src/mod/use.md:42
 msgid ""
 "// This is equivalent to `use deeply::nested::function as function`.\n"
 "        // This `function()` will shadow the outer one.\n"
 msgstr ""
+"// 这等同于 `use deeply::nested::function as function`。\n"
+"        // 这个 `function()` 将遮蔽外部的同名函数。\n"
 
 #: src/mod/use.md:46
 msgid ""
 "// `use` bindings have a local scope. In this case, the\n"
 "        // shadowing of `function()` is only in this block.\n"
 msgstr ""
+"// `use` 绑定具有局部作用域。在这种情况下，\n"
+"        // `function()` 的遮蔽仅在此块内有效。\n"
 
 #: src/mod/use.md:50
 msgid "\"Leaving block\""
-msgstr ""
+msgstr "\"离开块\""
 
 #: src/mod/super.md:3
 msgid ""
 "The `super` and `self` keywords can be used in the path to remove ambiguity "
 "when accessing items and to prevent unnecessary hardcoding of paths."
-msgstr ""
+msgstr "`super` 和 `self` 关键字可以在路径中使用，以消除访问项目时的歧义，并防止不必要的路径硬编码。"
 
 #: src/mod/super.md:13
 msgid "\"called `cool::function()`\""
-msgstr ""
+msgstr "\"调用 `cool::function()`\""
 
 #: src/mod/super.md:19 src/mod/split.md:49
 msgid "\"called `my::function()`\""
-msgstr ""
+msgstr "\"调用 `my::function()`\""
 
 #: src/mod/super.md:24
 msgid "\"called `my::cool::function()`\""
-msgstr ""
+msgstr "\"调用 `my::cool::function()`\""
 
 #: src/mod/super.md:29
 msgid "// Let's access all the functions named `function` from this scope!\n"
-msgstr ""
+msgstr "// 让我们从这个作用域访问所有名为 `function` 的函数！\n"
 
 #: src/mod/super.md:30
 msgid "\"called `my::indirect_call()`, that\\n> \""
-msgstr ""
+msgstr "\"调用 `my::indirect_call()`，它\\n> \""
 
 #: src/mod/super.md:32
 msgid ""
-"// The `self` keyword refers to the current module scope - in this case "
-"`my`.\n"
+"// The `self` keyword refers to the current module scope - in this case `my`.\n"
 "        // Calling `self::function()` and calling `function()` directly both "
 "give\n"
 "        // the same result, because they refer to the same function.\n"
 msgstr ""
+"// `self` 关键字指的是当前模块作用域 - 在这种情况下是 `my`。\n"
+"        // 调用 `self::function()` 和直接调用 `function()` 都会\n"
+"        // 得到相同的结果，因为它们指的是同一个函数。\n"
 
 #: src/mod/super.md:38
 msgid "// We can also use `self` to access another module inside `my`:\n"
-msgstr ""
+msgstr "// 我们也可以使用 `self` 来访问 `my` 内的另一个模块：\n"
 
 #: src/mod/super.md:41
 msgid ""
 "// The `super` keyword refers to the parent scope (outside the `my` module).\n"
-msgstr ""
+msgstr "// `super` 关键字指的是父作用域（`my` 模块之外）。\n"
 
 #: src/mod/super.md:44
 msgid ""
 "// This will bind to the `cool::function` in the *crate* scope.\n"
 "        // In this case the crate scope is the outermost scope.\n"
 msgstr ""
+"// 这将绑定到 *crate* 作用域中的 `cool::function`。\n"
+"        // 在这种情况下，crate 作用域是最外层作用域。\n"
 
 #: src/mod/split.md:3
 msgid ""
 "Modules can be mapped to a file/directory hierarchy. Let's break down the "
 "[visibility example](visibility.md) in files:"
-msgstr ""
+msgstr "模块可以映射到文件/目录层次结构。让我们将[可见性示例](visibility.md)拆分到多个文件中："
 
 #: src/mod/split.md:16
 msgid "In `split.rs`:"
-msgstr ""
+msgstr "在 `split.rs` 中："
 
 #: src/mod/split.md:19
 msgid ""
 "// This declaration will look for a file named `my.rs` and will\n"
 "// insert its contents inside a module named `my` under this scope\n"
 msgstr ""
+"// 这个声明会查找一个名为 `my.rs` 的文件，并将其内容插入到这个作用域下名为 `my` 的模块中\n"
 
 #: src/mod/split.md:39
 msgid "In `my.rs`:"
-msgstr ""
+msgstr "在 `my.rs` 中："
 
 #: src/mod/split.md:42
 msgid ""
@@ -6660,38 +6710,40 @@ msgid ""
 "// and `inaccessible.rs` files and insert them here under their respective\n"
 "// modules\n"
 msgstr ""
+"// 类似地，`mod inaccessible` 和 `mod nested` 将定位 `nested.rs` \n"
+"// 和 `inaccessible.rs` 文件，并将它们插入到这里各自的模块下\n"
 
 #: src/mod/split.md:53
 msgid "\"called `my::private_function()`\""
-msgstr ""
+msgstr "\"调用 `my::private_function()`\""
 
 #: src/mod/split.md:57
 msgid "\"called `my::indirect_access()`, that\\n> \""
-msgstr ""
+msgstr "\"调用 `my::indirect_access()`，它\\n> \""
 
 #: src/mod/split.md:63
 msgid "In `my/nested.rs`:"
-msgstr ""
+msgstr "在 `my/nested.rs` 中："
 
 #: src/mod/split.md:67
 msgid "\"called `my::nested::function()`\""
-msgstr ""
+msgstr "\"调用 `my::nested::function()`\""
 
 #: src/mod/split.md:72
 msgid "\"called `my::nested::private_function()`\""
-msgstr ""
+msgstr "\"调用 `my::nested::private_function()`\""
 
 #: src/mod/split.md:76
 msgid "In `my/inaccessible.rs`:"
-msgstr ""
+msgstr "在 `my/inaccessible.rs` 中："
 
 #: src/mod/split.md:81
 msgid "\"called `my::inaccessible::public_function()`\""
-msgstr ""
+msgstr "\"调用 `my::inaccessible::public_function()`\""
 
 #: src/mod/split.md:85
 msgid "Let's check that things still work as before:"
-msgstr ""
+msgstr "让我们检查一下是否一切仍然像之前一样工作："
 
 #: src/crates.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2830,199 +2830,208 @@ msgstr "[`match`](../flow_control/match.md)、[`fn`](../fn.md) 和 [`String`](..
 
 #: src/custom_types/enum/enum_use.md:3
 msgid "The `use` declaration can be used so manual scoping isn't needed:"
-msgstr ""
+msgstr "`use` 声明可以用来避免手动作用域限定："
 
 #: src/custom_types/enum/enum_use.md:20
 msgid ""
 "// Explicitly `use` each name so they are available without\n"
 "    // manual scoping.\n"
 msgstr ""
+"// 显式 `use` 每个名称，这样它们就可以不用\n"
+"    // 手动作用域限定而直接使用。\n"
 
 #: src/custom_types/enum/enum_use.md:23
 msgid "// Automatically `use` each name inside `Role`.\n"
-msgstr ""
+msgstr "// 自动 `use` `Role` 内部的每个名称。\n"
 
 #: src/custom_types/enum/enum_use.md:26
 msgid "// Equivalent to `Stage::Beginner`.\n"
-msgstr ""
+msgstr "// 等同于 `Stage::Beginner`。\n"
 
 #: src/custom_types/enum/enum_use.md:28
 msgid "// Equivalent to `Role::Student`.\n"
-msgstr ""
+msgstr "// 等同于 `Role::Student`。\n"
 
 #: src/custom_types/enum/enum_use.md:32
 msgid "// Note the lack of scoping because of the explicit `use` above.\n"
-msgstr ""
+msgstr "// 注意由于上面的显式 `use`，这里不需要作用域限定。\n"
 
 #: src/custom_types/enum/enum_use.md:33
 msgid "\"Beginners are starting their learning journey!\""
-msgstr ""
+msgstr "\"初学者正在开始他们的学习之旅！\""
 
 #: src/custom_types/enum/enum_use.md:34
 msgid "\"Advanced learners are mastering their subjects...\""
-msgstr ""
+msgstr "\"高级学习者正在掌握他们的科目...\""
 
 #: src/custom_types/enum/enum_use.md:38
 msgid "// Note again the lack of scoping.\n"
-msgstr ""
+msgstr "// 再次注意这里不需要作用域限定。\n"
 
 #: src/custom_types/enum/enum_use.md:39
 msgid "\"Students are acquiring knowledge!\""
-msgstr ""
+msgstr "\"学生正在获取知识！\""
 
 #: src/custom_types/enum/enum_use.md:40
 msgid "\"Teachers are spreading knowledge!\""
-msgstr ""
+msgstr "\"教师正在传播知识！\""
 
 #: src/custom_types/enum/enum_use.md:47
 msgid "[`match`](../../flow_control/match.md) and [`use`](../../mod/use.md)"
-msgstr ""
+msgstr "[`match`](../../flow_control/match.md) 和 [`use`](../../mod/use.md)"
 
 #: src/custom_types/enum/c_like.md:3
 msgid "`enum` can also be used as C-like enums."
-msgstr ""
+msgstr "`enum` 也可以像 C 语言那样使用。"
 
 #: src/custom_types/enum/c_like.md:8
 msgid "// enum with implicit discriminator (starts at 0)\n"
-msgstr ""
+msgstr "// 隐式辨别值（从 0 开始）的枚举\n"
 
 #: src/custom_types/enum/c_like.md:15
 msgid "// enum with explicit discriminator\n"
-msgstr ""
+msgstr "// 显式辨别值的枚举\n"
 
 #: src/custom_types/enum/c_like.md:24
 msgid "// `enums` can be cast as integers.\n"
-msgstr ""
+msgstr "// `enum` 可以转换为整数。\n"
 
 #: src/custom_types/enum/c_like.md:25
 msgid "\"zero is {}\""
-msgstr ""
+msgstr "\"zero 是 {}\""
 
 #: src/custom_types/enum/c_like.md:26
 msgid "\"one is {}\""
-msgstr ""
+msgstr "\"one 是 {}\""
 
 #: src/custom_types/enum/c_like.md:28
 msgid "\"roses are #{:06x}\""
-msgstr ""
+msgstr "\"玫瑰花是 #{:06x}\""
 
 #: src/custom_types/enum/c_like.md:29
 msgid "\"violets are #{:06x}\""
-msgstr ""
+msgstr "\"紫罗兰是 #{:06x}\""
 
 #: src/custom_types/enum/c_like.md:35
 msgid "[casting](../../types/cast.md)"
-msgstr ""
+msgstr "[类型转换](../../types/cast.md)"
 
 #: src/custom_types/enum/testcase_linked_list.md:3
 msgid "A common way to implement a linked-list is via `enums`:"
-msgstr ""
+msgstr "使用 `enum` 实现链表是一种常见的方法："
 
 #: src/custom_types/enum/testcase_linked_list.md:9
 msgid ""
 "// Cons: Tuple struct that wraps an element and a pointer to the next node\n"
-msgstr ""
+msgstr "// Cons：元组结构体包含一个元素和一个指向下一节点的指针\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:11
 msgid "// Nil: A node that signifies the end of the linked list\n"
-msgstr ""
+msgstr "// Nil：表示链表结束的节点\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:14
 msgid "// Methods can be attached to an enum\n"
-msgstr ""
+msgstr "// 可以为枚举实现方法\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:17
 msgid "// Create an empty list\n"
-msgstr ""
+msgstr "// 创建一个空链表\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:19
 msgid "// `Nil` has type `List`\n"
-msgstr ""
+msgstr "// `Nil` 属于 `List` 类型\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:23
 msgid ""
 "// Consume a list, and return the same list with a new element at its front\n"
-msgstr ""
+msgstr "// 处理一个链表，并返回在其头部插入新元素后的同一链表\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:25
 msgid "// `Cons` also has type List\n"
-msgstr ""
+msgstr "// `Cons` 也是 List 类型\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:29
 msgid "// Return the length of the list\n"
-msgstr ""
+msgstr "// 返回链表的长度\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:31
 msgid ""
 "// `self` has to be matched, because the behavior of this method\n"
 "        // depends on the variant of `self`\n"
-"        // `self` has type `&List`, and `*self` has type `List`, matching on "
-"a\n"
+"        // `self` has type `&List`, and `*self` has type `List`, matching on a\n"
 "        // concrete type `T` is preferred over a match on a reference `&T`\n"
-"        // after Rust 2018 you can use self here and tail (with no ref) below "
-"as well,\n"
+"        // after Rust 2018 you can use self here and tail (with no ref) below as well,\n"
 "        // rust will infer &s and ref tail. \n"
-"        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-"
-"and-lifetimes/default-match-bindings.html\n"
+"        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/default-match-bindings.html\n"
 msgstr ""
+"// 必须对 `self` 进行匹配，因为这个方法的行为取决于 `self` 的成员\n"
+"        // `self` 的类型是 `&List`，而 `*self` 的类型是 `List`，匹配一个具体的\n"
+"        // 类型 `T` 要优于匹配一个引用 `&T`\n"
+"        // 在 Rust 2018 之后，你也可以在这里使用 self，在下面使用 tail（不带 ref），\n"
+"        // Rust 会推断出 &s 和 ref tail。\n"
+"        // 参见 https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/default-match-bindings.html\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:39
 msgid ""
 "// Can't take ownership of the tail, because `self` is borrowed;\n"
 "            // instead take a reference to the tail\n"
 msgstr ""
+"// 不能获取 tail 的所有权，因为 `self` 是借用的；\n"
+"            // 相反，我们获取 tail 的引用\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:42
 msgid "// Base Case: An empty list has zero length\n"
-msgstr ""
+msgstr "// 基本情况：空链表的长度为零\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:47
 msgid "// Return representation of the list as a (heap allocated) string\n"
-msgstr ""
+msgstr "// 返回链表的字符串表示（堆分配）\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:51
 msgid ""
 "// `format!` is similar to `print!`, but returns a heap\n"
 "                // allocated string instead of printing to the console\n"
 msgstr ""
+"// `format!` 类似于 `print!`，但返回一个堆分配的字符串，\n"
+"                // 而不是打印到控制台\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:53 src/generics/impl.md:44
 msgid "\"{}, {}\""
-msgstr ""
+msgstr "\"{}, {}\""
 
 #: src/custom_types/enum/testcase_linked_list.md:56
 msgid "\"Nil\""
-msgstr ""
+msgstr "\"Nil\""
 
 #: src/custom_types/enum/testcase_linked_list.md:63
 msgid "// Create an empty linked list\n"
-msgstr ""
+msgstr "// 创建一个空链表\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:66
 msgid "// Prepend some elements\n"
-msgstr ""
+msgstr "// 在头部添加一些元素\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:71
 msgid "// Show the final state of the list\n"
-msgstr ""
+msgstr "// 显示链表的最终状态\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:72
 msgid "\"linked list has length: {}\""
-msgstr ""
+msgstr "\"链表的长度为：{}\""
 
 #: src/custom_types/enum/testcase_linked_list.md:79
 msgid "[`Box`](../../std/box.md) and [methods](../../fn/methods.md)"
-msgstr ""
+msgstr "[`Box`](../../std/box.md) 和 [方法](../../fn/methods.md)"
 
 #: src/custom_types/constants.md:3
 msgid ""
 "Rust has two different types of constants which can be declared in any scope "
 "including global. Both require explicit type annotation:"
-msgstr ""
+msgstr "Rust 有两种不同类型的常量，可以在包括全局作用域在内的任何作用域中声明。两者都需要显式的类型注解："
 
 #: src/custom_types/constants.md:6
 msgid "`const`: An unchangeable value (the common case)."
-msgstr ""
+msgstr "`const`：不可改变的值（常见用法）。"
 
 #: src/custom_types/constants.md:7
 msgid ""
@@ -3031,46 +3040,48 @@ msgid ""
 "have to be specified. Accessing or modifying a mutable static variable is "
 "[`unsafe`](../unsafe.md)."
 msgstr ""
+"`static`：具有 [`'static`](../scope/lifetime/static_lifetime.md) 生命周期的可能可变的变量。"
+"静态生命周期是自动推断的，不需要明确指定。访问或修改可变静态变量是 [`unsafe`](../unsafe.md) 的。"
 
 #: src/custom_types/constants.md:12
 msgid "// Globals are declared outside all other scopes.\n"
-msgstr ""
+msgstr "// 全局变量在所有其他作用域之外声明。\n"
 
 #: src/custom_types/constants.md:13
 msgid "\"Rust\""
-msgstr ""
+msgstr "\"Rust\""
 
 #: src/custom_types/constants.md:17
 msgid "// Access constant in some function\n"
-msgstr ""
+msgstr "// 在某个函数中访问常量\n"
 
 #: src/custom_types/constants.md:24
 msgid "// Access constant in the main thread\n"
-msgstr ""
+msgstr "// 在主线程中访问常量\n"
 
 #: src/custom_types/constants.md:25
 msgid "\"This is {}\""
-msgstr ""
+msgstr "\"这是 {}\""
 
 #: src/custom_types/constants.md:26
 msgid "\"The threshold is {}\""
-msgstr ""
+msgstr "\"阈值是 {}\""
 
 #: src/custom_types/constants.md:27
 msgid "\"{} is {}\""
-msgstr ""
+msgstr "\"{} 是 {}\""
 
 #: src/custom_types/constants.md:27
 msgid "\"big\""
-msgstr ""
+msgstr "\"大的\""
 
 #: src/custom_types/constants.md:27
 msgid "\"small\""
-msgstr ""
+msgstr "\"小的\""
 
 #: src/custom_types/constants.md:29
 msgid "// Error! Cannot modify a `const`.\n"
-msgstr ""
+msgstr "// 错误！不能修改 `const`。\n"
 
 #: src/custom_types/constants.md:31 src/variable_bindings/scope.md:21
 #: src/variable_bindings/declare.md:25 src/variable_bindings/freeze.md:16
@@ -3078,7 +3089,7 @@ msgstr ""
 #: src/scope/borrow.md:41 src/scope/borrow/mut.md:52 src/std/vec.md:31
 #: src/std/vec.md:44 src/std/hash/hashset.md:48
 msgid "// FIXME ^ Comment out this line\n"
-msgstr ""
+msgstr "// 修复 ^ 注释掉这一行\n"
 
 #: src/custom_types/constants.md:37
 msgid ""
@@ -3086,6 +3097,9 @@ msgid ""
 "text/0246-const-vs-static.md), [`'static` lifetime](../scope/lifetime/"
 "static_lifetime.md)"
 msgstr ""
+"[`const`/`static` RFC](https://github.com/rust-lang/rfcs/blob/master/"
+"text/0246-const-vs-static.md)，[`'static` 生命周期](../scope/lifetime/"
+"static_lifetime.md)"
 
 #: src/variable_bindings.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -1,0 +1,15005 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Rust By Example\n"
+"POT-Creation-Date: 2024-08-17T09:33:02+08:00\n"
+"PO-Revision-Date: 2024-08-17 10:48+0800\n"
+"Last-Translator: Binlogo <binboy@live.com>\n"
+"Language-Team: Chinese\n"
+"Language: zh\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/SUMMARY.md:1
+msgid "Summary"
+msgstr ""
+
+#: src/SUMMARY.md:3
+msgid "Introduction"
+msgstr ""
+
+#: src/SUMMARY.md:5 src/hello.md:1
+msgid "Hello World"
+msgstr ""
+
+#: src/SUMMARY.md:6 src/hello/comment.md:1
+msgid "Comments"
+msgstr ""
+
+#: src/SUMMARY.md:7 src/hello/print.md:1
+msgid "Formatted print"
+msgstr ""
+
+#: src/SUMMARY.md:8 src/hello/print/print_debug.md:1
+msgid "Debug"
+msgstr ""
+
+#: src/SUMMARY.md:9 src/hello/print/print_display.md:1
+msgid "Display"
+msgstr ""
+
+#: src/SUMMARY.md:10 src/hello/print/print_display/testcase_list.md:1
+msgid "Testcase: List"
+msgstr ""
+
+#: src/SUMMARY.md:11 src/hello/print/fmt.md:1
+msgid "Formatting"
+msgstr ""
+
+#: src/SUMMARY.md:13 src/primitives.md:1
+msgid "Primitives"
+msgstr ""
+
+#: src/SUMMARY.md:14 src/primitives/literals.md:1
+msgid "Literals and operators"
+msgstr ""
+
+#: src/SUMMARY.md:15 src/primitives/tuples.md:1
+msgid "Tuples"
+msgstr ""
+
+#: src/SUMMARY.md:16 src/primitives/array.md:1
+msgid "Arrays and Slices"
+msgstr ""
+
+#: src/SUMMARY.md:18 src/custom_types.md:1
+msgid "Custom Types"
+msgstr ""
+
+#: src/SUMMARY.md:19 src/custom_types/structs.md:1
+msgid "Structures"
+msgstr ""
+
+#: src/SUMMARY.md:20 src/custom_types/enum.md:1
+msgid "Enums"
+msgstr ""
+
+#: src/SUMMARY.md:21 src/custom_types/enum/enum_use.md:1
+msgid "use"
+msgstr ""
+
+#: src/SUMMARY.md:22 src/custom_types/enum/c_like.md:1
+msgid "C-like"
+msgstr ""
+
+#: src/SUMMARY.md:23 src/custom_types/enum/testcase_linked_list.md:1
+msgid "Testcase: linked-list"
+msgstr ""
+
+#: src/SUMMARY.md:24 src/custom_types/constants.md:1
+msgid "constants"
+msgstr ""
+
+#: src/SUMMARY.md:26 src/variable_bindings.md:1
+msgid "Variable Bindings"
+msgstr ""
+
+#: src/SUMMARY.md:27 src/SUMMARY.md:120 src/SUMMARY.md:123
+#: src/variable_bindings/mut.md:1 src/scope/move/mut.md:1
+#: src/scope/borrow/mut.md:1
+msgid "Mutability"
+msgstr ""
+
+#: src/SUMMARY.md:28 src/variable_bindings/scope.md:1
+msgid "Scope and Shadowing"
+msgstr ""
+
+#: src/SUMMARY.md:29 src/variable_bindings/declare.md:1
+msgid "Declare first"
+msgstr ""
+
+#: src/SUMMARY.md:30 src/variable_bindings/freeze.md:1
+msgid "Freezing"
+msgstr ""
+
+#: src/SUMMARY.md:32 src/types.md:1
+msgid "Types"
+msgstr ""
+
+#: src/SUMMARY.md:33 src/types/cast.md:1
+msgid "Casting"
+msgstr ""
+
+#: src/SUMMARY.md:34 src/types/literals.md:1
+msgid "Literals"
+msgstr ""
+
+#: src/SUMMARY.md:35 src/types/inference.md:1
+msgid "Inference"
+msgstr ""
+
+#: src/SUMMARY.md:36 src/SUMMARY.md:124 src/types/alias.md:1
+#: src/scope/borrow/alias.md:1
+msgid "Aliasing"
+msgstr ""
+
+#: src/SUMMARY.md:38 src/conversion.md:1
+msgid "Conversion"
+msgstr ""
+
+#: src/SUMMARY.md:39 src/conversion/from_into.md:1
+msgid "`From` and `Into`"
+msgstr ""
+
+#: src/SUMMARY.md:40 src/conversion/try_from_try_into.md:1
+msgid "`TryFrom` and `TryInto`"
+msgstr ""
+
+#: src/SUMMARY.md:41
+msgid "To and from `String`s"
+msgstr ""
+
+#: src/SUMMARY.md:43 src/expression.md:1
+msgid "Expressions"
+msgstr ""
+
+#: src/SUMMARY.md:45 src/flow_control.md:1
+msgid "Flow of Control"
+msgstr ""
+
+#: src/SUMMARY.md:46 src/flow_control/if_else.md:1
+msgid "if/else"
+msgstr ""
+
+#: src/SUMMARY.md:47 src/flow_control/loop.md:1
+msgid "loop"
+msgstr ""
+
+#: src/SUMMARY.md:48 src/flow_control/loop/nested.md:1
+msgid "Nesting and labels"
+msgstr ""
+
+#: src/SUMMARY.md:49 src/flow_control/loop/return.md:1
+msgid "Returning from loops"
+msgstr ""
+
+#: src/SUMMARY.md:50 src/flow_control/while.md:1
+msgid "while"
+msgstr ""
+
+#: src/SUMMARY.md:51 src/flow_control/for.md:3
+msgid "for and range"
+msgstr ""
+
+#: src/SUMMARY.md:52 src/flow_control/match.md:1
+msgid "match"
+msgstr ""
+
+#: src/SUMMARY.md:53 src/flow_control/match/destructuring.md:1
+msgid "Destructuring"
+msgstr ""
+
+#: src/SUMMARY.md:54 src/flow_control/match/destructuring/destructure_tuple.md:1
+msgid "tuples"
+msgstr ""
+
+#: src/SUMMARY.md:55 src/flow_control/match/destructuring/destructure_slice.md:1
+msgid "arrays/slices"
+msgstr ""
+
+#: src/SUMMARY.md:56 src/flow_control/match/destructuring/destructure_enum.md:1
+msgid "enums"
+msgstr ""
+
+#: src/SUMMARY.md:57
+#: src/flow_control/match/destructuring/destructure_pointers.md:1
+msgid "pointers/ref"
+msgstr ""
+
+#: src/SUMMARY.md:58
+#: src/flow_control/match/destructuring/destructure_structures.md:1
+msgid "structs"
+msgstr ""
+
+#: src/SUMMARY.md:59 src/flow_control/match/guard.md:1
+msgid "Guards"
+msgstr ""
+
+#: src/SUMMARY.md:60 src/flow_control/match/binding.md:1
+msgid "Binding"
+msgstr ""
+
+#: src/SUMMARY.md:61 src/flow_control/if_let.md:1
+msgid "if let"
+msgstr ""
+
+#: src/SUMMARY.md:62 src/flow_control/let_else.md:1
+msgid "let-else"
+msgstr ""
+
+#: src/SUMMARY.md:63 src/flow_control/while_let.md:1
+msgid "while let"
+msgstr ""
+
+#: src/SUMMARY.md:65 src/SUMMARY.md:103 src/SUMMARY.md:128 src/fn.md:1
+#: src/generics/gen_fn.md:1 src/scope/lifetime/fn.md:1
+msgid "Functions"
+msgstr ""
+
+#: src/SUMMARY.md:66 src/SUMMARY.md:129 src/scope/lifetime/methods.md:1
+msgid "Methods"
+msgstr ""
+
+#: src/SUMMARY.md:67 src/fn/closures.md:1
+msgid "Closures"
+msgstr ""
+
+#: src/SUMMARY.md:68 src/fn/closures/capture.md:1
+msgid "Capturing"
+msgstr ""
+
+#: src/SUMMARY.md:69 src/fn/closures/input_parameters.md:1
+msgid "As input parameters"
+msgstr ""
+
+#: src/SUMMARY.md:70 src/fn/closures/anonymity.md:1
+msgid "Type anonymity"
+msgstr ""
+
+#: src/SUMMARY.md:71 src/fn/closures/input_functions.md:1
+msgid "Input functions"
+msgstr ""
+
+#: src/SUMMARY.md:72 src/fn/closures/output_parameters.md:1
+msgid "As output parameters"
+msgstr ""
+
+#: src/SUMMARY.md:73 src/fn/closures/closure_examples.md:1
+msgid "Examples in `std`"
+msgstr ""
+
+#: src/SUMMARY.md:74 src/fn/closures/closure_examples/iter_any.md:1
+msgid "Iterator::any"
+msgstr ""
+
+#: src/SUMMARY.md:75 src/fn/closures/closure_examples/iter_find.md:1
+msgid "Searching through iterators"
+msgstr ""
+
+#: src/SUMMARY.md:76 src/fn/hof.md:1
+msgid "Higher Order Functions"
+msgstr ""
+
+#: src/SUMMARY.md:77 src/fn/diverging.md:1
+msgid "Diverging functions"
+msgstr ""
+
+#: src/SUMMARY.md:79 src/mod.md:1
+msgid "Modules"
+msgstr ""
+
+#: src/SUMMARY.md:80 src/mod/visibility.md:1
+msgid "Visibility"
+msgstr ""
+
+#: src/SUMMARY.md:81 src/mod/struct_visibility.md:1
+msgid "Struct visibility"
+msgstr ""
+
+#: src/SUMMARY.md:82 src/mod/use.md:1
+msgid "The `use` declaration"
+msgstr ""
+
+#: src/SUMMARY.md:83 src/mod/super.md:1
+msgid "`super` and `self`"
+msgstr ""
+
+#: src/SUMMARY.md:84 src/mod/split.md:1
+msgid "File hierarchy"
+msgstr ""
+
+#: src/SUMMARY.md:86 src/SUMMARY.md:98 src/crates.md:1 src/attribute/crate.md:1
+#: src/std_misc/arg.md:30
+msgid "Crates"
+msgstr ""
+
+#: src/SUMMARY.md:87 src/crates/lib.md:1
+msgid "Creating a Library"
+msgstr ""
+
+#: src/SUMMARY.md:88 src/crates/using_lib.md:1
+msgid "Using a Library"
+msgstr ""
+
+#: src/SUMMARY.md:90 src/cargo.md:1
+msgid "Cargo"
+msgstr ""
+
+#: src/SUMMARY.md:91 src/cargo/deps.md:1
+msgid "Dependencies"
+msgstr ""
+
+#: src/SUMMARY.md:92 src/cargo/conventions.md:1
+msgid "Conventions"
+msgstr ""
+
+#: src/SUMMARY.md:93
+msgid "Tests"
+msgstr ""
+
+#: src/SUMMARY.md:94 src/cargo/build_scripts.md:1
+msgid "Build Scripts"
+msgstr ""
+
+#: src/SUMMARY.md:96 src/attribute.md:1
+msgid "Attributes"
+msgstr ""
+
+#: src/SUMMARY.md:97 src/attribute/unused.md:1
+msgid "`dead_code`"
+msgstr ""
+
+#: src/SUMMARY.md:99 src/attribute/cfg.md:1
+msgid "`cfg`"
+msgstr ""
+
+#: src/SUMMARY.md:100 src/attribute/cfg/custom.md:1
+msgid "Custom"
+msgstr ""
+
+#: src/SUMMARY.md:102 src/generics.md:1
+msgid "Generics"
+msgstr ""
+
+#: src/SUMMARY.md:104 src/generics/impl.md:1
+msgid "Implementation"
+msgstr ""
+
+#: src/SUMMARY.md:105 src/SUMMARY.md:131 src/SUMMARY.md:137
+#: src/generics/gen_trait.md:1 src/scope/lifetime/trait.md:1 src/trait.md:1
+msgid "Traits"
+msgstr ""
+
+#: src/SUMMARY.md:106 src/SUMMARY.md:132 src/generics/bounds.md:1
+#: src/scope/lifetime/lifetime_bounds.md:1
+msgid "Bounds"
+msgstr ""
+
+#: src/SUMMARY.md:107 src/generics/bounds/testcase_empty.md:1
+msgid "Testcase: empty bounds"
+msgstr ""
+
+#: src/SUMMARY.md:108 src/generics/multi_bounds.md:1
+msgid "Multiple bounds"
+msgstr ""
+
+#: src/SUMMARY.md:109 src/generics/where.md:1
+msgid "Where clauses"
+msgstr ""
+
+#: src/SUMMARY.md:110 src/generics/new_types.md:1
+msgid "New Type Idiom"
+msgstr ""
+
+#: src/SUMMARY.md:111 src/generics/assoc_items.md:1
+msgid "Associated items"
+msgstr ""
+
+#: src/SUMMARY.md:112 src/generics/assoc_items/the_problem.md:1
+msgid "The Problem"
+msgstr ""
+
+#: src/SUMMARY.md:113 src/generics/assoc_items/types.md:1
+msgid "Associated types"
+msgstr ""
+
+#: src/SUMMARY.md:114 src/generics/phantom.md:1
+msgid "Phantom type parameters"
+msgstr ""
+
+#: src/SUMMARY.md:115 src/generics/phantom/testcase_units.md:1
+msgid "Testcase: unit clarification"
+msgstr ""
+
+#: src/SUMMARY.md:117 src/scope.md:1
+msgid "Scoping rules"
+msgstr ""
+
+#: src/SUMMARY.md:118 src/scope/raii.md:1
+msgid "RAII"
+msgstr ""
+
+#: src/SUMMARY.md:119 src/scope/move.md:1
+msgid "Ownership and moves"
+msgstr ""
+
+#: src/SUMMARY.md:121 src/scope/move/partial_move.md:1
+msgid "Partial moves"
+msgstr ""
+
+#: src/SUMMARY.md:122 src/scope/borrow.md:1
+msgid "Borrowing"
+msgstr ""
+
+#: src/SUMMARY.md:125 src/scope/borrow/ref.md:1
+msgid "The ref pattern"
+msgstr ""
+
+#: src/SUMMARY.md:126 src/scope/lifetime.md:1
+msgid "Lifetimes"
+msgstr ""
+
+#: src/SUMMARY.md:127 src/scope/lifetime/explicit.md:1
+msgid "Explicit annotation"
+msgstr ""
+
+#: src/SUMMARY.md:130 src/scope/lifetime/struct.md:1
+msgid "Structs"
+msgstr ""
+
+#: src/SUMMARY.md:133 src/scope/lifetime/lifetime_coercion.md:1
+msgid "Coercion"
+msgstr ""
+
+#: src/SUMMARY.md:134 src/scope/lifetime/static_lifetime.md:1
+msgid "Static"
+msgstr ""
+
+#: src/SUMMARY.md:135 src/scope/lifetime/elision.md:1
+msgid "Elision"
+msgstr ""
+
+#: src/SUMMARY.md:138 src/trait/derive.md:1
+msgid "Derive"
+msgstr ""
+
+#: src/SUMMARY.md:139 src/trait/dyn.md:1
+msgid "Returning Traits with `dyn`"
+msgstr ""
+
+#: src/SUMMARY.md:140 src/trait/ops.md:1
+msgid "Operator Overloading"
+msgstr ""
+
+#: src/SUMMARY.md:141 src/trait/drop.md:1
+msgid "Drop"
+msgstr ""
+
+#: src/SUMMARY.md:142 src/trait/iter.md:1
+msgid "Iterators"
+msgstr ""
+
+#: src/SUMMARY.md:143 src/trait/impl_trait.md:1
+msgid "`impl Trait`"
+msgstr ""
+
+#: src/SUMMARY.md:144 src/trait/clone.md:1
+msgid "Clone"
+msgstr ""
+
+#: src/SUMMARY.md:145 src/trait/supertraits.md:1
+msgid "Supertraits"
+msgstr ""
+
+#: src/SUMMARY.md:146 src/trait/disambiguating.md:1
+msgid "Disambiguating overlapping traits"
+msgstr ""
+
+#: src/SUMMARY.md:148 src/macros.md:1
+msgid "macro_rules!"
+msgstr ""
+
+#: src/SUMMARY.md:149 src/macros/syntax.md:1
+msgid "Syntax"
+msgstr ""
+
+#: src/SUMMARY.md:150 src/macros/designators.md:1
+msgid "Designators"
+msgstr ""
+
+#: src/SUMMARY.md:151 src/macros/overload.md:1
+msgid "Overload"
+msgstr ""
+
+#: src/SUMMARY.md:152 src/macros/repeat.md:1
+msgid "Repeat"
+msgstr ""
+
+#: src/SUMMARY.md:153 src/macros/dry.md:1
+msgid "DRY (Don't Repeat Yourself)"
+msgstr ""
+
+#: src/SUMMARY.md:154
+msgid "DSL (Domain Specific Languages)"
+msgstr ""
+
+#: src/SUMMARY.md:155
+msgid "Variadics"
+msgstr ""
+
+#: src/SUMMARY.md:157 src/error.md:1
+msgid "Error handling"
+msgstr ""
+
+#: src/SUMMARY.md:158 src/error/panic.md:1
+msgid "`panic`"
+msgstr ""
+
+#: src/SUMMARY.md:159
+msgid "`abort` & `unwind`"
+msgstr ""
+
+#: src/SUMMARY.md:160 src/error/option_unwrap.md:1
+msgid "`Option` & `unwrap`"
+msgstr ""
+
+#: src/SUMMARY.md:161 src/error/option_unwrap/question_mark.md:1
+msgid "Unpacking options with `?`"
+msgstr ""
+
+#: src/SUMMARY.md:162 src/error/option_unwrap/map.md:1
+msgid "Combinators: `map`"
+msgstr ""
+
+#: src/SUMMARY.md:163 src/error/option_unwrap/and_then.md:1
+msgid "Combinators: `and_then`"
+msgstr ""
+
+#: src/SUMMARY.md:164
+msgid "Defaults: `or`, `or_else`, `get_or_insert`, `get_or_insert_with`"
+msgstr ""
+
+#: src/SUMMARY.md:165 src/SUMMARY.md:183 src/error/result.md:1
+#: src/std/result.md:1
+msgid "`Result`"
+msgstr ""
+
+#: src/SUMMARY.md:166 src/error/result/result_map.md:1
+msgid "`map` for `Result`"
+msgstr ""
+
+#: src/SUMMARY.md:167 src/error/result/result_alias.md:1
+msgid "aliases for `Result`"
+msgstr ""
+
+#: src/SUMMARY.md:168 src/error/result/early_returns.md:1
+msgid "Early returns"
+msgstr ""
+
+#: src/SUMMARY.md:169 src/error/result/enter_question_mark.md:1
+msgid "Introducing `?`"
+msgstr ""
+
+#: src/SUMMARY.md:170 src/error/multiple_error_types.md:1
+msgid "Multiple error types"
+msgstr ""
+
+#: src/SUMMARY.md:171 src/error/multiple_error_types/option_result.md:1
+msgid "Pulling `Result`s out of `Option`s"
+msgstr ""
+
+#: src/SUMMARY.md:172 src/error/multiple_error_types/define_error_type.md:1
+msgid "Defining an error type"
+msgstr ""
+
+#: src/SUMMARY.md:173 src/error/multiple_error_types/boxing_errors.md:1
+msgid "`Box`ing errors"
+msgstr ""
+
+#: src/SUMMARY.md:174 src/error/multiple_error_types/reenter_question_mark.md:1
+msgid "Other uses of `?`"
+msgstr ""
+
+#: src/SUMMARY.md:175 src/error/multiple_error_types/wrap_error.md:1
+msgid "Wrapping errors"
+msgstr ""
+
+#: src/SUMMARY.md:176 src/error/iter_result.md:1
+msgid "Iterating over `Result`s"
+msgstr ""
+
+#: src/SUMMARY.md:178 src/std.md:1
+msgid "Std library types"
+msgstr ""
+
+#: src/SUMMARY.md:179 src/std/box.md:1
+msgid "Box, stack and heap"
+msgstr ""
+
+#: src/SUMMARY.md:180 src/std/vec.md:1
+msgid "Vectors"
+msgstr ""
+
+#: src/SUMMARY.md:181 src/std/str.md:1
+msgid "Strings"
+msgstr ""
+
+#: src/SUMMARY.md:182 src/std/option.md:1
+msgid "`Option`"
+msgstr ""
+
+#: src/SUMMARY.md:184 src/std/result/question_mark.md:1
+msgid "`?`"
+msgstr ""
+
+#: src/SUMMARY.md:185 src/std/panic.md:1
+msgid "`panic!`"
+msgstr ""
+
+#: src/SUMMARY.md:186 src/std/hash.md:1
+msgid "HashMap"
+msgstr ""
+
+#: src/SUMMARY.md:187 src/std/hash/alt_key_types.md:1
+msgid "Alternate/custom key types"
+msgstr ""
+
+#: src/SUMMARY.md:188 src/std/hash/hashset.md:1
+msgid "HashSet"
+msgstr ""
+
+#: src/SUMMARY.md:189 src/std/rc.md:1
+msgid "`Rc`"
+msgstr ""
+
+#: src/SUMMARY.md:190
+msgid "`Arc`"
+msgstr ""
+
+#: src/SUMMARY.md:192 src/std_misc.md:1
+msgid "Std misc"
+msgstr ""
+
+#: src/SUMMARY.md:193 src/std_misc.md:6 src/std_misc/threads.md:1
+msgid "Threads"
+msgstr ""
+
+#: src/SUMMARY.md:194 src/std_misc/threads/testcase_mapreduce.md:1
+msgid "Testcase: map-reduce"
+msgstr ""
+
+#: src/SUMMARY.md:195 src/std_misc.md:7 src/std_misc/channels.md:1
+msgid "Channels"
+msgstr ""
+
+#: src/SUMMARY.md:196 src/std_misc/path.md:1
+msgid "Path"
+msgstr ""
+
+#: src/SUMMARY.md:197 src/std_misc.md:8 src/std_misc/file.md:1
+msgid "File I/O"
+msgstr ""
+
+#: src/SUMMARY.md:198 src/std_misc/file/open.md:1
+msgid "`open`"
+msgstr ""
+
+#: src/SUMMARY.md:199 src/std_misc/file/create.md:1
+msgid "`create`"
+msgstr ""
+
+#: src/SUMMARY.md:200 src/std_misc/file/read_lines.md:1
+msgid "`read_lines`"
+msgstr ""
+
+#: src/SUMMARY.md:201 src/std_misc/process.md:1
+msgid "Child processes"
+msgstr ""
+
+#: src/SUMMARY.md:202 src/std_misc/process/pipe.md:1
+msgid "Pipes"
+msgstr ""
+
+#: src/SUMMARY.md:203 src/std_misc/process/wait.md:1
+msgid "Wait"
+msgstr ""
+
+#: src/SUMMARY.md:204 src/std_misc/fs.md:1
+msgid "Filesystem Operations"
+msgstr ""
+
+#: src/SUMMARY.md:205 src/std_misc/arg.md:1
+msgid "Program arguments"
+msgstr ""
+
+#: src/SUMMARY.md:206 src/std_misc/arg/matching.md:1
+msgid "Argument parsing"
+msgstr ""
+
+#: src/SUMMARY.md:207 src/std_misc/ffi.md:1
+msgid "Foreign Function Interface"
+msgstr ""
+
+#: src/SUMMARY.md:209 src/cargo/test.md:1 src/testing.md:1
+msgid "Testing"
+msgstr ""
+
+#: src/SUMMARY.md:210 src/testing/unit_testing.md:1
+msgid "Unit testing"
+msgstr ""
+
+#: src/SUMMARY.md:211 src/testing/doc_testing.md:1
+msgid "Documentation testing"
+msgstr ""
+
+#: src/SUMMARY.md:212 src/testing/integration_testing.md:1
+msgid "Integration testing"
+msgstr ""
+
+#: src/SUMMARY.md:213
+msgid "Dev-dependencies"
+msgstr ""
+
+#: src/SUMMARY.md:215 src/unsafe.md:1
+msgid "Unsafe Operations"
+msgstr ""
+
+#: src/SUMMARY.md:216 src/unsafe/asm.md:1
+msgid "Inline assembly"
+msgstr ""
+
+#: src/SUMMARY.md:218 src/compatibility.md:1
+msgid "Compatibility"
+msgstr ""
+
+#: src/SUMMARY.md:219 src/compatibility/raw_identifiers.md:1
+msgid "Raw identifiers"
+msgstr ""
+
+#: src/SUMMARY.md:221 src/meta.md:1
+msgid "Meta"
+msgstr ""
+
+#: src/SUMMARY.md:222 src/meta/doc.md:1
+msgid "Documentation"
+msgstr ""
+
+#: src/SUMMARY.md:223 src/meta/playground.md:1
+msgid "Playground"
+msgstr ""
+
+#: src/index.md:1
+msgid "Rust by Example"
+msgstr ""
+
+#: src/index.md:3
+msgid ""
+"[Rust](https://www.rust-lang.org/) is a modern systems programming language "
+"focusing on safety, speed, and concurrency. It accomplishes these goals by "
+"being memory safe without using garbage collection."
+msgstr ""
+
+#: src/index.md:7
+msgid ""
+"Rust by Example (RBE) is a collection of runnable examples that illustrate "
+"various Rust concepts and standard libraries. To get even more out of these "
+"examples, don't forget to [install Rust locally](https://www.rust-lang.org/"
+"tools/install) and check out the [official docs](https://doc.rust-lang.org/"
+"std/). Additionally for the curious, you can also [check out the source code "
+"for this site](https://github.com/rust-lang/rust-by-example)."
+msgstr ""
+
+#: src/index.md:12
+msgid "Now let's begin!"
+msgstr ""
+
+#: src/index.md:14
+msgid "[Hello World](hello.md) - Start with a traditional Hello World program."
+msgstr ""
+
+#: src/index.md:16
+msgid ""
+"[Primitives](primitives.md) - Learn about signed integers, unsigned integers "
+"and other primitives."
+msgstr ""
+
+#: src/index.md:18
+msgid "[Custom Types](custom_types.md) - `struct` and `enum`."
+msgstr ""
+
+#: src/index.md:20
+msgid ""
+"[Variable Bindings](variable_bindings.md) - mutable bindings, scope, "
+"shadowing."
+msgstr ""
+
+#: src/index.md:22
+msgid "[Types](types.md) - Learn about changing and defining types."
+msgstr ""
+
+#: src/index.md:24
+msgid ""
+"[Conversion](conversion.md) - Convert between different types, such as "
+"strings, integers, and floats."
+msgstr ""
+
+#: src/index.md:26
+msgid ""
+"[Expressions](expression.md) - Learn about Expressions & how to use them."
+msgstr ""
+
+#: src/index.md:28
+msgid "[Flow of Control](flow_control.md) - `if`/`else`, `for`, and others."
+msgstr ""
+
+#: src/index.md:30
+msgid ""
+"[Functions](fn.md) - Learn about Methods, Closures and Higher Order Functions."
+msgstr ""
+
+#: src/index.md:32
+msgid "[Modules](mod.md) - Organize code using modules"
+msgstr ""
+
+#: src/index.md:34
+msgid ""
+"[Crates](crates.md) - A crate is a compilation unit in Rust. Learn to create "
+"a library."
+msgstr ""
+
+#: src/index.md:36
+msgid ""
+"[Cargo](cargo.md) - Go through some basic features of the official Rust "
+"package management tool."
+msgstr ""
+
+#: src/index.md:38
+msgid ""
+"[Attributes](attribute.md) - An attribute is metadata applied to some module, "
+"crate or item."
+msgstr ""
+
+#: src/index.md:40
+msgid ""
+"[Generics](generics.md) - Learn about writing a function or data type which "
+"can work for multiple types of arguments."
+msgstr ""
+
+#: src/index.md:42
+msgid ""
+"[Scoping rules](scope.md) - Scopes play an important part in ownership, "
+"borrowing, and lifetimes."
+msgstr ""
+
+#: src/index.md:44
+msgid ""
+"[Traits](trait.md) - A trait is a collection of methods defined for an "
+"unknown type: `Self`"
+msgstr ""
+
+#: src/index.md:46
+msgid ""
+"[Macros](macros.md) - Macros are a way of writing code that writes other "
+"code, which is known as metaprogramming."
+msgstr ""
+
+#: src/index.md:48
+msgid "[Error handling](error.md) - Learn Rust way of handling failures."
+msgstr ""
+
+#: src/index.md:50
+msgid ""
+"[Std library types](std.md) - Learn about some custom types provided by `std` "
+"library."
+msgstr ""
+
+#: src/index.md:52
+msgid "[Std misc](std_misc.md) - More custom types for file handling, threads."
+msgstr ""
+
+#: src/index.md:54
+msgid "[Testing](testing.md) - All sorts of testing in Rust."
+msgstr ""
+
+#: src/index.md:56
+msgid ""
+"[Unsafe Operations](unsafe.md) - Learn about entering a block of unsafe "
+"operations."
+msgstr ""
+
+#: src/index.md:58
+msgid ""
+"[Compatibility](compatibility.md) - Handling Rust's evolution and potential "
+"compatibility issues."
+msgstr ""
+
+#: src/index.md:60
+msgid "[Meta](meta.md) - Documentation, Benchmarking."
+msgstr ""
+
+#: src/hello.md:3
+msgid "This is the source code of the traditional Hello World program."
+msgstr ""
+
+#: src/hello.md:6
+msgid ""
+"// This is a comment, and is ignored by the compiler.\n"
+"// You can test this code by clicking the \"Run\" button over there ->\n"
+"// or if you prefer to use your keyboard, you can use the \"Ctrl + Enter\"\n"
+"// shortcut.\n"
+msgstr ""
+
+#: src/hello.md:10
+msgid ""
+"// This code is editable, feel free to hack it!\n"
+"// You can always return to the original code by clicking the \"Reset\" "
+"button ->\n"
+msgstr ""
+
+#: src/hello.md:13
+msgid "// This is the main function.\n"
+msgstr ""
+
+#: src/hello.md:16
+msgid "// Statements here are executed when the compiled binary is called.\n"
+msgstr ""
+
+#: src/hello.md:18
+msgid "// Print text to the console.\n"
+msgstr ""
+
+#: src/hello.md:19 src/error/result.md:55 src/meta/playground.md:12
+msgid "\"Hello World!\""
+msgstr ""
+
+#: src/hello.md:23
+msgid "`println!` is a [_macro_](macros.md) that prints text to the console."
+msgstr ""
+
+#: src/hello.md:26
+msgid "A binary can be generated using the Rust compiler: `rustc`."
+msgstr ""
+
+#: src/hello.md:32
+msgid "`rustc` will produce a `hello` binary that can be executed."
+msgstr ""
+
+#: src/hello.md:39 src/hello/print/print_display.md:107
+#: src/hello/print/print_display/testcase_list.md:53 src/hello/print/fmt.md:70
+#: src/primitives/tuples.md:64 src/custom_types/structs.md:89
+msgid "Activity"
+msgstr ""
+
+#: src/hello.md:41
+msgid ""
+"Click 'Run' above to see the expected output. Next, add a new line with a "
+"second `println!` macro so that the output shows:"
+msgstr ""
+
+#: src/hello/comment.md:3
+msgid ""
+"Any program requires comments, and Rust supports a few different varieties:"
+msgstr ""
+
+#: src/hello/comment.md:6
+msgid "_Regular comments_ which are ignored by the compiler:"
+msgstr ""
+
+#: src/hello/comment.md:7
+msgid "`// Line comments which go to the end of the line.`"
+msgstr ""
+
+#: src/hello/comment.md:8
+msgid "`/* Block comments which go to the closing delimiter. */`"
+msgstr ""
+
+#: src/hello/comment.md:9
+msgid ""
+"_Doc comments_ which are parsed into HTML library [documentation](../meta/doc."
+"md):"
+msgstr ""
+
+#: src/hello/comment.md:10
+msgid "`/// Generate library docs for the following item.`"
+msgstr ""
+
+#: src/hello/comment.md:11
+msgid "`//! Generate library docs for the enclosing item.`"
+msgstr ""
+
+#: src/hello/comment.md:15
+msgid ""
+"// This is an example of a line comment.\n"
+"    // There are two slashes at the beginning of the line.\n"
+"    // And nothing written after these will be read by the compiler.\n"
+msgstr ""
+
+#: src/hello/comment.md:19
+msgid "// println!(\"Hello, world!\");\n"
+msgstr ""
+
+#: src/hello/comment.md:21
+msgid "// Run it. See? Now try deleting the two slashes, and run it again.\n"
+msgstr ""
+
+#: src/hello/comment.md:23
+msgid ""
+"/*\n"
+"     * This is another type of comment, a block comment. In general,\n"
+"     * line comments are the recommended comment style. But block comments\n"
+"     * are extremely useful for temporarily disabling chunks of code.\n"
+"     * /* Block comments can be /* nested, */ */ so it takes only a few\n"
+"     * keystrokes to comment out everything in this main() function.\n"
+"     * /*/*/* Try it yourself! */*/*/\n"
+"     */"
+msgstr ""
+
+#: src/hello/comment.md:32
+msgid ""
+"/*\n"
+"    Note: The previous column of `*` was entirely for style. There's\n"
+"    no actual need for it.\n"
+"    */"
+msgstr ""
+
+#: src/hello/comment.md:37
+msgid ""
+"// You can manipulate expressions more easily with block comments\n"
+"    // than with line comments. Try deleting the comment delimiters\n"
+"    // to change the result:\n"
+msgstr ""
+
+#: src/hello/comment.md:40
+msgid "/* 90 + */"
+msgstr ""
+
+#: src/hello/comment.md:41
+msgid "\"Is `x` 10 or 100? x = {}\""
+msgstr ""
+
+#: src/hello/comment.md:45 src/hello/print.md:103
+#: src/hello/print/print_debug.md:75 src/hello/print/print_display.md:118
+#: src/hello/print/print_display/testcase_list.md:62 src/hello/print/fmt.md:89
+#: src/primitives.md:55 src/custom_types/enum.md:100
+#: src/custom_types/enum/enum_use.md:45 src/custom_types/enum/c_like.md:33
+#: src/custom_types/enum/testcase_linked_list.md:77
+#: src/custom_types/constants.md:35 src/types/alias.md:30
+#: src/flow_control/for.md:121
+#: src/flow_control/match/destructuring/destructure_tuple.md:25
+#: src/flow_control/match/destructuring/destructure_slice.md:46
+#: src/flow_control/match/destructuring/destructure_enum.md:48
+#: src/flow_control/match/destructuring/destructure_pointers.md:63
+#: src/flow_control/match/destructuring/destructure_structures.md:45
+#: src/flow_control/match/guard.md:43 src/flow_control/match/binding.md:49
+#: src/flow_control/if_let.md:118 src/flow_control/let_else.md:57
+#: src/flow_control/while_let.md:56 src/fn/closures/capture.md:110
+#: src/fn/closures/input_parameters.md:84 src/fn/closures/anonymity.md:47
+#: src/fn/closures/input_functions.md:32 src/fn/closures/output_parameters.md:49
+#: src/fn/closures/closure_examples/iter_any.md:50
+#: src/fn/closures/closure_examples/iter_find.md:68
+#: src/mod/struct_visibility.md:53 src/attribute/cfg.md:39 src/generics.md:59
+#: src/generics/gen_fn.md:54 src/generics/impl.md:48
+#: src/generics/gen_trait.md:39 src/generics/bounds.md:73
+#: src/generics/bounds/testcase_empty.md:37 src/generics/multi_bounds.md:32
+#: src/generics/where.md:49 src/generics/new_types.md:54
+#: src/generics/assoc_items.md:10 src/generics/assoc_items/the_problem.md:62
+#: src/generics/phantom.md:56 src/generics/phantom/testcase_units.md:75
+#: src/scope/raii.md:92 src/scope/move/partial_move.md:45
+#: src/scope/borrow/mut.md:56 src/scope/lifetime/explicit.md:68
+#: src/scope/lifetime/fn.md:58 src/scope/lifetime/methods.md:24
+#: src/scope/lifetime/struct.md:41 src/scope/lifetime/trait.md:28
+#: src/scope/lifetime/lifetime_bounds.md:46
+#: src/scope/lifetime/static_lifetime.md:131 src/scope/lifetime/elision.md:39
+#: src/trait/derive.md:64 src/trait/supertraits.md:40
+#: src/trait/disambiguating.md:60 src/error/option_unwrap/map.md:79
+#: src/error/option_unwrap/and_then.md:73
+#: src/error/option_unwrap/defaults.md:113 src/error/result/result_alias.md:41
+#: src/error/multiple_error_types/boxing_errors.md:57
+#: src/error/multiple_error_types/reenter_question_mark.md:74
+#: src/error/multiple_error_types/wrap_error.md:91 src/std.md:12
+#: src/std/rc.md:49 src/std_misc.md:12
+#: src/std_misc/threads/testcase_mapreduce.md:128 src/std_misc/path.md:54
+#: src/std_misc/fs.md:150 src/meta/doc.md:109 src/meta/playground.md:49
+msgid "See also:"
+msgstr ""
+
+#: src/hello/comment.md:47
+msgid "[Library documentation](../meta/doc.md)"
+msgstr ""
+
+#: src/hello/print.md:3
+msgid ""
+"Printing is handled by a series of [`macros`](../macros.md) defined in [`std::"
+"fmt`](https://doc.rust-lang.org/std/fmt/) some of which are:"
+msgstr ""
+
+#: src/hello/print.md:6
+msgid "`format!`: write formatted text to [`String`](../std/str.md)"
+msgstr ""
+
+#: src/hello/print.md:7
+msgid ""
+"`print!`: same as `format!` but the text is printed to the console (io::"
+"stdout)."
+msgstr ""
+
+#: src/hello/print.md:9
+msgid "`println!`: same as `print!` but a newline is appended."
+msgstr ""
+
+#: src/hello/print.md:10
+msgid ""
+"`eprint!`: same as `print!` but the text is printed to the standard error "
+"(io::stderr)."
+msgstr ""
+
+#: src/hello/print.md:12
+msgid "`eprintln!`: same as `eprint!` but a newline is appended."
+msgstr ""
+
+#: src/hello/print.md:14
+msgid ""
+"All parse text in the same fashion. As a plus, Rust checks formatting "
+"correctness at compile time."
+msgstr ""
+
+#: src/hello/print.md:19
+msgid ""
+"// In general, the `{}` will be automatically replaced with any\n"
+"    // arguments. These will be stringified.\n"
+msgstr ""
+
+#: src/hello/print.md:21
+msgid "\"{} days\""
+msgstr ""
+
+#: src/hello/print.md:23
+msgid ""
+"// Positional arguments can be used. Specifying an integer inside `{}`\n"
+"    // determines which additional argument will be replaced. Arguments "
+"start\n"
+"    // at 0 immediately after the format string.\n"
+msgstr ""
+
+#: src/hello/print.md:26
+msgid "\"{0}, this is {1}. {1}, this is {0}\""
+msgstr ""
+
+#: src/hello/print.md:26 src/scope/move/partial_move.md:20
+msgid "\"Alice\""
+msgstr ""
+
+#: src/hello/print.md:26 src/flow_control/for.md:65 src/flow_control/for.md:85
+#: src/flow_control/for.md:104
+msgid "\"Bob\""
+msgstr ""
+
+#: src/hello/print.md:28
+msgid "// As can named arguments.\n"
+msgstr ""
+
+#: src/hello/print.md:29
+msgid "\"{subject} {verb} {object}\""
+msgstr ""
+
+#: src/hello/print.md:30
+msgid "\"the lazy dog\""
+msgstr ""
+
+#: src/hello/print.md:31
+msgid "\"the quick brown fox\""
+msgstr ""
+
+#: src/hello/print.md:32
+msgid "\"jumps over\""
+msgstr ""
+
+#: src/hello/print.md:34
+msgid ""
+"// Different formatting can be invoked by specifying the format character\n"
+"    // after a `:`.\n"
+msgstr ""
+
+#: src/hello/print.md:36
+msgid "\"Base 10:               {}\""
+msgstr ""
+
+#: src/hello/print.md:36
+msgid "// 69420\n"
+msgstr ""
+
+#: src/hello/print.md:37
+msgid "\"Base 2 (binary):       {:b}\""
+msgstr ""
+
+#: src/hello/print.md:37
+msgid "// 10000111100101100\n"
+msgstr ""
+
+#: src/hello/print.md:38
+msgid "\"Base 8 (octal):        {:o}\""
+msgstr ""
+
+#: src/hello/print.md:38
+msgid "// 207454\n"
+msgstr ""
+
+#: src/hello/print.md:39
+msgid "\"Base 16 (hexadecimal): {:x}\""
+msgstr ""
+
+#: src/hello/print.md:39
+msgid "// 10f2c\n"
+msgstr ""
+
+#: src/hello/print.md:41
+msgid ""
+"// You can right-justify text with a specified width. This will\n"
+"    // output \"    1\". (Four white spaces and a \"1\", for a total width of "
+"5.)\n"
+msgstr ""
+
+#: src/hello/print.md:43
+msgid "\"{number:>5}\""
+msgstr ""
+
+#: src/hello/print.md:45
+msgid "// You can pad numbers with extra zeroes,\n"
+msgstr ""
+
+#: src/hello/print.md:46
+msgid "\"{number:0>5}\""
+msgstr ""
+
+#: src/hello/print.md:46
+msgid ""
+"// 00001\n"
+"    // and left-adjust by flipping the sign. This will output \"10000\".\n"
+msgstr ""
+
+#: src/hello/print.md:48
+msgid "\"{number:0<5}\""
+msgstr ""
+
+#: src/hello/print.md:48
+msgid "// 10000\n"
+msgstr ""
+
+#: src/hello/print.md:50
+msgid ""
+"// You can use named arguments in the format specifier by appending a `$`.\n"
+msgstr ""
+
+#: src/hello/print.md:51
+msgid "\"{number:0>width$}\""
+msgstr ""
+
+#: src/hello/print.md:53
+msgid ""
+"// Rust even checks to make sure the correct number of arguments are used.\n"
+msgstr ""
+
+#: src/hello/print.md:54
+msgid "\"My name is {0}, {1} {0}\""
+msgstr ""
+
+#: src/hello/print.md:54
+msgid "\"Bond\""
+msgstr ""
+
+#: src/hello/print.md:55
+msgid "// FIXME ^ Add the missing argument: \"James\"\n"
+msgstr ""
+
+#: src/hello/print.md:57
+msgid ""
+"// Only types that implement fmt::Display can be formatted with `{}`. User-\n"
+"    // defined types do not implement fmt::Display by default.\n"
+msgstr ""
+
+#: src/hello/print.md:60
+msgid "// disable `dead_code` which warn against unused module\n"
+msgstr ""
+
+#: src/hello/print.md:63
+msgid ""
+"// This will not compile because `Structure` does not implement\n"
+"    // fmt::Display.\n"
+"    // println!(\"This struct `{}` won't print...\", Structure(3));\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/hello/print.md:68
+msgid ""
+"// For Rust 1.58 and above, you can directly capture the argument from a\n"
+"    // surrounding variable. Just like the above, this will output\n"
+"    // \"    1\", 4 white spaces and a \"1\".\n"
+msgstr ""
+
+#: src/hello/print.md:73
+msgid "\"{number:>width$}\""
+msgstr ""
+
+#: src/hello/print.md:77
+msgid ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) contains many [`traits`]"
+"(https://doc.rust-lang.org/std/fmt/#formatting-traits) which govern the "
+"display of text. The base form of two important ones are listed below:"
+msgstr ""
+
+#: src/hello/print.md:80
+msgid ""
+"`fmt::Debug`: Uses the `{:?}` marker. Format text for debugging purposes."
+msgstr ""
+
+#: src/hello/print.md:81
+msgid ""
+"`fmt::Display`: Uses the `{}` marker. Format text in a more elegant, user "
+"friendly fashion."
+msgstr ""
+
+#: src/hello/print.md:84
+msgid ""
+"Here, we used `fmt::Display` because the std library provides implementations "
+"for these types. To print text for custom types, more steps are required."
+msgstr ""
+
+#: src/hello/print.md:87
+msgid ""
+"Implementing the `fmt::Display` trait automatically implements the "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait "
+"which allows us to [convert](../conversion/string.md) the type to [`String`]"
+"(../std/str.md)."
+msgstr ""
+
+#: src/hello/print.md:90
+msgid ""
+"In _line 43_, `#[allow(dead_code)]` is an [attribute](../attribute.md) which "
+"only applies to the module after it."
+msgstr ""
+
+#: src/hello/print.md:92
+msgid "Activities"
+msgstr ""
+
+#: src/hello/print.md:94
+msgid ""
+"Fix the issue in the above code (see FIXME) so that it runs without error."
+msgstr ""
+
+#: src/hello/print.md:96
+msgid ""
+"Try uncommenting the line that attempts to format the `Structure` struct (see "
+"TODO)"
+msgstr ""
+
+#: src/hello/print.md:98
+msgid ""
+"Add a `println!` macro call that prints: `Pi is roughly 3.142` by controlling "
+"the number of decimal places shown. For the purposes of this exercise, use "
+"`let pi = 3.141592` as an estimate for pi. (Hint: you may need to check the "
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) documentation for setting "
+"the number of decimals to display)"
+msgstr ""
+
+#: src/hello/print.md:105
+msgid ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/), [`macros`](../macros.md), "
+"[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/"
+"std/fmt/#formatting-traits), and [`dead_code`](../attribute/unused.md)"
+msgstr ""
+
+#: src/hello/print/print_debug.md:3
+msgid ""
+"All types which want to use `std::fmt` formatting `traits` require an "
+"implementation to be printable. Automatic implementations are only provided "
+"for types such as in the `std` library. All others _must_ be manually "
+"implemented somehow."
+msgstr ""
+
+#: src/hello/print/print_debug.md:8
+msgid ""
+"The `fmt::Debug` `trait` makes this very straightforward. _All_ types can "
+"`derive` (automatically create) the `fmt::Debug` implementation. This is not "
+"true for `fmt::Display` which must be manually implemented."
+msgstr ""
+
+#: src/hello/print/print_debug.md:13
+msgid ""
+"// This structure cannot be printed either with `fmt::Display` or\n"
+"// with `fmt::Debug`.\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:16
+msgid ""
+"// The `derive` attribute automatically creates the implementation\n"
+"// required to make this `struct` printable with `fmt::Debug`.\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:23
+msgid "All `std` library types are automatically printable with `{:?}` too:"
+msgstr ""
+
+#: src/hello/print/print_debug.md:26
+msgid ""
+"// Derive the `fmt::Debug` implementation for `Structure`. `Structure`\n"
+"// is a structure which contains a single `i32`.\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:30
+msgid ""
+"// Put a `Structure` inside of the structure `Deep`. Make it printable\n"
+"// also.\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:37
+msgid "// Printing with `{:?}` is similar to with `{}`.\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:38
+msgid "\"{:?} months in a year.\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:39
+msgid "\"{1:?} {0:?} is the {actor:?} name.\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:40
+msgid "\"Slater\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:41
+msgid "\"Christian\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:42
+msgid "\"actor's\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:44
+msgid "// `Structure` is printable!\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:45 src/hello/print/print_debug.md:49
+msgid "\"Now {:?} will print!\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:47
+msgid ""
+"// The problem with `derive` is there is no control over how\n"
+"    // the results look. What if I want this to just show a `7`?\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:53
+msgid ""
+"So `fmt::Debug` definitely makes this printable but sacrifices some elegance. "
+"Rust also provides \"pretty printing\" with `{:#?}`."
+msgstr ""
+
+#: src/hello/print/print_debug.md:64 src/custom_types/structs.md:42
+msgid "\"Peter\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:68
+msgid "// Pretty print\n"
+msgstr ""
+
+#: src/hello/print/print_debug.md:69
+msgid "\"{:#?}\""
+msgstr ""
+
+#: src/hello/print/print_debug.md:73
+msgid "One can manually implement `fmt::Display` to control the display."
+msgstr ""
+
+#: src/hello/print/print_debug.md:77
+msgid ""
+"[`attributes`](https://doc.rust-lang.org/reference/attributes.html), "
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/std/"
+"fmt/), and [`struct`](../../custom_types/structs.md)"
+msgstr ""
+
+#: src/hello/print/print_display.md:3
+msgid ""
+"`fmt::Debug` hardly looks compact and clean, so it is often advantageous to "
+"customize the output appearance. This is done by manually implementing [`fmt::"
+"Display`](https://doc.rust-lang.org/std/fmt/), which uses the `{}` print "
+"marker. Implementing it looks like this:"
+msgstr ""
+
+#: src/hello/print/print_display.md:9
+msgid "// Import (via `use`) the `fmt` module to make it available.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:11
+msgid ""
+"// Define a structure for which `fmt::Display` will be implemented. This is\n"
+"// a tuple struct named `Structure` that contains an `i32`.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:15
+msgid ""
+"// To use the `{}` marker, the trait `fmt::Display` must be implemented\n"
+"// manually for the type.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:19
+msgid "// This trait requires `fmt` with this exact signature.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:21
+msgid ""
+"// Write strictly the first element into the supplied output\n"
+"        // stream: `f`. Returns `fmt::Result` which indicates whether the\n"
+"        // operation succeeded or failed. Note that `write!` uses syntax "
+"which\n"
+"        // is very similar to `println!`.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:25
+#: src/hello/print/print_display/testcase_list.md:13
+#: src/hello/print/print_display/testcase_list.md:39
+#: src/hello/print/print_display/testcase_list.md:49 src/hello/print/fmt.md:53
+#: src/custom_types/enum/testcase_linked_list.md:73 src/conversion/string.md:25
+#: src/flow_control/loop.md:26 src/flow_control/while.md:21
+#: src/flow_control/for.md:23 src/flow_control/for.md:43 src/fn.md:40
+#: src/fn/closures/capture.md:96 src/fn/closures/capture.md:97
+#: src/fn/closures/anonymity.md:41 src/generics/bounds.md:12
+#: src/macros/repeat.md:24 src/macros/repeat.md:25 src/macros/repeat.md:26
+#: src/error/result.md:73 src/std/str.md:92 src/std/str.md:102
+#: src/std/str.md:106 src/std/str.md:111 src/std/result.md:72
+#: src/std/result/question_mark.md:57 src/std/result/question_mark.md:65
+#: src/std_misc/file/read_lines.md:60 src/std_misc/arg/matching.md:9
+#: src/std_misc/arg/matching.md:13
+msgid "\"{}\""
+msgstr ""
+
+#: src/hello/print/print_display.md:30
+msgid ""
+"`fmt::Display` may be cleaner than `fmt::Debug` but this presents a problem "
+"for the `std` library. How should ambiguous types be displayed? For example, "
+"if the `std` library implemented a single style for all `Vec<T>`, what style "
+"should it be? Would it be either of these two?"
+msgstr ""
+
+#: src/hello/print/print_display.md:35
+msgid "`Vec<path>`: `/:/etc:/home/username:/bin` (split on `:`)"
+msgstr ""
+
+#: src/hello/print/print_display.md:36
+msgid "`Vec<number>`: `1,2,3` (split on `,`)"
+msgstr ""
+
+#: src/hello/print/print_display.md:38
+msgid ""
+"No, because there is no ideal style for all types and the `std` library "
+"doesn't presume to dictate one. `fmt::Display` is not implemented for "
+"`Vec<T>` or for any other generic containers. `fmt::Debug` must then be used "
+"for these generic cases."
+msgstr ""
+
+#: src/hello/print/print_display.md:43
+msgid ""
+"This is not a problem though because for any new _container_ type which is "
+"_not_ generic, `fmt::Display` can be implemented."
+msgstr ""
+
+#: src/hello/print/print_display.md:47
+msgid "// Import `fmt`\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:48
+msgid ""
+"// A structure holding two numbers. `Debug` will be derived so the results "
+"can\n"
+"// be contrasted with `Display`.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:53
+msgid "// Implement `Display` for `MinMax`.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:57
+msgid "// Use `self.number` to refer to each positional data point.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:58
+msgid "\"({}, {})\""
+msgstr ""
+
+#: src/hello/print/print_display.md:61
+msgid "// Define a structure where the fields are nameable for comparison.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:68
+msgid "// Similarly, implement `Display` for `Point2D`.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:72
+msgid "// Customize so only `x` and `y` are denoted.\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:73
+msgid "\"x: {}, y: {}\""
+msgstr ""
+
+#: src/hello/print/print_display.md:80
+msgid "\"Compare structures:\""
+msgstr ""
+
+#: src/hello/print/print_display.md:81 src/hello/print/print_display.md:94
+msgid "\"Display: {}\""
+msgstr ""
+
+#: src/hello/print/print_display.md:82 src/hello/print/print_display.md:95
+msgid "\"Debug: {:?}\""
+msgstr ""
+
+#: src/hello/print/print_display.md:87
+msgid "\"The big range is {big} and the small is {small}\""
+msgstr ""
+
+#: src/hello/print/print_display.md:93
+msgid "\"Compare points:\""
+msgstr ""
+
+#: src/hello/print/print_display.md:97
+msgid ""
+"// Error. Both `Debug` and `Display` were implemented, but `{:b}`\n"
+"    // requires `fmt::Binary` to be implemented. This will not work.\n"
+"    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
+msgstr ""
+
+#: src/hello/print/print_display.md:103
+msgid ""
+"So, `fmt::Display` has been implemented but `fmt::Binary` has not, and "
+"therefore cannot be used. `std::fmt` has many such [`traits`](https://doc."
+"rust-lang.org/std/fmt/#formatting-traits) and each requires its own "
+"implementation. This is detailed further in [`std::fmt`](https://doc.rust-"
+"lang.org/std/fmt/)."
+msgstr ""
+
+#: src/hello/print/print_display.md:109
+msgid ""
+"After checking the output of the above example, use the `Point2D` struct as a "
+"guide to add a `Complex` struct to the example. When printed in the same way, "
+"the output should be:"
+msgstr ""
+
+#: src/hello/print/print_display.md:120
+msgid ""
+"[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/std/"
+"fmt/), [`macros`](../../macros.md), [`struct`](../../custom_types/structs."
+"md), [`trait`](https://doc.rust-lang.org/std/fmt/#formatting-traits), and "
+"[`use`](../../mod/use.md)"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:3
+msgid ""
+"Implementing `fmt::Display` for a structure where the elements must each be "
+"handled sequentially is tricky. The problem is that each `write!` generates a "
+"`fmt::Result`. Proper handling of this requires dealing with _all_ the "
+"results. Rust provides the `?` operator for exactly this purpose."
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:8
+msgid "Using `?` on `write!` looks like this:"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:11
+msgid ""
+"// Try `write!` to see if it errors. If it errors, return\n"
+"// the error. Otherwise continue.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:16
+msgid ""
+"With `?` available, implementing `fmt::Display` for a `Vec` is "
+"straightforward:"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:20
+msgid "// Import the `fmt` module.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:21
+msgid "// Define a structure named `List` containing a `Vec`.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:27
+msgid ""
+"// Extract the value using tuple indexing,\n"
+"        // and create a reference to `vec`.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:31
+msgid "\"[\""
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:33
+msgid ""
+"// Iterate over `v` in `vec` while enumerating the iteration\n"
+"        // count in `count`.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:36
+msgid ""
+"// For every element except the first, add a comma.\n"
+"            // Use the ? operator to return on errors.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:38 src/std/str.md:36
+msgid "\", \""
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:42
+msgid "// Close the opened bracket and return a fmt::Result value.\n"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:43
+msgid "\"]\""
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:55
+msgid ""
+"Try changing the program so that the index of each element in the vector is "
+"also printed. The new output should look like this:"
+msgstr ""
+
+#: src/hello/print/print_display/testcase_list.md:64
+msgid ""
+"[`for`](../../../flow_control/for.md), [`ref`](../../../scope/borrow/ref.md), "
+"[`Result`](../../../std/result.md), [`struct`](../../../custom_types/structs."
+"md), [`?`](../../../std/result/question_mark.md), and [`vec!`](../../../std/"
+"vec.md)"
+msgstr ""
+
+#: src/hello/print/fmt.md:3
+msgid "We've seen that formatting is specified via a _format string_:"
+msgstr ""
+
+#: src/hello/print/fmt.md:5
+msgid "`format!(\"{}\", foo)` -> `\"3735928559\"`"
+msgstr ""
+
+#: src/hello/print/fmt.md:6
+msgid ""
+"`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/"
+"wiki/Deadbeef#Magic_debug_values)"
+msgstr ""
+
+#: src/hello/print/fmt.md:7
+msgid "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
+msgstr ""
+
+#: src/hello/print/fmt.md:9
+msgid ""
+"The same variable (`foo`) can be formatted differently depending on which "
+"_argument type_ is used: `X` vs `o` vs _unspecified_."
+msgstr ""
+
+#: src/hello/print/fmt.md:12
+msgid ""
+"This formatting functionality is implemented via traits, and there is one "
+"trait for each argument type. The most common formatting trait is `Display`, "
+"which handles cases where the argument type is left unspecified: `{}` for "
+"instance."
+msgstr ""
+
+#: src/hello/print/fmt.md:21
+msgid "// Latitude\n"
+msgstr ""
+
+#: src/hello/print/fmt.md:23
+msgid "// Longitude\n"
+msgstr ""
+
+#: src/hello/print/fmt.md:28
+msgid ""
+"// `f` is a buffer, and this method must write the formatted string into it.\n"
+msgstr ""
+
+#: src/hello/print/fmt.md:30
+msgid "'N'"
+msgstr ""
+
+#: src/hello/print/fmt.md:30
+msgid "'S'"
+msgstr ""
+
+#: src/hello/print/fmt.md:31
+msgid "'E'"
+msgstr ""
+
+#: src/hello/print/fmt.md:31
+msgid "'W'"
+msgstr ""
+
+#: src/hello/print/fmt.md:33
+msgid ""
+"// `write!` is like `format!`, but it will write the formatted string\n"
+"        // into a buffer (the first argument).\n"
+msgstr ""
+
+#: src/hello/print/fmt.md:35
+msgid "\"{}: {:.3}°{} {:.3}°{}\""
+msgstr ""
+
+#: src/hello/print/fmt.md:49
+msgid "\"Dublin\""
+msgstr ""
+
+#: src/hello/print/fmt.md:50
+msgid "\"Oslo\""
+msgstr ""
+
+#: src/hello/print/fmt.md:51
+msgid "\"Vancouver\""
+msgstr ""
+
+#: src/hello/print/fmt.md:60
+msgid ""
+"// Switch this to use {} once you've added an implementation\n"
+"        // for fmt::Display.\n"
+msgstr ""
+
+#: src/hello/print/fmt.md:62 src/primitives/tuples.md:60
+#: src/custom_types/structs.md:47 src/types/inference.md:23
+#: src/conversion/string.md:76 src/generics/bounds.md:49
+#: src/generics/where.md:38 src/std/str.md:137 src/std/result.md:59
+#: src/std/result.md:61 src/std/result.md:63 src/std/arc.md:26
+#: src/std_misc/channels.md:53
+msgid "\"{:?}\""
+msgstr ""
+
+#: src/hello/print/fmt.md:67
+msgid ""
+"You can view a [full list of formatting traits](https://doc.rust-lang.org/std/"
+"fmt/#formatting-traits) and their argument types in the [`std::fmt`](https://"
+"doc.rust-lang.org/std/fmt/) documentation."
+msgstr ""
+
+#: src/hello/print/fmt.md:72
+msgid ""
+"Add an implementation of the `fmt::Display` trait for the `Color` struct "
+"above so that the output displays as:"
+msgstr ""
+
+#: src/hello/print/fmt.md:81
+msgid "Three hints if you get stuck:"
+msgstr ""
+
+#: src/hello/print/fmt.md:83
+msgid ""
+"The formula for calculating a color in the RGB color space is: `RGB = "
+"(R*65536)+(G*256)+B , (when R is RED, G is GREEN and B is BLUE)`. For more "
+"see [RGB color format & calculation](https://www.rapidtables.com/web/color/"
+"RGB_Color.html#rgb-format)."
+msgstr ""
+
+#: src/hello/print/fmt.md:86
+msgid ""
+"You [may need to list each color more than once](https://doc.rust-lang.org/"
+"std/fmt/#named-parameters)."
+msgstr ""
+
+#: src/hello/print/fmt.md:87
+msgid ""
+"You can [pad with zeros to a width of 2](https://doc.rust-lang.org/std/fmt/"
+"#width) with `:0>2`."
+msgstr ""
+
+#: src/hello/print/fmt.md:91
+msgid "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
+msgstr ""
+
+#: src/primitives.md:3
+msgid ""
+"Rust provides access to a wide variety of `primitives`. A sample includes:"
+msgstr ""
+
+#: src/primitives.md:5
+msgid "Scalar Types"
+msgstr ""
+
+#: src/primitives.md:7
+msgid ""
+"Signed integers: `i8`, `i16`, `i32`, `i64`, `i128` and `isize` (pointer size)"
+msgstr ""
+
+#: src/primitives.md:8
+msgid ""
+"Unsigned integers: `u8`, `u16`, `u32`, `u64`, `u128` and `usize` (pointer "
+"size)"
+msgstr ""
+
+#: src/primitives.md:10
+msgid "Floating point: `f32`, `f64`"
+msgstr ""
+
+#: src/primitives.md:11
+msgid "`char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each)"
+msgstr ""
+
+#: src/primitives.md:12
+msgid "`bool` either `true` or `false`"
+msgstr ""
+
+#: src/primitives.md:13
+msgid "The unit type `()`, whose only possible value is an empty tuple: `()`"
+msgstr ""
+
+#: src/primitives.md:15
+msgid ""
+"Despite the value of a unit type being a tuple, it is not considered a "
+"compound type because it does not contain multiple values."
+msgstr ""
+
+#: src/primitives.md:18
+msgid "Compound Types"
+msgstr ""
+
+#: src/primitives.md:20
+msgid "Arrays like `[1, 2, 3]`"
+msgstr ""
+
+#: src/primitives.md:21
+msgid "Tuples like `(1, true)`"
+msgstr ""
+
+#: src/primitives.md:23
+msgid ""
+"Variables can always be _type annotated_. Numbers may additionally be "
+"annotated via a _suffix_ or _by default_. Integers default to `i32` and "
+"floats to `f64`. Note that Rust can also infer types from context."
+msgstr ""
+
+#: src/primitives.md:29
+msgid "// Variables can be type annotated.\n"
+msgstr ""
+
+#: src/primitives.md:32
+msgid "// Regular annotation\n"
+msgstr ""
+
+#: src/primitives.md:33
+msgid "// Suffix annotation\n"
+msgstr ""
+
+#: src/primitives.md:35
+msgid "// Or a default will be used.\n"
+msgstr ""
+
+#: src/primitives.md:36
+msgid "// `f64`\n"
+msgstr ""
+
+#: src/primitives.md:37
+msgid "// `i32`\n"
+msgstr ""
+
+#: src/primitives.md:39
+msgid "// A type can also be inferred from context.\n"
+msgstr ""
+
+#: src/primitives.md:40
+msgid "// Type i64 is inferred from another line.\n"
+msgstr ""
+
+#: src/primitives.md:43
+msgid "// A mutable variable's value can be changed.\n"
+msgstr ""
+
+#: src/primitives.md:44
+msgid "// Mutable `i32`\n"
+msgstr ""
+
+#: src/primitives.md:47
+msgid "// Error! The type of a variable can't be changed.\n"
+msgstr ""
+
+#: src/primitives.md:50
+msgid "// Variables can be overwritten with shadowing.\n"
+msgstr ""
+
+#: src/primitives.md:57
+msgid ""
+"[the `std` library](https://doc.rust-lang.org/std/), [`mut`]"
+"(variable_bindings/mut.md), [`inference`](types/inference.md), and "
+"[`shadowing`](variable_bindings/scope.md)"
+msgstr ""
+
+#: src/primitives/literals.md:3
+msgid ""
+"Integers `1`, floats `1.2`, characters `'a'`, strings `\"abc\"`, booleans "
+"`true` and the unit type `()` can be expressed using literals."
+msgstr ""
+
+#: src/primitives/literals.md:6
+msgid ""
+"Integers can, alternatively, be expressed using hexadecimal, octal or binary "
+"notation using these prefixes respectively: `0x`, `0o` or `0b`."
+msgstr ""
+
+#: src/primitives/literals.md:9
+msgid ""
+"Underscores can be inserted in numeric literals to improve readability, e.g. "
+"`1_000` is the same as `1000`, and `0.000_001` is the same as `0.000001`."
+msgstr ""
+
+#: src/primitives/literals.md:12
+msgid ""
+"Rust also supports scientific [E-notation](https://en.wikipedia.org/wiki/"
+"Scientific_notation#E_notation), e.g. `1e6`, `7.6e-4`. The associated type is "
+"`f64`."
+msgstr ""
+
+#: src/primitives/literals.md:15
+msgid ""
+"We need to tell the compiler the type of the literals we use. For now, we'll "
+"use the `u32` suffix to indicate that the literal is an unsigned 32-bit "
+"integer, and the `i32` suffix to indicate that it's a signed 32-bit integer."
+msgstr ""
+
+#: src/primitives/literals.md:19
+msgid ""
+"The operators available and their precedence [in Rust](https://doc.rust-lang."
+"org/reference/expressions.html#expression-precedence) are similar to other [C-"
+"like languages](https://en.wikipedia.org/wiki/"
+"Operator_precedence#Programming_languages)."
+msgstr ""
+
+#: src/primitives/literals.md:24
+msgid "// Integer addition\n"
+msgstr ""
+
+#: src/primitives/literals.md:25
+msgid "\"1 + 2 = {}\""
+msgstr ""
+
+#: src/primitives/literals.md:27
+msgid "// Integer subtraction\n"
+msgstr ""
+
+#: src/primitives/literals.md:28
+msgid "\"1 - 2 = {}\""
+msgstr ""
+
+#: src/primitives/literals.md:29
+msgid ""
+"// TODO ^ Try changing `1i32` to `1u32` to see why the type is important\n"
+msgstr ""
+
+#: src/primitives/literals.md:31
+msgid "// Scientific notation\n"
+msgstr ""
+
+#: src/primitives/literals.md:32
+msgid "\"1e4 is {}, -2.5e-3 is {}\""
+msgstr ""
+
+#: src/primitives/literals.md:34
+msgid "// Short-circuiting boolean logic\n"
+msgstr ""
+
+#: src/primitives/literals.md:35
+msgid "\"true AND false is {}\""
+msgstr ""
+
+#: src/primitives/literals.md:36
+msgid "\"true OR false is {}\""
+msgstr ""
+
+#: src/primitives/literals.md:37
+msgid "\"NOT true is {}\""
+msgstr ""
+
+#: src/primitives/literals.md:39
+msgid "// Bitwise operations\n"
+msgstr ""
+
+#: src/primitives/literals.md:40
+msgid "\"0011 AND 0101 is {:04b}\""
+msgstr ""
+
+#: src/primitives/literals.md:41
+msgid "\"0011 OR 0101 is {:04b}\""
+msgstr ""
+
+#: src/primitives/literals.md:42
+msgid "\"0011 XOR 0101 is {:04b}\""
+msgstr ""
+
+#: src/primitives/literals.md:43
+msgid "\"1 << 5 is {}\""
+msgstr ""
+
+#: src/primitives/literals.md:44
+msgid "\"0x80 >> 2 is 0x{:x}\""
+msgstr ""
+
+#: src/primitives/literals.md:46
+msgid "// Use underscores to improve readability!\n"
+msgstr ""
+
+#: src/primitives/literals.md:47
+msgid "\"One million is written as {}\""
+msgstr ""
+
+#: src/primitives/tuples.md:3
+msgid ""
+"A tuple is a collection of values of different types. Tuples are constructed "
+"using parentheses `()`, and each tuple itself is a value with type signature "
+"`(T1, T2, ...)`, where `T1`, `T2` are the types of its members. Functions can "
+"use tuples to return multiple values, as tuples can hold any number of values."
+msgstr ""
+
+#: src/primitives/tuples.md:9
+msgid "// Tuples can be used as function arguments and as return values.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:11
+msgid "// `let` can be used to bind the members of a tuple to variables.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:16
+msgid "// The following struct is for the activity.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:22
+msgid "// A tuple with a bunch of different types.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:26 src/generics.md:50 src/generics.md:55
+#: src/generics/gen_fn.md:47
+msgid "'a'"
+msgstr ""
+
+#: src/primitives/tuples.md:28
+msgid "// Values can be extracted from the tuple using tuple indexing.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:29
+msgid "\"Long tuple first value: {}\""
+msgstr ""
+
+#: src/primitives/tuples.md:30
+msgid "\"Long tuple second value: {}\""
+msgstr ""
+
+#: src/primitives/tuples.md:32
+msgid "// Tuples can be tuple members.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:35
+msgid "// Tuples are printable.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:36
+msgid "\"tuple of tuples: {:?}\""
+msgstr ""
+
+#: src/primitives/tuples.md:38
+msgid ""
+"// But long Tuples (more than 12 elements) cannot be printed.\n"
+"    //let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
+"    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
+"    // TODO ^ Uncomment the above 2 lines to see the compiler error\n"
+msgstr ""
+
+#: src/primitives/tuples.md:44
+msgid "\"Pair is {:?}\""
+msgstr ""
+
+#: src/primitives/tuples.md:46
+msgid "\"The reversed pair is {:?}\""
+msgstr ""
+
+#: src/primitives/tuples.md:48
+msgid ""
+"// To create one element tuples, the comma is required to tell them apart\n"
+"    // from a literal surrounded by parentheses.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:50
+msgid "\"One element tuple: {:?}\""
+msgstr ""
+
+#: src/primitives/tuples.md:51
+msgid "\"Just an integer: {:?}\""
+msgstr ""
+
+#: src/primitives/tuples.md:53
+msgid "// Tuples can be destructured to create bindings.\n"
+msgstr ""
+
+#: src/primitives/tuples.md:54 src/conversion/from_into.md:17
+#: src/fn/closures/input_parameters.md:52 src/std_misc/fs.md:51
+msgid "\"hello\""
+msgstr ""
+
+#: src/primitives/tuples.md:57
+msgid "\"{:?}, {:?}, {:?}, {:?}\""
+msgstr ""
+
+#: src/primitives/tuples.md:66
+msgid ""
+"_Recap_: Add the `fmt::Display` trait to the `Matrix` struct in the above "
+"example, so that if you switch from printing the debug format `{:?}` to the "
+"display format `{}`, you see the following output:"
+msgstr ""
+
+#: src/primitives/tuples.md:75
+msgid ""
+"You may want to refer back to the example for [print display](../hello/print/"
+"print_display.md)."
+msgstr ""
+
+#: src/primitives/tuples.md:76
+msgid ""
+"Add a `transpose` function using the `reverse` function as a template, which "
+"accepts a matrix as an argument, and returns a matrix in which two elements "
+"have been swapped. For example:"
+msgstr ""
+
+#: src/primitives/tuples.md:81
+msgid "\"Matrix:\\n{}\""
+msgstr ""
+
+#: src/primitives/tuples.md:82
+msgid "\"Transpose:\\n{}\""
+msgstr ""
+
+#: src/primitives/tuples.md:85
+msgid "Results in the output:"
+msgstr ""
+
+#: src/primitives/array.md:3
+msgid ""
+"An array is a collection of objects of the same type `T`, stored in "
+"contiguous memory. Arrays are created using brackets `[]`, and their length, "
+"which is known at compile time, is part of their type signature `[T; length]`."
+msgstr ""
+
+#: src/primitives/array.md:7
+msgid ""
+"Slices are similar to arrays, but their length is not known at compile time. "
+"Instead, a slice is a two-word object; the first word is a pointer to the "
+"data, the second word is the length of the slice. The word size is the same "
+"as usize, determined by the processor architecture, e.g. 64 bits on an "
+"x86-64. Slices can be used to borrow a section of an array and have the type "
+"signature `&[T]`."
+msgstr ""
+
+#: src/primitives/array.md:15
+msgid "// This function borrows a slice.\n"
+msgstr ""
+
+#: src/primitives/array.md:18
+msgid "\"First element of the slice: {}\""
+msgstr ""
+
+#: src/primitives/array.md:19
+msgid "\"The slice has {} elements\""
+msgstr ""
+
+#: src/primitives/array.md:23
+msgid "// Fixed-size array (type signature is superfluous).\n"
+msgstr ""
+
+#: src/primitives/array.md:26
+msgid "// All elements can be initialized to the same value.\n"
+msgstr ""
+
+#: src/primitives/array.md:29
+msgid "// Indexing starts at 0.\n"
+msgstr ""
+
+#: src/primitives/array.md:30
+msgid "\"First element of the array: {}\""
+msgstr ""
+
+#: src/primitives/array.md:31
+msgid "\"Second element of the array: {}\""
+msgstr ""
+
+#: src/primitives/array.md:33
+msgid "// `len` returns the count of elements in the array.\n"
+msgstr ""
+
+#: src/primitives/array.md:34
+msgid "\"Number of elements in array: {}\""
+msgstr ""
+
+#: src/primitives/array.md:36
+msgid "// Arrays are stack allocated.\n"
+msgstr ""
+
+#: src/primitives/array.md:37
+msgid "\"Array occupies {} bytes\""
+msgstr ""
+
+#: src/primitives/array.md:39
+msgid "// Arrays can be automatically borrowed as slices.\n"
+msgstr ""
+
+#: src/primitives/array.md:40
+msgid "\"Borrow the whole array as a slice.\""
+msgstr ""
+
+#: src/primitives/array.md:43
+msgid ""
+"// Slices can point to a section of an array.\n"
+"    // They are of the form [starting_index..ending_index].\n"
+"    // `starting_index` is the first position in the slice.\n"
+"    // `ending_index` is one more than the last position in the slice.\n"
+msgstr ""
+
+#: src/primitives/array.md:47
+msgid "\"Borrow a section of the array as a slice.\""
+msgstr ""
+
+#: src/primitives/array.md:50
+msgid "// Example of empty slice `&[]`:\n"
+msgstr ""
+
+#: src/primitives/array.md:53
+msgid "// Same but more verbose\n"
+msgstr ""
+
+#: src/primitives/array.md:55
+msgid ""
+"// Arrays can be safely accessed using `.get`, which returns an\n"
+"    // `Option`. This can be matched as shown below, or used with\n"
+"    // `.expect()` if you would like the program to exit with a nice\n"
+"    // message instead of happily continue.\n"
+msgstr ""
+
+#: src/primitives/array.md:59
+msgid "// Oops, one element too far!\n"
+msgstr ""
+
+#: src/primitives/array.md:61
+msgid "\"{}: {}\""
+msgstr ""
+
+#: src/primitives/array.md:62
+msgid "\"Slow down! {} is too far!\""
+msgstr ""
+
+#: src/primitives/array.md:66
+msgid ""
+"// Out of bound indexing on array causes compile time error.\n"
+"    //println!(\"{}\", xs[5]);\n"
+"    // Out of bound indexing on slice causes runtime error.\n"
+"    //println!(\"{}\", xs[..][5]);\n"
+msgstr ""
+
+#: src/custom_types.md:3
+msgid "Rust custom data types are formed mainly through the two keywords:"
+msgstr ""
+
+#: src/custom_types.md:5
+msgid "`struct`: define a structure"
+msgstr ""
+
+#: src/custom_types.md:6
+msgid "`enum`: define an enumeration"
+msgstr ""
+
+#: src/custom_types.md:8
+msgid "Constants can also be created via the `const` and `static` keywords."
+msgstr ""
+
+#: src/custom_types/structs.md:3
+msgid ""
+"There are three types of structures (\"structs\") that can be created using "
+"the `struct` keyword:"
+msgstr ""
+
+#: src/custom_types/structs.md:6
+msgid "Tuple structs, which are, basically, named tuples."
+msgstr ""
+
+#: src/custom_types/structs.md:7
+msgid ""
+"The classic [C structs](https://en.wikipedia.org/wiki/"
+"Struct_(C_programming_language))"
+msgstr ""
+
+#: src/custom_types/structs.md:8
+msgid "Unit structs, which are field-less, are useful for generics."
+msgstr ""
+
+#: src/custom_types/structs.md:11 src/custom_types/enum/enum_use.md:6
+#: src/custom_types/enum/c_like.md:6
+msgid "// An attribute to hide warnings for unused code.\n"
+msgstr ""
+
+#: src/custom_types/structs.md:19
+msgid "// A unit struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:22
+msgid "// A tuple struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:25
+msgid "// A struct with two fields\n"
+msgstr ""
+
+#: src/custom_types/structs.md:31
+msgid "// Structs can be reused as fields of another struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:34
+msgid ""
+"// A rectangle can be specified by where the top left and bottom right\n"
+"    // corners are in space.\n"
+msgstr ""
+
+#: src/custom_types/structs.md:41
+msgid "// Create struct with field init shorthand\n"
+msgstr ""
+
+#: src/custom_types/structs.md:46
+msgid "// Print debug struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:49
+msgid "// Instantiate a `Point`\n"
+msgstr ""
+
+#: src/custom_types/structs.md:53
+msgid "// Access the fields of the point\n"
+msgstr ""
+
+#: src/custom_types/structs.md:54
+msgid "\"point coordinates: ({}, {})\""
+msgstr ""
+
+#: src/custom_types/structs.md:56
+msgid ""
+"// Make a new point by using struct update syntax to use the fields of our\n"
+"    // other one\n"
+msgstr ""
+
+#: src/custom_types/structs.md:60
+msgid ""
+"// `bottom_right.y` will be the same as `another_point.y` because we used "
+"that field\n"
+"    // from `another_point`\n"
+msgstr ""
+
+#: src/custom_types/structs.md:62
+msgid "\"second point: ({}, {})\""
+msgstr ""
+
+#: src/custom_types/structs.md:64
+msgid "// Destructure the point using a `let` binding\n"
+msgstr ""
+
+#: src/custom_types/structs.md:68
+msgid "// struct instantiation is an expression too\n"
+msgstr ""
+
+#: src/custom_types/structs.md:73
+msgid "// Instantiate a unit struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:76
+msgid "// Instantiate a tuple struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:79
+msgid "// Access the fields of a tuple struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:80 src/custom_types/structs.md:85
+msgid "\"pair contains {:?} and {:?}\""
+msgstr ""
+
+#: src/custom_types/structs.md:82
+msgid "// Destructure a tuple struct\n"
+msgstr ""
+
+#: src/custom_types/structs.md:91
+msgid ""
+"Add a function `rect_area` which calculates the area of a `Rectangle` (try "
+"using nested destructuring)."
+msgstr ""
+
+#: src/custom_types/structs.md:93
+msgid ""
+"Add a function `square` which takes a `Point` and a `f32` as arguments, and "
+"returns a `Rectangle` with its top left corner on the point, and a width and "
+"height corresponding to the `f32`."
+msgstr ""
+
+#: src/custom_types/structs.md:97
+msgid "See also"
+msgstr ""
+
+#: src/custom_types/structs.md:99
+msgid ""
+"[`attributes`](../attribute.md), [raw identifiers](../compatibility/"
+"raw_identifiers.md) and [destructuring](../flow_control/match/destructuring."
+"md)"
+msgstr ""
+
+#: src/custom_types/enum.md:3
+msgid ""
+"The `enum` keyword allows the creation of a type which may be one of a few "
+"different variants. Any variant which is valid as a `struct` is also valid in "
+"an `enum`."
+msgstr ""
+
+#: src/custom_types/enum.md:8
+msgid ""
+"// Create an `enum` to classify a web event. Note how both\n"
+"// names and type information together specify the variant:\n"
+"// `PageLoad != PageUnload` and `KeyPress(char) != Paste(String)`.\n"
+"// Each is different and independent.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:13
+msgid "// An `enum` variant may either be `unit-like`,\n"
+msgstr ""
+
+#: src/custom_types/enum.md:16
+msgid "// like tuple structs,\n"
+msgstr ""
+
+#: src/custom_types/enum.md:19
+msgid "// or c-like structures.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:22
+msgid ""
+"// A function which takes a `WebEvent` enum as an argument and\n"
+"// returns nothing.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:27
+msgid "\"page loaded\""
+msgstr ""
+
+#: src/custom_types/enum.md:28
+msgid "\"page unloaded\""
+msgstr ""
+
+#: src/custom_types/enum.md:29
+msgid "// Destructure `c` from inside the `enum` variant.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:30
+msgid "\"pressed '{}'.\""
+msgstr ""
+
+#: src/custom_types/enum.md:31
+msgid "\"pasted \\\"{}\\\".\""
+msgstr ""
+
+#: src/custom_types/enum.md:32
+msgid "// Destructure `Click` into `x` and `y`.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:34
+msgid "\"clicked at x={}, y={}.\""
+msgstr ""
+
+#: src/custom_types/enum.md:40
+msgid "'x'"
+msgstr ""
+
+#: src/custom_types/enum.md:41
+msgid "// `to_owned()` creates an owned `String` from a string slice.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:42
+msgid "\"my text\""
+msgstr ""
+
+#: src/custom_types/enum.md:56
+msgid "Type aliases"
+msgstr ""
+
+#: src/custom_types/enum.md:58
+msgid ""
+"If you use a type alias, you can refer to each enum variant via its alias. "
+"This might be useful if the enum's name is too long or too generic, and you "
+"want to rename it."
+msgstr ""
+
+#: src/custom_types/enum.md:67
+msgid "// Creates a type alias\n"
+msgstr ""
+
+#: src/custom_types/enum.md:72
+msgid ""
+"// We can refer to each variant via its alias, not its long and inconvenient\n"
+"    // name.\n"
+msgstr ""
+
+#: src/custom_types/enum.md:78
+msgid ""
+"The most common place you'll see this is in `impl` blocks using the `Self` "
+"alias."
+msgstr ""
+
+#: src/custom_types/enum.md:96
+msgid ""
+"To learn more about enums and type aliases, you can read the [stabilization "
+"report](https://github.com/rust-lang/rust/pull/61682/#issuecomment-502472847) "
+"from when this feature was stabilized into Rust."
+msgstr ""
+
+#: src/custom_types/enum.md:102
+msgid ""
+"[`match`](../flow_control/match.md), [`fn`](../fn.md), and [`String`](../std/"
+"str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
+"rfcs/2338-type-alias-enum-variants.html)"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:3
+msgid "The `use` declaration can be used so manual scoping isn't needed:"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:20
+msgid ""
+"// Explicitly `use` each name so they are available without\n"
+"    // manual scoping.\n"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:23
+msgid "// Automatically `use` each name inside `Role`.\n"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:26
+msgid "// Equivalent to `Stage::Beginner`.\n"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:28
+msgid "// Equivalent to `Role::Student`.\n"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:32
+msgid "// Note the lack of scoping because of the explicit `use` above.\n"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:33
+msgid "\"Beginners are starting their learning journey!\""
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:34
+msgid "\"Advanced learners are mastering their subjects...\""
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:38
+msgid "// Note again the lack of scoping.\n"
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:39
+msgid "\"Students are acquiring knowledge!\""
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:40
+msgid "\"Teachers are spreading knowledge!\""
+msgstr ""
+
+#: src/custom_types/enum/enum_use.md:47
+msgid "[`match`](../../flow_control/match.md) and [`use`](../../mod/use.md)"
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:3
+msgid "`enum` can also be used as C-like enums."
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:8
+msgid "// enum with implicit discriminator (starts at 0)\n"
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:15
+msgid "// enum with explicit discriminator\n"
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:24
+msgid "// `enums` can be cast as integers.\n"
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:25
+msgid "\"zero is {}\""
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:26
+msgid "\"one is {}\""
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:28
+msgid "\"roses are #{:06x}\""
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:29
+msgid "\"violets are #{:06x}\""
+msgstr ""
+
+#: src/custom_types/enum/c_like.md:35
+msgid "[casting](../../types/cast.md)"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:3
+msgid "A common way to implement a linked-list is via `enums`:"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:9
+msgid ""
+"// Cons: Tuple struct that wraps an element and a pointer to the next node\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:11
+msgid "// Nil: A node that signifies the end of the linked list\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:14
+msgid "// Methods can be attached to an enum\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:17
+msgid "// Create an empty list\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:19
+msgid "// `Nil` has type `List`\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:23
+msgid ""
+"// Consume a list, and return the same list with a new element at its front\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:25
+msgid "// `Cons` also has type List\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:29
+msgid "// Return the length of the list\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:31
+msgid ""
+"// `self` has to be matched, because the behavior of this method\n"
+"        // depends on the variant of `self`\n"
+"        // `self` has type `&List`, and `*self` has type `List`, matching on "
+"a\n"
+"        // concrete type `T` is preferred over a match on a reference `&T`\n"
+"        // after Rust 2018 you can use self here and tail (with no ref) below "
+"as well,\n"
+"        // rust will infer &s and ref tail. \n"
+"        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-"
+"and-lifetimes/default-match-bindings.html\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:39
+msgid ""
+"// Can't take ownership of the tail, because `self` is borrowed;\n"
+"            // instead take a reference to the tail\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:42
+msgid "// Base Case: An empty list has zero length\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:47
+msgid "// Return representation of the list as a (heap allocated) string\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:51
+msgid ""
+"// `format!` is similar to `print!`, but returns a heap\n"
+"                // allocated string instead of printing to the console\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:53 src/generics/impl.md:44
+msgid "\"{}, {}\""
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:56
+msgid "\"Nil\""
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:63
+msgid "// Create an empty linked list\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:66
+msgid "// Prepend some elements\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:71
+msgid "// Show the final state of the list\n"
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:72
+msgid "\"linked list has length: {}\""
+msgstr ""
+
+#: src/custom_types/enum/testcase_linked_list.md:79
+msgid "[`Box`](../../std/box.md) and [methods](../../fn/methods.md)"
+msgstr ""
+
+#: src/custom_types/constants.md:3
+msgid ""
+"Rust has two different types of constants which can be declared in any scope "
+"including global. Both require explicit type annotation:"
+msgstr ""
+
+#: src/custom_types/constants.md:6
+msgid "`const`: An unchangeable value (the common case)."
+msgstr ""
+
+#: src/custom_types/constants.md:7
+msgid ""
+"`static`: A possibly mutable variable with [`'static`](../scope/lifetime/"
+"static_lifetime.md) lifetime. The static lifetime is inferred and does not "
+"have to be specified. Accessing or modifying a mutable static variable is "
+"[`unsafe`](../unsafe.md)."
+msgstr ""
+
+#: src/custom_types/constants.md:12
+msgid "// Globals are declared outside all other scopes.\n"
+msgstr ""
+
+#: src/custom_types/constants.md:13
+msgid "\"Rust\""
+msgstr ""
+
+#: src/custom_types/constants.md:17
+msgid "// Access constant in some function\n"
+msgstr ""
+
+#: src/custom_types/constants.md:24
+msgid "// Access constant in the main thread\n"
+msgstr ""
+
+#: src/custom_types/constants.md:25
+msgid "\"This is {}\""
+msgstr ""
+
+#: src/custom_types/constants.md:26
+msgid "\"The threshold is {}\""
+msgstr ""
+
+#: src/custom_types/constants.md:27
+msgid "\"{} is {}\""
+msgstr ""
+
+#: src/custom_types/constants.md:27
+msgid "\"big\""
+msgstr ""
+
+#: src/custom_types/constants.md:27
+msgid "\"small\""
+msgstr ""
+
+#: src/custom_types/constants.md:29
+msgid "// Error! Cannot modify a `const`.\n"
+msgstr ""
+
+#: src/custom_types/constants.md:31 src/variable_bindings/scope.md:21
+#: src/variable_bindings/declare.md:25 src/variable_bindings/freeze.md:16
+#: src/types/cast.md:19 src/types/cast.md:28 src/flow_control/for.md:95
+#: src/scope/borrow.md:41 src/scope/borrow/mut.md:52 src/std/vec.md:31
+#: src/std/vec.md:44 src/std/hash/hashset.md:48
+msgid "// FIXME ^ Comment out this line\n"
+msgstr ""
+
+#: src/custom_types/constants.md:37
+msgid ""
+"[The `const`/`static` RFC](https://github.com/rust-lang/rfcs/blob/master/"
+"text/0246-const-vs-static.md), [`'static` lifetime](../scope/lifetime/"
+"static_lifetime.md)"
+msgstr ""
+
+#: src/variable_bindings.md:3
+msgid ""
+"Rust provides type safety via static typing. Variable bindings can be type "
+"annotated when declared. However, in most cases, the compiler will be able to "
+"infer the type of the variable from the context, heavily reducing the "
+"annotation burden."
+msgstr ""
+
+#: src/variable_bindings.md:8
+msgid ""
+"Values (like literals) can be bound to variables, using the `let` binding."
+msgstr ""
+
+#: src/variable_bindings.md:16
+msgid "// copy `an_integer` into `copied_integer`\n"
+msgstr ""
+
+#: src/variable_bindings.md:19
+msgid "\"An integer: {:?}\""
+msgstr ""
+
+#: src/variable_bindings.md:20
+msgid "\"A boolean: {:?}\""
+msgstr ""
+
+#: src/variable_bindings.md:21
+msgid "\"Meet the unit value: {:?}\""
+msgstr ""
+
+#: src/variable_bindings.md:23
+msgid ""
+"// The compiler warns about unused variable bindings; these warnings can\n"
+"    // be silenced by prefixing the variable name with an underscore\n"
+msgstr ""
+
+#: src/variable_bindings.md:28
+msgid ""
+"// FIXME ^ Prefix with an underscore to suppress the warning\n"
+"    // Please note that warnings may not be shown in a browser\n"
+msgstr ""
+
+#: src/variable_bindings/mut.md:3
+msgid ""
+"Variable bindings are immutable by default, but this can be overridden using "
+"the `mut` modifier."
+msgstr ""
+
+#: src/variable_bindings/mut.md:11
+msgid "\"Before mutation: {}\""
+msgstr ""
+
+#: src/variable_bindings/mut.md:13
+msgid "// Ok\n"
+msgstr ""
+
+#: src/variable_bindings/mut.md:16
+msgid "\"After mutation: {}\""
+msgstr ""
+
+#: src/variable_bindings/mut.md:18
+msgid "// Error! Cannot assign a new value to an immutable variable\n"
+msgstr ""
+
+#: src/variable_bindings/mut.md:23
+msgid "The compiler will throw a detailed diagnostic about mutability errors."
+msgstr ""
+
+#: src/variable_bindings/scope.md:3
+msgid ""
+"Variable bindings have a scope, and are constrained to live in a _block_. A "
+"block is a collection of statements enclosed by braces `{}`."
+msgstr ""
+
+#: src/variable_bindings/scope.md:7
+msgid "// This binding lives in the main function\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:10
+msgid "// This is a block, and has a smaller scope than the main function\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:12
+msgid "// This binding only exists in this block\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:15
+msgid "\"inner short: {}\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:17
+msgid "// End of the block\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:19
+msgid "// Error! `short_lived_binding` doesn't exist in this scope\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:20
+msgid "\"outer short: {}\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:23
+msgid "\"outer long: {}\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:26
+msgid ""
+"Also, [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing) "
+"is allowed."
+msgstr ""
+
+#: src/variable_bindings/scope.md:32
+msgid "\"before being shadowed: {}\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:34
+msgid "// This binding *shadows* the outer one\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:35
+msgid "\"abc\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:37
+msgid "\"shadowed in inner block: {}\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:39
+msgid "\"outside inner block: {}\""
+msgstr ""
+
+#: src/variable_bindings/scope.md:41
+msgid "// This binding *shadows* the previous binding\n"
+msgstr ""
+
+#: src/variable_bindings/scope.md:43
+msgid "\"shadowed in outer block: {}\""
+msgstr ""
+
+#: src/variable_bindings/declare.md:3
+msgid ""
+"It's possible to declare variable bindings first, and initialize them later. "
+"However, this form is seldom used, as it may lead to the use of uninitialized "
+"variables."
+msgstr ""
+
+#: src/variable_bindings/declare.md:9
+msgid "// Declare a variable binding\n"
+msgstr ""
+
+#: src/variable_bindings/declare.md:15
+msgid "// Initialize the binding\n"
+msgstr ""
+
+#: src/variable_bindings/declare.md:19
+msgid "\"a binding: {}\""
+msgstr ""
+
+#: src/variable_bindings/declare.md:23
+msgid "// Error! Use of uninitialized binding\n"
+msgstr ""
+
+#: src/variable_bindings/declare.md:24 src/variable_bindings/declare.md:29
+msgid "\"another binding: {}\""
+msgstr ""
+
+#: src/variable_bindings/declare.md:33
+msgid ""
+"The compiler forbids use of uninitialized variables, as this would lead to "
+"undefined behavior."
+msgstr ""
+
+#: src/variable_bindings/freeze.md:3
+msgid ""
+"When data is bound by the same name immutably, it also _freezes_. _Frozen_ "
+"data can't be modified until the immutable binding goes out of scope:"
+msgstr ""
+
+#: src/variable_bindings/freeze.md:11
+msgid "// Shadowing by immutable `_mutable_integer`\n"
+msgstr ""
+
+#: src/variable_bindings/freeze.md:14
+msgid "// Error! `_mutable_integer` is frozen in this scope\n"
+msgstr ""
+
+#: src/variable_bindings/freeze.md:18
+msgid "// `_mutable_integer` goes out of scope\n"
+msgstr ""
+
+#: src/variable_bindings/freeze.md:21
+msgid "// Ok! `_mutable_integer` is not frozen in this scope\n"
+msgstr ""
+
+#: src/types.md:3
+msgid ""
+"Rust provides several mechanisms to change or define the type of primitive "
+"and user defined types. The following sections cover:"
+msgstr ""
+
+#: src/types.md:5
+msgid "[Casting](types/cast.md) between primitive types"
+msgstr ""
+
+#: src/types.md:6
+msgid "Specifying the desired type of [literals](types/literals.md)"
+msgstr ""
+
+#: src/types.md:7
+msgid "Using [type inference](types/inference.md)"
+msgstr ""
+
+#: src/types.md:8
+msgid "[Aliasing](types/alias.md) types"
+msgstr ""
+
+#: src/types/cast.md:3
+msgid ""
+"Rust provides no implicit type conversion (coercion) between primitive types. "
+"But, explicit type conversion (casting) can be performed using the `as` "
+"keyword."
+msgstr ""
+
+#: src/types/cast.md:6
+msgid ""
+"Rules for converting between integral types follow C conventions generally, "
+"except in cases where C has undefined behavior. The behavior of all casts "
+"between integral types is well defined in Rust."
+msgstr ""
+
+#: src/types/cast.md:11
+msgid "// Suppress all warnings from casts which overflow.\n"
+msgstr ""
+
+#: src/types/cast.md:17
+msgid "// Error! No implicit conversion\n"
+msgstr ""
+
+#: src/types/cast.md:21
+msgid "// Explicit conversion\n"
+msgstr ""
+
+#: src/types/cast.md:25
+msgid ""
+"// Error! There are limitations in conversion rules.\n"
+"    // A float cannot be directly converted to a char.\n"
+msgstr ""
+
+#: src/types/cast.md:30
+msgid "\"Casting: {} -> {} -> {}\""
+msgstr ""
+
+#: src/types/cast.md:32
+msgid ""
+"// when casting any value to an unsigned type, T,\n"
+"    // T::MAX + 1 is added or subtracted until the value\n"
+"    // fits into the new type\n"
+msgstr ""
+
+#: src/types/cast.md:36
+msgid "// 1000 already fits in a u16\n"
+msgstr ""
+
+#: src/types/cast.md:37
+msgid "\"1000 as a u16 is: {}\""
+msgstr ""
+
+#: src/types/cast.md:39
+msgid ""
+"// 1000 - 256 - 256 - 256 = 232\n"
+"    // Under the hood, the first 8 least significant bits (LSB) are kept,\n"
+"    // while the rest towards the most significant bit (MSB) get truncated.\n"
+msgstr ""
+
+#: src/types/cast.md:42 src/types/cast.md:61
+msgid "\"1000 as a u8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:43
+msgid "// -1 + 256 = 255\n"
+msgstr ""
+
+#: src/types/cast.md:44
+msgid "\"  -1 as a u8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:46
+msgid "// For positive numbers, this is the same as the modulus\n"
+msgstr ""
+
+#: src/types/cast.md:47
+msgid "\"1000 mod 256 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:49
+msgid ""
+"// When casting to a signed type, the (bitwise) result is the same as\n"
+"    // first casting to the corresponding unsigned type. If the most "
+"significant\n"
+"    // bit of that value is 1, then the value is negative.\n"
+msgstr ""
+
+#: src/types/cast.md:53
+msgid "// Unless it already fits, of course.\n"
+msgstr ""
+
+#: src/types/cast.md:54
+msgid "\" 128 as a i16 is: {}\""
+msgstr ""
+
+#: src/types/cast.md:56
+msgid ""
+"// In boundary case 128 value in 8-bit two's complement representation is "
+"-128\n"
+msgstr ""
+
+#: src/types/cast.md:57
+msgid "\" 128 as a i8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:59
+msgid ""
+"// repeating the example above\n"
+"    // 1000 as u8 -> 232\n"
+msgstr ""
+
+#: src/types/cast.md:62
+msgid ""
+"// and the value of 232 in 8-bit two's complement representation is -24\n"
+msgstr ""
+
+#: src/types/cast.md:63
+msgid "\" 232 as a i8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:65
+msgid ""
+"// Since Rust 1.45, the `as` keyword performs a *saturating cast*\n"
+"    // when casting from float to int. If the floating point value exceeds\n"
+"    // the upper bound or is less than the lower bound, the returned value\n"
+"    // will be equal to the bound crossed.\n"
+msgstr ""
+
+#: src/types/cast.md:70
+msgid "// 300.0 as u8 is 255\n"
+msgstr ""
+
+#: src/types/cast.md:71 src/types/cast.md:82
+msgid "\" 300.0 as u8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:72
+msgid "// -100.0 as u8 is 0\n"
+msgstr ""
+
+#: src/types/cast.md:73 src/types/cast.md:84
+msgid "\"-100.0 as u8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:74 src/types/cast.md:85
+msgid "// nan as u8 is 0\n"
+msgstr ""
+
+#: src/types/cast.md:75 src/types/cast.md:86
+msgid "\"   nan as u8 is : {}\""
+msgstr ""
+
+#: src/types/cast.md:77
+msgid ""
+"// This behavior incurs a small runtime cost and can be avoided\n"
+"    // with unsafe methods, however the results might overflow and\n"
+"    // return **unsound values**. Use these methods wisely:\n"
+msgstr ""
+
+#: src/types/cast.md:81
+msgid "// 300.0 as u8 is 44\n"
+msgstr ""
+
+#: src/types/cast.md:83
+msgid "// -100.0 as u8 is 156\n"
+msgstr ""
+
+#: src/types/literals.md:3
+msgid ""
+"Numeric literals can be type annotated by adding the type as a suffix. As an "
+"example, to specify that the literal `42` should have the type `i32`, write "
+"`42i32`."
+msgstr ""
+
+#: src/types/literals.md:6
+msgid ""
+"The type of unsuffixed numeric literals will depend on how they are used. If "
+"no constraint exists, the compiler will use `i32` for integers, and `f64` for "
+"floating-point numbers."
+msgstr ""
+
+#: src/types/literals.md:12
+msgid "// Suffixed literals, their types are known at initialization\n"
+msgstr ""
+
+#: src/types/literals.md:17
+msgid "// Unsuffixed literals, their types depend on how they are used\n"
+msgstr ""
+
+#: src/types/literals.md:21
+msgid "// `size_of_val` returns the size of a variable in bytes\n"
+msgstr ""
+
+#: src/types/literals.md:22
+msgid "\"size of `x` in bytes: {}\""
+msgstr ""
+
+#: src/types/literals.md:23
+msgid "\"size of `y` in bytes: {}\""
+msgstr ""
+
+#: src/types/literals.md:24
+msgid "\"size of `z` in bytes: {}\""
+msgstr ""
+
+#: src/types/literals.md:25
+msgid "\"size of `i` in bytes: {}\""
+msgstr ""
+
+#: src/types/literals.md:26
+msgid "\"size of `f` in bytes: {}\""
+msgstr ""
+
+#: src/types/literals.md:30
+msgid ""
+"There are some concepts used in the previous code that haven't been explained "
+"yet, here's a brief explanation for the impatient readers:"
+msgstr ""
+
+#: src/types/literals.md:33
+msgid ""
+"`std::mem::size_of_val` is a function, but called with its _full path_. Code "
+"can be split in logical units called _modules_. In this case, the "
+"`size_of_val` function is defined in the `mem` module, and the `mem` module "
+"is defined in the `std` _crate_. For more details, see [modules](../mod.md) "
+"and [crates](../crates.md)."
+msgstr ""
+
+#: src/types/inference.md:3
+msgid ""
+"The type inference engine is pretty smart. It does more than looking at the "
+"type of the value expression during an initialization. It also looks at how "
+"the variable is used afterwards to infer its type. Here's an advanced example "
+"of type inference:"
+msgstr ""
+
+#: src/types/inference.md:10
+msgid ""
+"// Because of the annotation, the compiler knows that `elem` has type u8.\n"
+msgstr ""
+
+#: src/types/inference.md:13
+msgid "// Create an empty vector (a growable array).\n"
+msgstr ""
+
+#: src/types/inference.md:15
+msgid ""
+"// At this point the compiler doesn't know the exact type of `vec`, it\n"
+"    // just knows that it's a vector of something (`Vec<_>`).\n"
+msgstr ""
+
+#: src/types/inference.md:18
+msgid "// Insert `elem` in the vector.\n"
+msgstr ""
+
+#: src/types/inference.md:20
+msgid ""
+"// Aha! Now the compiler knows that `vec` is a vector of `u8`s (`Vec<u8>`)\n"
+"    // TODO ^ Try commenting out the `vec.push(elem)` line\n"
+msgstr ""
+
+#: src/types/inference.md:27
+msgid ""
+"No type annotation of variables was needed, the compiler is happy and so is "
+"the programmer!"
+msgstr ""
+
+#: src/types/alias.md:3
+msgid ""
+"The `type` statement can be used to give a new name to an existing type. "
+"Types must have `UpperCamelCase` names, or the compiler will raise a warning. "
+"The exception to this rule are the primitive types: `usize`, `f32`, etc."
+msgstr ""
+
+#: src/types/alias.md:8
+msgid "// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.\n"
+msgstr ""
+
+#: src/types/alias.md:14
+msgid "// `NanoSecond` = `Inch` = `U64` = `u64`.\n"
+msgstr ""
+
+#: src/types/alias.md:18
+msgid ""
+"// Note that type aliases *don't* provide any extra type safety, because\n"
+"    // aliases are *not* new types\n"
+msgstr ""
+
+#: src/types/alias.md:20
+msgid "\"{} nanoseconds + {} inches = {} unit?\""
+msgstr ""
+
+#: src/types/alias.md:27
+msgid ""
+"The main use of aliases is to reduce boilerplate; for example the `io::"
+"Result<T>` type is an alias for the `Result<T, io::Error>` type."
+msgstr ""
+
+#: src/types/alias.md:32
+msgid "[Attributes](../attribute.md)"
+msgstr ""
+
+#: src/conversion.md:3
+msgid ""
+"Primitive types can be converted to each other through [casting](types/cast."
+"md)."
+msgstr ""
+
+#: src/conversion.md:5
+msgid ""
+"Rust addresses conversion between custom types (i.e., `struct` and `enum`) by "
+"the use of [traits](trait.md). The generic conversions will use the [`From`]"
+"(https://doc.rust-lang.org/std/convert/trait.From.html) and [`Into`](https://"
+"doc.rust-lang.org/std/convert/trait.Into.html) traits. However there are more "
+"specific ones for the more common cases, in particular when converting to and "
+"from `String`s."
+msgstr ""
+
+#: src/conversion/from_into.md:3
+msgid ""
+"The [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) traits are "
+"inherently linked, and this is actually part of its implementation. If you "
+"are able to convert type A from type B, then it should be easy to believe "
+"that we should be able to convert type B to type A."
+msgstr ""
+
+#: src/conversion/from_into.md:7
+msgid "`From`"
+msgstr ""
+
+#: src/conversion/from_into.md:9
+msgid ""
+"The [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) trait "
+"allows for a type to define how to create itself from another type, hence "
+"providing a very simple mechanism for converting between several types. There "
+"are numerous implementations of this trait within the standard library for "
+"conversion of primitive and common types."
+msgstr ""
+
+#: src/conversion/from_into.md:14
+msgid "For example we can easily convert a `str` into a `String`"
+msgstr ""
+
+#: src/conversion/from_into.md:21
+msgid "We can do something similar for defining a conversion for our own type."
+msgstr ""
+
+#: src/conversion/from_into.md:39 src/conversion/from_into.md:68
+#: src/conversion/from_into.md:98
+msgid "\"My number is {:?}\""
+msgstr ""
+
+#: src/conversion/from_into.md:43
+msgid "`Into`"
+msgstr ""
+
+#: src/conversion/from_into.md:45
+msgid ""
+"The [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) trait is "
+"simply the reciprocal of the `From` trait. It defines how to convert a type "
+"into another type."
+msgstr ""
+
+#: src/conversion/from_into.md:48
+msgid ""
+"Calling `into()` typically requires us to specify the result type as the "
+"compiler is unable to determine this most of the time."
+msgstr ""
+
+#: src/conversion/from_into.md:66
+msgid "// Try removing the type annotation\n"
+msgstr ""
+
+#: src/conversion/from_into.md:72
+msgid "`From` and `Into` are interchangable"
+msgstr ""
+
+#: src/conversion/from_into.md:74
+msgid ""
+"`From` and `Into` are designed to be complementary. We do not need to provide "
+"an implementation for both traits. If you have implemented the `From` trait "
+"for your type, `Into` will call it when necessary. Note, however, that the "
+"converse is not true: implementing `Into` for your type will not "
+"automatically provide it with an implementation of `From`."
+msgstr ""
+
+#: src/conversion/from_into.md:86
+msgid "// Define `From`\n"
+msgstr ""
+
+#: src/conversion/from_into.md:96
+msgid "// use `Into`\n"
+msgstr ""
+
+#: src/conversion/try_from_try_into.md:3
+msgid ""
+"Similar to [`From` and `Into`](from_into.html), [`TryFrom`](https://doc.rust-"
+"lang.org/std/convert/trait.TryFrom.html) and [`TryInto`](https://doc.rust-"
+"lang.org/std/convert/trait.TryInto.html) are generic traits for converting "
+"between types. Unlike `From`/`Into`, the `TryFrom`/`TryInto` traits are used "
+"for fallible conversions, and as such, return [`Result`](https://doc.rust-"
+"lang.org/std/result/enum.Result.html)s."
+msgstr ""
+
+#: src/conversion/try_from_try_into.md:33
+msgid "// TryFrom\n"
+msgstr ""
+
+#: src/conversion/try_from_try_into.md:38
+msgid "// TryInto\n"
+msgstr ""
+
+#: src/conversion/string.md:1
+msgid "To and from Strings"
+msgstr ""
+
+#: src/conversion/string.md:3
+msgid "Converting to String"
+msgstr ""
+
+#: src/conversion/string.md:5
+msgid ""
+"To convert any type to a `String` is as simple as implementing the "
+"[`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) trait "
+"for the type. Rather than doing so directly, you should implement the [`fmt::"
+"Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) trait which "
+"automagically provides [`ToString`](https://doc.rust-lang.org/std/string/"
+"trait.ToString.html) and also allows printing the type as discussed in the "
+"section on [`print!`](../hello/print.md)."
+msgstr ""
+
+#: src/conversion/string.md:19
+msgid "\"Circle of radius {}\""
+msgstr ""
+
+#: src/conversion/string.md:29
+msgid "Parsing a String"
+msgstr ""
+
+#: src/conversion/string.md:31
+msgid ""
+"It's useful to convert strings into many types, but one of the more common "
+"string operations is to convert them from string to number. The idiomatic "
+"approach to this is to use the [`parse`](https://doc.rust-lang.org/std/"
+"primitive.str.html#method.parse) function and either to arrange for type "
+"inference or to specify the type to parse using the 'turbofish' syntax. Both "
+"alternatives are shown in the following example."
+msgstr ""
+
+#: src/conversion/string.md:37
+msgid ""
+"This will convert the string into the type specified as long as the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait is "
+"implemented for that type. This is implemented for numerous types within the "
+"standard library."
+msgstr ""
+
+#: src/conversion/string.md:43 src/std_misc/process/wait.md:10
+msgid "\"5\""
+msgstr ""
+
+#: src/conversion/string.md:44 src/error/result.md:33 src/error/result.md:68
+#: src/error/result/result_map.md:42 src/error/result/result_map.md:75
+#: src/error/result/result_alias.md:36 src/error/result/early_returns.md:36
+#: src/error/result/enter_question_mark.md:34
+#: src/error/result/enter_question_mark.md:67
+msgid "\"10\""
+msgstr ""
+
+#: src/conversion/string.md:47
+msgid "\"Sum: {:?}\""
+msgstr ""
+
+#: src/conversion/string.md:51
+msgid ""
+"To obtain this functionality on a user defined type simply implement the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
+"that type."
+msgstr ""
+
+#: src/conversion/string.md:74
+msgid "\"    3 \""
+msgstr ""
+
+#: src/expression.md:3
+msgid "A Rust program is (mostly) made up of a series of statements:"
+msgstr ""
+
+#: src/expression.md:7
+msgid ""
+"// statement\n"
+"    // statement\n"
+"    // statement\n"
+msgstr ""
+
+#: src/expression.md:13
+msgid ""
+"There are a few kinds of statements in Rust. The most common two are "
+"declaring a variable binding, and using a `;` with an expression:"
+msgstr ""
+
+#: src/expression.md:18
+msgid "// variable binding\n"
+msgstr ""
+
+#: src/expression.md:21
+msgid "// expression;\n"
+msgstr ""
+
+#: src/expression.md:28
+msgid ""
+"Blocks are expressions too, so they can be used as values in assignments. The "
+"last expression in the block will be assigned to the place expression such as "
+"a local variable. However, if the last expression of the block ends with a "
+"semicolon, the return value will be `()`."
+msgstr ""
+
+#: src/expression.md:41
+msgid "// This expression will be assigned to `y`\n"
+msgstr ""
+
+#: src/expression.md:46
+msgid ""
+"// The semicolon suppresses this expression and `()` is assigned to `z`\n"
+msgstr ""
+
+#: src/expression.md:50
+msgid "\"x is {:?}\""
+msgstr ""
+
+#: src/expression.md:51
+msgid "\"y is {:?}\""
+msgstr ""
+
+#: src/expression.md:52
+msgid "\"z is {:?}\""
+msgstr ""
+
+#: src/flow_control.md:3
+msgid ""
+"An integral part of any programming language are ways to modify control flow: "
+"`if`/`else`, `for`, and others. Let's talk about them in Rust."
+msgstr ""
+
+#: src/flow_control/if_else.md:3
+msgid ""
+"Branching with `if`\\-`else` is similar to other languages. Unlike many of "
+"them, the boolean condition doesn't need to be surrounded by parentheses, and "
+"each condition is followed by a block. `if`\\-`else` conditionals are "
+"expressions, and, all branches must return the same type."
+msgstr ""
+
+#: src/flow_control/if_else.md:13
+msgid "\"{} is negative\""
+msgstr ""
+
+#: src/flow_control/if_else.md:15
+msgid "\"{} is positive\""
+msgstr ""
+
+#: src/flow_control/if_else.md:17
+msgid "\"{} is zero\""
+msgstr ""
+
+#: src/flow_control/if_else.md:22
+msgid "\", and is a small number, increase ten-fold\""
+msgstr ""
+
+#: src/flow_control/if_else.md:24
+msgid "// This expression returns an `i32`.\n"
+msgstr ""
+
+#: src/flow_control/if_else.md:27
+msgid "\", and is a big number, halve the number\""
+msgstr ""
+
+#: src/flow_control/if_else.md:29
+msgid "// This expression must return an `i32` as well.\n"
+msgstr ""
+
+#: src/flow_control/if_else.md:31
+msgid "// TODO ^ Try suppressing this expression with a semicolon.\n"
+msgstr ""
+
+#: src/flow_control/if_else.md:33
+msgid ""
+"//   ^ Don't forget to put a semicolon here! All `let` bindings need it.\n"
+msgstr ""
+
+#: src/flow_control/if_else.md:35 src/flow_control/match.md:35
+msgid "\"{} -> {}\""
+msgstr ""
+
+#: src/flow_control/loop.md:3
+msgid "Rust provides a `loop` keyword to indicate an infinite loop."
+msgstr ""
+
+#: src/flow_control/loop.md:5
+msgid ""
+"The `break` statement can be used to exit a loop at anytime, whereas the "
+"`continue` statement can be used to skip the rest of the iteration and start "
+"a new one."
+msgstr ""
+
+#: src/flow_control/loop.md:13
+msgid "\"Let's count until infinity!\""
+msgstr ""
+
+#: src/flow_control/loop.md:15
+msgid "// Infinite loop\n"
+msgstr ""
+
+#: src/flow_control/loop.md:20
+msgid "\"three\""
+msgstr ""
+
+#: src/flow_control/loop.md:22
+msgid "// Skip the rest of this iteration\n"
+msgstr ""
+
+#: src/flow_control/loop.md:29
+msgid "\"OK, that's enough\""
+msgstr ""
+
+#: src/flow_control/loop.md:31
+msgid "// Exit this loop\n"
+msgstr ""
+
+#: src/flow_control/loop/nested.md:3
+msgid ""
+"It's possible to `break` or `continue` outer loops when dealing with nested "
+"loops. In these cases, the loops must be annotated with some `'label`, and "
+"the label must be passed to the `break`/`continue` statement."
+msgstr ""
+
+#: src/flow_control/loop/nested.md:12
+msgid "\"Entered the outer loop\""
+msgstr ""
+
+#: src/flow_control/loop/nested.md:15
+msgid "\"Entered the inner loop\""
+msgstr ""
+
+#: src/flow_control/loop/nested.md:17
+msgid ""
+"// This would break only the inner loop\n"
+"            //break;\n"
+msgstr ""
+
+#: src/flow_control/loop/nested.md:20
+msgid "// This breaks the outer loop\n"
+msgstr ""
+
+#: src/flow_control/loop/nested.md:24
+msgid "\"This point will never be reached\""
+msgstr ""
+
+#: src/flow_control/loop/nested.md:27
+msgid "\"Exited the outer loop\""
+msgstr ""
+
+#: src/flow_control/loop/return.md:3
+msgid ""
+"One of the uses of a `loop` is to retry an operation until it succeeds. If "
+"the operation returns a value though, you might need to pass it to the rest "
+"of the code: put it after the `break`, and it will be returned by the `loop` "
+"expression."
+msgstr ""
+
+#: src/flow_control/while.md:3
+msgid "The `while` keyword can be used to run a loop while a condition is true."
+msgstr ""
+
+#: src/flow_control/while.md:5
+msgid ""
+"Let's write the infamous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) "
+"using a `while` loop."
+msgstr ""
+
+#: src/flow_control/while.md:9
+msgid "// A counter variable\n"
+msgstr ""
+
+#: src/flow_control/while.md:12
+msgid "// Loop while `n` is less than 101\n"
+msgstr ""
+
+#: src/flow_control/while.md:15 src/flow_control/for.md:17
+#: src/flow_control/for.md:37 src/fn.md:34
+msgid "\"fizzbuzz\""
+msgstr ""
+
+#: src/flow_control/while.md:17 src/flow_control/for.md:19
+#: src/flow_control/for.md:39 src/fn.md:36
+msgid "\"fizz\""
+msgstr ""
+
+#: src/flow_control/while.md:19 src/flow_control/for.md:21
+#: src/flow_control/for.md:41 src/fn.md:38
+msgid "\"buzz\""
+msgstr ""
+
+#: src/flow_control/while.md:24
+msgid "// Increment counter\n"
+msgstr ""
+
+#: src/flow_control/for.md:1
+msgid "for loops"
+msgstr ""
+
+#: src/flow_control/for.md:5
+msgid ""
+"The `for in` construct can be used to iterate through an `Iterator`. One of "
+"the easiest ways to create an iterator is to use the range notation `a..b`. "
+"This yields values from `a` (inclusive) to `b` (exclusive) in steps of one."
+msgstr ""
+
+#: src/flow_control/for.md:10
+msgid "Let's write FizzBuzz using `for` instead of `while`."
+msgstr ""
+
+#: src/flow_control/for.md:14 src/flow_control/for.md:34
+msgid "// `n` will take the values: 1, 2, ..., 100 in each iteration\n"
+msgstr ""
+
+#: src/flow_control/for.md:29
+msgid ""
+"Alternatively, `a..=b` can be used for a range that is inclusive on both "
+"ends. The above can be written as:"
+msgstr ""
+
+#: src/flow_control/for.md:49
+msgid "for and iterators"
+msgstr ""
+
+#: src/flow_control/for.md:51
+msgid ""
+"The `for in` construct is able to interact with an `Iterator` in several "
+"ways. As discussed in the section on the [Iterator](../trait/iter.md) trait, "
+"by default the `for` loop will apply the `into_iter` function to the "
+"collection. However, this is not the only means of converting collections "
+"into iterators."
+msgstr ""
+
+#: src/flow_control/for.md:56
+msgid ""
+"`into_iter`, `iter` and `iter_mut` all handle the conversion of a collection "
+"into an iterator in different ways, by providing different views on the data "
+"within."
+msgstr ""
+
+#: src/flow_control/for.md:60
+msgid ""
+"`iter` - This borrows each element of the collection through each iteration. "
+"Thus leaving the collection untouched and available for reuse after the loop."
+msgstr ""
+
+#: src/flow_control/for.md:65 src/flow_control/for.md:85
+#: src/flow_control/for.md:104
+msgid "\"Frank\""
+msgstr ""
+
+#: src/flow_control/for.md:65 src/flow_control/for.md:69
+#: src/flow_control/for.md:85 src/flow_control/for.md:89
+#: src/flow_control/for.md:104 src/flow_control/for.md:108
+msgid "\"Ferris\""
+msgstr ""
+
+#: src/flow_control/for.md:69 src/flow_control/for.md:89
+#: src/flow_control/for.md:108
+msgid "\"There is a rustacean among us!\""
+msgstr ""
+
+#: src/flow_control/for.md:70
+msgid "// TODO ^ Try deleting the & and matching just \"Ferris\"\n"
+msgstr ""
+
+#: src/flow_control/for.md:71 src/flow_control/for.md:90
+msgid "\"Hello {}\""
+msgstr ""
+
+#: src/flow_control/for.md:75 src/flow_control/for.md:94
+#: src/flow_control/for.md:113
+msgid "\"names: {:?}\""
+msgstr ""
+
+#: src/flow_control/for.md:79
+msgid ""
+"`into_iter` - This consumes the collection so that on each iteration the "
+"exact data is provided. Once the collection has been consumed it is no longer "
+"available for reuse as it has been 'moved' within the loop."
+msgstr ""
+
+#: src/flow_control/for.md:99
+msgid ""
+"`iter_mut` - This mutably borrows each element of the collection, allowing "
+"for the collection to be modified in place."
+msgstr ""
+
+#: src/flow_control/for.md:109
+msgid "\"Hello\""
+msgstr ""
+
+#: src/flow_control/for.md:117
+msgid ""
+"In the above snippets note the type of `match` branch, that is the key "
+"difference in the types of iteration. The difference in type then of course "
+"implies differing actions that are able to be performed."
+msgstr ""
+
+#: src/flow_control/for.md:123
+msgid "[Iterator](../trait/iter.md)"
+msgstr ""
+
+#: src/flow_control/match.md:3
+msgid ""
+"Rust provides pattern matching via the `match` keyword, which can be used "
+"like a C `switch`. The first matching arm is evaluated and all possible "
+"values must be covered."
+msgstr ""
+
+#: src/flow_control/match.md:10
+msgid "// TODO ^ Try different values for `number`\n"
+msgstr ""
+
+#: src/flow_control/match.md:12
+msgid "\"Tell me about {}\""
+msgstr ""
+
+#: src/flow_control/match.md:14
+msgid "// Match a single value\n"
+msgstr ""
+
+#: src/flow_control/match.md:15
+msgid "\"One!\""
+msgstr ""
+
+#: src/flow_control/match.md:16
+msgid "// Match several values\n"
+msgstr ""
+
+#: src/flow_control/match.md:17
+msgid "\"This is a prime\""
+msgstr ""
+
+#: src/flow_control/match.md:18
+msgid ""
+"// TODO ^ Try adding 13 to the list of prime values\n"
+"        // Match an inclusive range\n"
+msgstr ""
+
+#: src/flow_control/match.md:20
+msgid "\"A teen\""
+msgstr ""
+
+#: src/flow_control/match.md:21
+msgid "// Handle the rest of cases\n"
+msgstr ""
+
+#: src/flow_control/match.md:22
+msgid "\"Ain't special\""
+msgstr ""
+
+#: src/flow_control/match.md:23
+msgid "// TODO ^ Try commenting out this catch-all arm\n"
+msgstr ""
+
+#: src/flow_control/match.md:27
+msgid "// Match is an expression too\n"
+msgstr ""
+
+#: src/flow_control/match.md:29
+msgid "// The arms of a match must cover all the possible values\n"
+msgstr ""
+
+#: src/flow_control/match.md:32
+msgid "// TODO ^ Try commenting out one of these arms\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring.md:3
+msgid "A `match` block can destructure items in a variety of ways."
+msgstr ""
+
+#: src/flow_control/match/destructuring.md:5
+msgid "[Destructuring Tuples](destructuring/destructure_tuple.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring.md:6
+msgid "[Destructuring Arrays and Slices](destructuring/destructure_slice.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring.md:7
+msgid "[Destructuring Enums](destructuring/destructure_enum.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring.md:8
+msgid "[Destructuring Pointers](destructuring/destructure_pointers.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring.md:9
+msgid "[Destructuring Structures](destructuring/destructure_structures.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:3
+msgid "Tuples can be destructured in a `match` as follows:"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:8
+msgid "// TODO ^ Try different values for `triple`\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:10
+msgid "\"Tell me about {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:11
+msgid "// Match can be used to destructure a tuple\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:13
+msgid "// Destructure the second and third elements\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:14
+msgid "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:15
+msgid "\"First is `1` and the rest doesn't matter\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:16
+msgid "\"last is `2` and the rest doesn't matter\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:17
+msgid "\"First is `3`, last is `4`, and the rest doesn't matter\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:18
+msgid "// `..` can be used to ignore the rest of the tuple\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:19
+msgid "\"It doesn't matter what they are\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:20
+msgid "// `_` means don't bind the value to a variable\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_tuple.md:27
+msgid "[Tuples](../../../primitives/tuples.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:3
+msgid "Like tuples, arrays and slices can be destructured this way:"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:7
+msgid "// Try changing the values in the array, or make it a slice!\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:11
+msgid "// Binds the second and the third elements to the respective variables\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:13
+msgid "\"array[0] = 0, array[1] = {}, array[2] = {}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:15
+msgid "// Single values can be ignored with _\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:17
+msgid "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:21
+msgid "// You can also bind some and ignore the rest\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:23
+msgid "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:26
+msgid ""
+"// The code below would not compile\n"
+"        // [-1, second] => ...\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:29
+msgid ""
+"// Or store them in another array/slice (the type depends on\n"
+"        // that of the value that is being matched against)\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:32
+msgid "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:36
+msgid ""
+"// Combining these patterns, we can, for example, bind the first and\n"
+"        // last values, and store the rest of them in a single array\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:39
+msgid "\"array[0] = {}, middle = {:?}, array[2] = {}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_slice.md:48
+msgid ""
+"[Arrays and Slices](../../../primitives/array.md) and [Binding](../binding."
+"md) for `@` sigil"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:3
+msgid "An `enum` is destructured similarly:"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:6
+msgid ""
+"// `allow` required to silence warnings because only\n"
+"// one variant is used.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:10
+msgid "// These 3 are specified solely by their name.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:14
+msgid "// These likewise tie `u32` tuples to different names: color models.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:24
+msgid "// TODO ^ Try different variants for `color`\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:26
+msgid "\"What color is it?\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:27
+msgid "// An `enum` can be destructured using a `match`.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:29
+msgid "\"The color is Red!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:30
+msgid "\"The color is Blue!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:31
+msgid "\"The color is Green!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:33
+msgid "\"Red: {}, green: {}, and blue: {}!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:35
+msgid "\"Hue: {}, saturation: {}, value: {}!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:37
+msgid "\"Hue: {}, saturation: {}, lightness: {}!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:39
+msgid "\"Cyan: {}, magenta: {}, yellow: {}!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:41
+msgid "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:43
+msgid "// Don't need another arm because all variants have been examined\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_enum.md:50
+msgid ""
+"[`#[allow(...)]`](../../../attribute/unused.md), [color models](https://en."
+"wikipedia.org/wiki/Color_model) and [`enum`](../../../custom_types/enum.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:3
+msgid ""
+"For pointers, a distinction needs to be made between destructuring and "
+"dereferencing as they are different concepts which are used differently from "
+"languages like C/C++."
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:7
+msgid "Dereferencing uses `*`"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:8
+msgid "Destructuring uses `&`, `ref`, and `ref mut`"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:12
+msgid ""
+"// Assign a reference of type `i32`. The `&` signifies there\n"
+"    // is a reference being assigned.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:17
+msgid ""
+"// If `reference` is pattern matched against `&val`, it results\n"
+"        // in a comparison like:\n"
+"        // `&i32`\n"
+"        // `&val`\n"
+"        // ^ We see that if the matching `&`s are dropped, then the `i32`\n"
+"        // should be assigned to `val`.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:23
+msgid "\"Got a value via destructuring: {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:26
+msgid "// To avoid the `&`, you dereference before matching.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:28
+msgid "\"Got a value via dereferencing: {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:31
+msgid ""
+"// What if you don't start with a reference? `reference` was a `&`\n"
+"    // because the right side was already a reference. This is not\n"
+"    // a reference because the right side is not one.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:36
+msgid ""
+"// Rust provides `ref` for exactly this purpose. It modifies the\n"
+"    // assignment so that a reference is created for the element; this\n"
+"    // reference is assigned.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:41
+msgid ""
+"// Accordingly, by defining 2 values without references, references\n"
+"    // can be retrieved via `ref` and `ref mut`.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:46
+msgid "// Use `ref` keyword to create a reference.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:48
+msgid "\"Got a reference to a value: {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:51
+msgid "// Use `ref mut` similarly.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:54
+msgid ""
+"// Got a reference. Gotta dereference it before we can\n"
+"            // add anything to it.\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:57
+msgid "\"We added 10. `mut_value`: {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_pointers.md:65
+msgid "[The ref pattern](../../../scope/borrow/ref.md)"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:3
+msgid "Similarly, a `struct` can be destructured as shown:"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:12
+msgid "// Try changing the values in the struct to see what happens\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:16
+msgid "\"First of x is 1, b = {},  y = {} \""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:18
+msgid ""
+"// you can destructure structs and rename the variables,\n"
+"        // the order is not important\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:20
+msgid "\"y is 2, i = {:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:22
+msgid "// and you can also ignore some variables:\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:23
+msgid "\"y = {}, we don't care about x\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:24
+msgid ""
+"// this will give an error: pattern does not mention field `x`\n"
+"        //Foo { y } => println!(\"y = {}\", y),\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:30
+msgid "// You do not need a match block to destructure structs:\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:32
+msgid "\"Outside: x0 = {x0:?}, y0 = {y0}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:34
+msgid "// Destructuring works with nested structs as well:\n"
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:41
+msgid "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
+msgstr ""
+
+#: src/flow_control/match/destructuring/destructure_structures.md:47
+msgid "[Structs](../../../custom_types/structs.md)"
+msgstr ""
+
+#: src/flow_control/match/guard.md:3
+msgid "A `match` _guard_ can be added to filter the arm."
+msgstr ""
+
+#: src/flow_control/match/guard.md:14
+msgid "// ^ TODO try different values for `temperature`\n"
+msgstr ""
+
+#: src/flow_control/match/guard.md:17
+msgid "\"{}C is above 30 Celsius\""
+msgstr ""
+
+#: src/flow_control/match/guard.md:18
+msgid "// The `if condition` part ^ is a guard\n"
+msgstr ""
+
+#: src/flow_control/match/guard.md:19
+msgid "\"{}C is equal to or below 30 Celsius\""
+msgstr ""
+
+#: src/flow_control/match/guard.md:21
+msgid "\"{}F is above 86 Fahrenheit\""
+msgstr ""
+
+#: src/flow_control/match/guard.md:22
+msgid "\"{}F is equal to or below 86 Fahrenheit\""
+msgstr ""
+
+#: src/flow_control/match/guard.md:27
+msgid ""
+"Note that the compiler won't take guard conditions into account when checking "
+"if all patterns are covered by the match expression."
+msgstr ""
+
+#: src/flow_control/match/guard.md:35
+msgid "\"Zero\""
+msgstr ""
+
+#: src/flow_control/match/guard.md:36
+msgid "\"Greater than zero\""
+msgstr ""
+
+#: src/flow_control/match/guard.md:37
+msgid ""
+"// _ => unreachable!(\"Should never happen.\"),\n"
+"        // TODO ^ uncomment to fix compilation\n"
+msgstr ""
+
+#: src/flow_control/match/guard.md:45
+msgid "[Tuples](../../primitives/tuples.md) [Enums](../../custom_types/enum.md)"
+msgstr ""
+
+#: src/flow_control/match/binding.md:3
+msgid ""
+"Indirectly accessing a variable makes it impossible to branch and use that "
+"variable without re-binding. `match` provides the `@` sigil for binding "
+"values to names:"
+msgstr ""
+
+#: src/flow_control/match/binding.md:8
+msgid "// A function `age` which returns a `u32`.\n"
+msgstr ""
+
+#: src/flow_control/match/binding.md:14
+msgid "\"Tell me what type of person you are\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:17
+msgid "\"I haven't celebrated my first birthday yet\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:18
+msgid ""
+"// Could `match` 1 ..= 12 directly but then what age\n"
+"        // would the child be? Instead, bind to `n` for the\n"
+"        // sequence of 1 ..= 12. Now the age can be reported.\n"
+msgstr ""
+
+#: src/flow_control/match/binding.md:21
+msgid "\"I'm a child of age {:?}\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:22
+msgid "\"I'm a teen of age {:?}\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:23
+msgid "// Nothing bound. Return the result.\n"
+msgstr ""
+
+#: src/flow_control/match/binding.md:24
+msgid "\"I'm an old person of age {:?}\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:29
+msgid ""
+"You can also use binding to \"destructure\" `enum` variants, such as `Option`:"
+msgstr ""
+
+#: src/flow_control/match/binding.md:38
+msgid ""
+"// Got `Some` variant, match if its value, bound to `n`,\n"
+"        // is equal to 42.\n"
+msgstr ""
+
+#: src/flow_control/match/binding.md:40
+msgid "\"The Answer: {}!\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:41
+msgid "// Match any other number.\n"
+msgstr ""
+
+#: src/flow_control/match/binding.md:42
+msgid "\"Not interesting... {}\""
+msgstr ""
+
+#: src/flow_control/match/binding.md:43
+msgid "// Match anything else (`None` variant).\n"
+msgstr ""
+
+#: src/flow_control/match/binding.md:50
+msgid ""
+"[`functions`](../../fn.md), [`enums`](../../custom_types/enum.md) and "
+"[`Option`](../../std/option.md)"
+msgstr ""
+
+#: src/flow_control/if_let.md:3
+msgid ""
+"For some use cases, when matching enums, `match` is awkward. For example:"
+msgstr ""
+
+#: src/flow_control/if_let.md:6 src/flow_control/while_let.md:7
+#: src/flow_control/while_let.md:35
+msgid "// Make `optional` of type `Option<i32>`\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:10
+msgid "\"This is a really long string and `{:?}`\""
+msgstr ""
+
+#: src/flow_control/if_let.md:12
+msgid ""
+"// ^ Required because `match` is exhaustive. Doesn't it seem\n"
+"    // like wasted space?\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:18
+msgid ""
+"`if let` is cleaner for this use case and in addition allows various failure "
+"options to be specified:"
+msgstr ""
+
+#: src/flow_control/if_let.md:23
+msgid "// All have type `Option<i32>`\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:28
+msgid ""
+"// The `if let` construct reads: \"if `let` destructures `number` into\n"
+"    // `Some(i)`, evaluate the block (`{}`).\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:31 src/flow_control/if_let.md:36
+#: src/flow_control/if_let.md:46
+msgid "\"Matched {:?}!\""
+msgstr ""
+
+#: src/flow_control/if_let.md:34
+msgid "// If you need to specify a failure, use an else:\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:38
+msgid "// Destructure failed. Change to the failure case.\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:39 src/flow_control/if_let.md:50
+msgid "\"Didn't match a number. Let's go with a letter!\""
+msgstr ""
+
+#: src/flow_control/if_let.md:42
+msgid "// Provide an altered failing condition.\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:47
+msgid ""
+"// Destructure failed. Evaluate an `else if` condition to see if the\n"
+"    // alternate failure branch should be taken:\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:52
+msgid "// The condition evaluated false. This branch is the default:\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:53
+msgid "\"I don't like letters. Let's go with an emoticon :)!\""
+msgstr ""
+
+#: src/flow_control/if_let.md:58
+msgid "In the same way, `if let` can be used to match any enum value:"
+msgstr ""
+
+#: src/flow_control/if_let.md:61
+msgid "// Our example enum\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:69
+msgid "// Create example variables\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:74 src/flow_control/if_let.md:110
+msgid "// Variable a matches Foo::Bar\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:76 src/flow_control/if_let.md:113
+msgid "\"a is foobar\""
+msgstr ""
+
+#: src/flow_control/if_let.md:79
+msgid ""
+"// Variable b does not match Foo::Bar\n"
+"    // So this will print nothing\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:82
+msgid "\"b is foobar\""
+msgstr ""
+
+#: src/flow_control/if_let.md:85
+msgid ""
+"// Variable c matches Foo::Qux which has a value\n"
+"    // Similar to Some() in the previous example\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:88
+msgid "\"c is {}\""
+msgstr ""
+
+#: src/flow_control/if_let.md:91
+msgid "// Binding also works with `if let`\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:93
+msgid "\"c is one hundred\""
+msgstr ""
+
+#: src/flow_control/if_let.md:98
+msgid ""
+"Another benefit is that `if let` allows us to match non-parameterized enum "
+"variants. This is true even in cases where the enum doesn't implement or "
+"derive `PartialEq`. In such cases `if Foo::Bar == a` would fail to compile, "
+"because instances of the enum cannot be equated, however `if let` will "
+"continue to work."
+msgstr ""
+
+#: src/flow_control/if_let.md:100
+msgid "Would you like a challenge? Fix the following example to use `if let`:"
+msgstr ""
+
+#: src/flow_control/if_let.md:103
+msgid ""
+"// This enum purposely neither implements nor derives PartialEq.\n"
+"// That is why comparing Foo::Bar == a fails below.\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:112
+msgid "// ^-- this causes a compile-time error. Use `if let` instead.\n"
+msgstr ""
+
+#: src/flow_control/if_let.md:120
+msgid ""
+"[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the [RFC]"
+"(https://github.com/rust-lang/rfcs/pull/160)"
+msgstr ""
+
+#: src/flow_control/let_else.md:4
+msgid "🛈 stable since: rust 1.65"
+msgstr ""
+
+#: src/flow_control/let_else.md:6
+msgid ""
+"🛈 you can target specific edition by compiling like this `rustc --"
+"edition=2021 main.rs`"
+msgstr ""
+
+#: src/flow_control/let_else.md:10
+msgid ""
+"With `let`\\-`else`, a refutable pattern can match and bind variables in the "
+"surrounding scope like a normal `let`, or else diverge (e.g. `break`, "
+"`return`, `panic!`) when the pattern doesn't match."
+msgstr ""
+
+#: src/flow_control/let_else.md:18 src/flow_control/let_else.md:41
+#: src/std/str.md:41
+msgid "' '"
+msgstr ""
+
+#: src/flow_control/let_else.md:20 src/flow_control/let_else.md:44
+msgid "\"Can't segment count item pair: '{s}'\""
+msgstr ""
+
+#: src/flow_control/let_else.md:23 src/flow_control/let_else.md:49
+msgid "\"Can't parse integer: '{count_str}'\""
+msgstr ""
+
+#: src/flow_control/let_else.md:29 src/flow_control/let_else.md:54
+msgid "\"3 chairs\""
+msgstr ""
+
+#: src/flow_control/let_else.md:29 src/flow_control/let_else.md:54
+msgid "\"chairs\""
+msgstr ""
+
+#: src/flow_control/let_else.md:33
+msgid ""
+"The scope of name bindings is the main thing that makes this different from "
+"`match` or `if let`\\-`else` expressions. You could previously approximate "
+"these patterns with an unfortunate bit of repetition and an outer `let`:"
+msgstr ""
+
+#: src/flow_control/let_else.md:59
+msgid ""
+"[option](../std/option.md), [match](./match.md), [if let](./if_let.md) and "
+"the [let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
+msgstr ""
+
+#: src/flow_control/while_let.md:3
+msgid ""
+"Similar to `if let`, `while let` can make awkward `match` sequences more "
+"tolerable. Consider the following sequence that increments `i`:"
+msgstr ""
+
+#: src/flow_control/while_let.md:9
+msgid "// Repeatedly try this test.\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:13
+msgid "// If `optional` destructures, evaluate the block.\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:16 src/flow_control/while_let.md:42
+msgid "\"Greater than 9, quit!\""
+msgstr ""
+
+#: src/flow_control/while_let.md:19 src/flow_control/while_let.md:45
+msgid "\"`i` is `{:?}`. Try again.\""
+msgstr ""
+
+#: src/flow_control/while_let.md:22
+msgid "// ^ Requires 3 indentations!\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:24
+msgid "// Quit the loop when the destructure fails:\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:26
+msgid "// ^ Why should this be required? There must be a better way!\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:31
+msgid "Using `while let` makes this sequence much nicer:"
+msgstr ""
+
+#: src/flow_control/while_let.md:38
+msgid ""
+"// This reads: \"while `let` destructures `optional` into\n"
+"    // `Some(i)`, evaluate the block (`{}`). Else `break`.\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:48
+msgid ""
+"// ^ Less rightward drift and doesn't require\n"
+"        // explicitly handling the failing case.\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:51
+msgid ""
+"// ^ `if let` had additional optional `else`/`else if`\n"
+"    // clauses. `while let` does not have these.\n"
+msgstr ""
+
+#: src/flow_control/while_let.md:58
+msgid ""
+"[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the [RFC]"
+"(https://github.com/rust-lang/rfcs/pull/214)"
+msgstr ""
+
+#: src/fn.md:3
+msgid ""
+"Functions are declared using the `fn` keyword. Its arguments are type "
+"annotated, just like variables, and, if the function returns a value, the "
+"return type must be specified after an arrow `->`."
+msgstr ""
+
+#: src/fn.md:7
+msgid ""
+"The final expression in the function will be used as return value. "
+"Alternatively, the `return` statement can be used to return a value earlier "
+"from within the function, even from inside loops or `if` statements."
+msgstr ""
+
+#: src/fn.md:11
+msgid "Let's rewrite FizzBuzz using functions!"
+msgstr ""
+
+#: src/fn.md:14
+msgid ""
+"// Unlike C/C++, there's no restriction on the order of function definitions\n"
+msgstr ""
+
+#: src/fn.md:16
+msgid "// We can use this function here, and define it somewhere later\n"
+msgstr ""
+
+#: src/fn.md:19
+msgid "// Function that returns a boolean value\n"
+msgstr ""
+
+#: src/fn.md:22
+msgid "// Corner case, early return\n"
+msgstr ""
+
+#: src/fn.md:27
+msgid "// This is an expression, the `return` keyword is not necessary here\n"
+msgstr ""
+
+#: src/fn.md:30
+msgid ""
+"// Functions that \"don't\" return a value, actually return the unit type "
+"`()`\n"
+msgstr ""
+
+#: src/fn.md:43
+msgid ""
+"// When a function returns `()`, the return type can be omitted from the\n"
+"// signature\n"
+msgstr ""
+
+#: src/fn/methods.md:1
+msgid "Associated functions & Methods"
+msgstr ""
+
+#: src/fn/methods.md:3
+msgid ""
+"Some functions are connected to a particular type. These come in two forms: "
+"associated functions, and methods. Associated functions are functions that "
+"are defined on a type generally, while methods are associated functions that "
+"are called on a particular instance of a type."
+msgstr ""
+
+#: src/fn/methods.md:13
+msgid ""
+"// Implementation block, all `Point` associated functions & methods go in "
+"here\n"
+msgstr ""
+
+#: src/fn/methods.md:16
+msgid ""
+"// This is an \"associated function\" because this function is associated "
+"with\n"
+"    // a particular type, that is, Point.\n"
+"    //\n"
+"    // Associated functions don't need to be called with an instance.\n"
+"    // These functions are generally used like constructors.\n"
+msgstr ""
+
+#: src/fn/methods.md:25
+msgid "// Another associated function, taking two arguments:\n"
+msgstr ""
+
+#: src/fn/methods.md:37
+msgid ""
+"// This is a method\n"
+"    // `&self` is sugar for `self: &Self`, where `Self` is the type of the\n"
+"    // caller object. In this case `Self` = `Rectangle`\n"
+msgstr ""
+
+#: src/fn/methods.md:41
+msgid "// `self` gives access to the struct fields via the dot operator\n"
+msgstr ""
+
+#: src/fn/methods.md:45
+msgid ""
+"// `abs` is a `f64` method that returns the absolute value of the\n"
+"        // caller\n"
+msgstr ""
+
+#: src/fn/methods.md:57
+msgid ""
+"// This method requires the caller object to be mutable\n"
+"    // `&mut self` desugars to `self: &mut Self`\n"
+msgstr ""
+
+#: src/fn/methods.md:67
+msgid "// `Pair` owns resources: two heap allocated integers\n"
+msgstr ""
+
+#: src/fn/methods.md:72
+msgid ""
+"// This method \"consumes\" the resources of the caller object\n"
+"    // `self` desugars to `self: Self`\n"
+msgstr ""
+
+#: src/fn/methods.md:75
+msgid "// Destructure `self`\n"
+msgstr ""
+
+#: src/fn/methods.md:78
+msgid "\"Destroying Pair({}, {})\""
+msgstr ""
+
+#: src/fn/methods.md:80
+msgid "// `first` and `second` go out of scope and get freed\n"
+msgstr ""
+
+#: src/fn/methods.md:86
+msgid "// Associated functions are called using double colons\n"
+msgstr ""
+
+#: src/fn/methods.md:91
+msgid ""
+"// Methods are called using the dot operator\n"
+"    // Note that the first argument `&self` is implicitly passed, i.e.\n"
+"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
+msgstr ""
+
+#: src/fn/methods.md:94
+msgid "\"Rectangle perimeter: {}\""
+msgstr ""
+
+#: src/fn/methods.md:95
+msgid "\"Rectangle area: {}\""
+msgstr ""
+
+#: src/fn/methods.md:102
+msgid ""
+"// Error! `rectangle` is immutable, but this method requires a mutable\n"
+"    // object\n"
+"    //rectangle.translate(1.0, 0.0);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/fn/methods.md:107
+msgid "// Okay! Mutable objects can call mutable methods\n"
+msgstr ""
+
+#: src/fn/methods.md:114
+msgid ""
+"// Error! Previous `destroy` call \"consumed\" `pair`\n"
+"    //pair.destroy();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/fn/closures.md:3
+msgid ""
+"Closures are functions that can capture the enclosing environment. For "
+"example, a closure that captures the `x` variable:"
+msgstr ""
+
+#: src/fn/closures.md:10
+msgid ""
+"The syntax and capabilities of closures make them very convenient for on the "
+"fly usage. Calling a closure is exactly like calling a function. However, "
+"both input and return types _can_ be inferred and input variable names _must_ "
+"be specified."
+msgstr ""
+
+#: src/fn/closures.md:15
+msgid "Other characteristics of closures include:"
+msgstr ""
+
+#: src/fn/closures.md:16
+msgid "using `||` instead of `()` around input variables."
+msgstr ""
+
+#: src/fn/closures.md:17
+msgid ""
+"optional body delimitation (`{}`) for a single line expression (mandatory "
+"otherwise)."
+msgstr ""
+
+#: src/fn/closures.md:18
+msgid "the ability to capture the outer environment variables."
+msgstr ""
+
+#: src/fn/closures.md:24
+msgid ""
+"// A regular function can't refer to variables in the enclosing environment\n"
+"    //fn function(i: i32) -> i32 { i + outer_var }\n"
+"    // TODO: uncomment the line above and see the compiler error. The "
+"compiler\n"
+"    // suggests that we define a closure instead.\n"
+msgstr ""
+
+#: src/fn/closures.md:29
+msgid ""
+"// Closures are anonymous, here we are binding them to references.\n"
+"    // Annotation is identical to function annotation but is optional\n"
+"    // as are the `{}` wrapping the body. These nameless functions\n"
+"    // are assigned to appropriately named variables.\n"
+msgstr ""
+
+#: src/fn/closures.md:36
+msgid "// Call the closures.\n"
+msgstr ""
+
+#: src/fn/closures.md:37
+msgid "\"closure_annotated: {}\""
+msgstr ""
+
+#: src/fn/closures.md:38
+msgid "\"closure_inferred: {}\""
+msgstr ""
+
+#: src/fn/closures.md:39
+msgid ""
+"// Once closure's type has been inferred, it cannot be inferred again with "
+"another type.\n"
+"    //println!(\"cannot reuse closure_inferred with another type: {}\", "
+"closure_inferred(42i64));\n"
+"    // TODO: uncomment the line above and see the compiler error.\n"
+msgstr ""
+
+#: src/fn/closures.md:43
+msgid ""
+"// A closure taking no arguments which returns an `i32`.\n"
+"    // The return type is inferred.\n"
+msgstr ""
+
+#: src/fn/closures.md:46
+msgid "\"closure returning one: {}\""
+msgstr ""
+
+#: src/fn/closures/capture.md:3
+msgid ""
+"Closures are inherently flexible and will do what the functionality requires "
+"to make the closure work without annotation. This allows capturing to "
+"flexibly adapt to the use case, sometimes moving and sometimes borrowing. "
+"Closures can capture variables:"
+msgstr ""
+
+#: src/fn/closures/capture.md:8
+msgid "by reference: `&T`"
+msgstr ""
+
+#: src/fn/closures/capture.md:9
+msgid "by mutable reference: `&mut T`"
+msgstr ""
+
+#: src/fn/closures/capture.md:10
+msgid "by value: `T`"
+msgstr ""
+
+#: src/fn/closures/capture.md:12
+msgid ""
+"They preferentially capture variables by reference and only go lower when "
+"required."
+msgstr ""
+
+#: src/fn/closures/capture.md:19
+msgid "\"green\""
+msgstr ""
+
+#: src/fn/closures/capture.md:21
+msgid ""
+"// A closure to print `color` which immediately borrows (`&`) `color` and\n"
+"    // stores the borrow and closure in the `print` variable. It will remain\n"
+"    // borrowed until `print` is used the last time. \n"
+"    //\n"
+"    // `println!` only requires arguments by immutable reference so it "
+"doesn't\n"
+"    // impose anything more restrictive.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:27
+msgid "\"`color`: {}\""
+msgstr ""
+
+#: src/fn/closures/capture.md:29
+msgid "// Call the closure using the borrow.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:32
+msgid ""
+"// `color` can be borrowed immutably again, because the closure only holds\n"
+"    // an immutable reference to `color`. \n"
+msgstr ""
+
+#: src/fn/closures/capture.md:37
+msgid "// A move or reborrow is allowed after the final use of `print`\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:42
+msgid ""
+"// A closure to increment `count` could take either `&mut count` or `count`\n"
+"    // but `&mut count` is less restrictive so it takes that. Immediately\n"
+"    // borrows `count`.\n"
+"    //\n"
+"    // A `mut` is required on `inc` because a `&mut` is stored inside. Thus,\n"
+"    // calling the closure mutates `count` which requires a `mut`.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:50
+msgid "\"`count`: {}\""
+msgstr ""
+
+#: src/fn/closures/capture.md:53
+msgid "// Call the closure using a mutable borrow.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:56
+msgid ""
+"// The closure still mutably borrows `count` because it is called later.\n"
+"    // An attempt to reborrow will lead to an error.\n"
+"    // let _reborrow = &count; \n"
+"    // ^ TODO: try uncommenting this line.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:62
+msgid ""
+"// The closure no longer needs to borrow `&mut count`. Therefore, it is\n"
+"    // possible to reborrow without an error\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:67
+msgid "// A non-copy type.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:70
+msgid ""
+"// `mem::drop` requires `T` so this must take by value. A copy type\n"
+"    // would copy into the closure leaving the original untouched.\n"
+"    // A non-copy must move and so `movable` immediately moves into\n"
+"    // the closure.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:75
+msgid "\"`movable`: {:?}\""
+msgstr ""
+
+#: src/fn/closures/capture.md:79
+msgid "// `consume` consumes the variable so this can only be called once.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:81
+msgid ""
+"// consume();\n"
+"    // ^ TODO: Try uncommenting this line.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:86
+msgid ""
+"Using `move` before vertical pipes forces closure to take ownership of "
+"captured variables:"
+msgstr ""
+
+#: src/fn/closures/capture.md:91
+msgid "// `Vec` has non-copy semantics.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:99
+msgid ""
+"// println!(\"There're {} elements in vec\", haystack.len());\n"
+"    // ^ Uncommenting above line will result in compile-time error\n"
+"    // because borrow checker doesn't allow re-using variable after it\n"
+"    // has been moved.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:104
+msgid ""
+"// Removing `move` from closure's signature will cause closure\n"
+"    // to borrow _haystack_ variable immutably, hence _haystack_ is still\n"
+"    // available and uncommenting above line will not cause an error.\n"
+msgstr ""
+
+#: src/fn/closures/capture.md:112
+msgid ""
+"[`Box`](../../std/box.md) and [`std::mem::drop`](https://doc.rust-lang.org/"
+"std/mem/fn.drop.html)"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:3
+msgid ""
+"While Rust chooses how to capture variables on the fly mostly without type "
+"annotation, this ambiguity is not allowed when writing functions. When taking "
+"a closure as an input parameter, the closure's complete type must be "
+"annotated using one of a few `traits`, and they're determined by what the "
+"closure does with captured value. In order of decreasing restriction, they "
+"are:"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:10
+msgid "`Fn`: the closure uses the captured value by reference (`&T`)"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:11
+msgid ""
+"`FnMut`: the closure uses the captured value by mutable reference (`&mut T`)"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:12
+msgid "`FnOnce`: the closure uses the captured value by value (`T`)"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:14
+msgid ""
+"On a variable-by-variable basis, the compiler will capture variables in the "
+"least restrictive manner possible."
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:17
+msgid ""
+"For instance, consider a parameter annotated as `FnOnce`. This specifies that "
+"the closure _may_ capture by `&T`, `&mut T`, or `T`, but the compiler will "
+"ultimately choose based on how the captured variables are used in the closure."
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:22
+msgid ""
+"This is because if a move is possible, then any type of borrow should also be "
+"possible. Note that the reverse is not true. If the parameter is annotated as "
+"`Fn`, then capturing variables by `&mut T` or `T` are not allowed. However, "
+"`&T` is allowed."
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:27
+msgid ""
+"In the following example, try swapping the usage of `Fn`, `FnMut`, and "
+"`FnOnce` to see what happens:"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:31
+msgid ""
+"// A function which takes a closure as an argument and calls it.\n"
+"// <F> denotes that F is a \"Generic type parameter\"\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:34
+msgid "// The closure takes no input and returns nothing.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:36
+msgid "// ^ TODO: Try changing this to `Fn` or `FnMut`.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:40
+msgid "// A function which takes a closure and returns an `i32`.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:43
+msgid "// The closure takes an `i32` and returns an `i32`.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:53
+msgid ""
+"// A non-copy type.\n"
+"    // `to_owned` creates owned data from borrowed one\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:55
+msgid "\"goodbye\""
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:57
+msgid ""
+"// Capture 2 variables: `greeting` by reference and\n"
+"    // `farewell` by value.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:60
+msgid "// `greeting` is by reference: requires `Fn`.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:61
+msgid "\"I said {}.\""
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:63
+msgid ""
+"// Mutation forces `farewell` to be captured by\n"
+"        // mutable reference. Now requires `FnMut`.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:65
+msgid "\"!!!\""
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:66
+msgid "\"Then I screamed {}.\""
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:67
+msgid "\"Now I can sleep. zzzzz\""
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:69
+msgid ""
+"// Manually calling drop forces `farewell` to\n"
+"        // be captured by value. Now requires `FnOnce`.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:74
+msgid "// Call the function which applies the closure.\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:77
+msgid "// `double` satisfies `apply_to_3`'s trait bound\n"
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:80
+msgid "\"3 doubled: {}\""
+msgstr ""
+
+#: src/fn/closures/input_parameters.md:86
+msgid ""
+"[`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html), [`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://doc.rust-"
+"lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md), [where]"
+"(../../generics/where.md) and [`FnOnce`](https://doc.rust-lang.org/std/ops/"
+"trait.FnOnce.html)"
+msgstr ""
+
+#: src/fn/closures/anonymity.md:3
+msgid ""
+"Closures succinctly capture variables from enclosing scopes. Does this have "
+"any consequences? It surely does. Observe how using a closure as a function "
+"parameter requires [generics](../../generics.md), which is necessary because "
+"of how they are defined:"
+msgstr ""
+
+#: src/fn/closures/anonymity.md:9
+msgid "// `F` must be generic.\n"
+msgstr ""
+
+#: src/fn/closures/anonymity.md:16
+msgid ""
+"When a closure is defined, the compiler implicitly creates a new anonymous "
+"structure to store the captured variables inside, meanwhile implementing the "
+"functionality via one of the `traits`: `Fn`, `FnMut`, or `FnOnce` for this "
+"unknown type. This type is assigned to the variable which is stored until "
+"calling."
+msgstr ""
+
+#: src/fn/closures/anonymity.md:22
+msgid ""
+"Since this new type is of unknown type, any usage in a function will require "
+"generics. However, an unbounded type parameter `<T>` would still be ambiguous "
+"and not be allowed. Thus, bounding by one of the `traits`: `Fn`, `FnMut`, or "
+"`FnOnce` (which it implements) is sufficient to specify its type."
+msgstr ""
+
+#: src/fn/closures/anonymity.md:28
+msgid ""
+"// `F` must implement `Fn` for a closure which takes no\n"
+"// inputs and returns nothing - exactly what is required\n"
+"// for `print`.\n"
+msgstr ""
+
+#: src/fn/closures/anonymity.md:39
+msgid ""
+"// Capture `x` into an anonymous type and implement\n"
+"    // `Fn` for it. Store it in `print`.\n"
+msgstr ""
+
+#: src/fn/closures/anonymity.md:49
+msgid ""
+"[A thorough analysis](https://huonw.github.io/blog/2015/05/finding-closure-in-"
+"rust/), [`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://"
+"doc.rust-lang.org/std/ops/trait.FnOnce.html)"
+msgstr ""
+
+#: src/fn/closures/input_functions.md:3
+msgid ""
+"Since closures may be used as arguments, you might wonder if the same can be "
+"said about functions. And indeed they can! If you declare a function that "
+"takes a closure as parameter, then any function that satisfies the trait "
+"bound of that closure can be passed as a parameter."
+msgstr ""
+
+#: src/fn/closures/input_functions.md:9
+msgid ""
+"// Define a function which takes a generic `F` argument\n"
+"// bounded by `Fn`, and calls it\n"
+msgstr ""
+
+#: src/fn/closures/input_functions.md:14
+msgid "// Define a wrapper function satisfying the `Fn` bound\n"
+msgstr ""
+
+#: src/fn/closures/input_functions.md:17
+msgid "\"I'm a function!\""
+msgstr ""
+
+#: src/fn/closures/input_functions.md:21
+msgid "// Define a closure satisfying the `Fn` bound\n"
+msgstr ""
+
+#: src/fn/closures/input_functions.md:22
+msgid "\"I'm a closure!\""
+msgstr ""
+
+#: src/fn/closures/input_functions.md:29
+msgid ""
+"As an additional note, the `Fn`, `FnMut`, and `FnOnce` `traits` dictate how a "
+"closure captures variables from the enclosing scope."
+msgstr ""
+
+#: src/fn/closures/input_functions.md:34
+msgid ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://doc.rust-"
+"lang.org/std/ops/trait.FnOnce.html)"
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:3
+msgid ""
+"Closures as input parameters are possible, so returning closures as output "
+"parameters should also be possible. However, anonymous closure types are, by "
+"definition, unknown, so we have to use `impl Trait` to return them."
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:8
+msgid "The valid traits for returning a closure are:"
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:10
+msgid "`Fn`"
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:11
+msgid "`FnMut`"
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:12
+msgid "`FnOnce`"
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:14
+msgid ""
+"Beyond this, the `move` keyword must be used, which signals that all captures "
+"occur by value. This is required because any captures by reference would be "
+"dropped as soon as the function exited, leaving invalid references in the "
+"closure."
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:21
+msgid "\"Fn\""
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:23
+#: src/fn/closures/output_parameters.md:29
+#: src/fn/closures/output_parameters.md:35
+msgid "\"This is a: {}\""
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:27
+msgid "\"FnMut\""
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:33
+msgid "\"FnOnce\""
+msgstr ""
+
+#: src/fn/closures/output_parameters.md:51
+msgid ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html), [`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md) "
+"and [impl Trait](../../trait/impl_trait.md)."
+msgstr ""
+
+#: src/fn/closures/closure_examples.md:3
+msgid ""
+"This section contains a few examples of using closures from the `std` library."
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:3
+msgid ""
+"`Iterator::any` is a function which when passed an iterator, will return "
+"`true` if any element satisfies the predicate. Otherwise `false`. Its "
+"signature:"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:9
+#: src/fn/closures/closure_examples/iter_find.md:9
+msgid "// The type being iterated over.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:12
+msgid ""
+"// `any` takes `&mut self` meaning the caller may be borrowed\n"
+"    // and modified, but not consumed.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:15
+msgid ""
+"// `FnMut` meaning any captured variable may at most be\n"
+"        // modified, not consumed. `Self::Item` states it takes\n"
+"        // arguments to the closure by value.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:27
+msgid "// `iter()` for vecs yields `&i32`. Destructure to `i32`.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:28
+msgid "\"2 in vec1: {}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:29
+msgid "// `into_iter()` for vecs yields `i32`. No destructuring required.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:30
+msgid "\"2 in vec2: {}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:32
+msgid ""
+"// `iter()` only borrows `vec1` and its elements, so they can be used again\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:33
+msgid "\"vec1 len: {}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:34
+msgid "\"First element of vec1 is: {}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:35
+msgid ""
+"// `into_iter()` does move `vec2` and its elements, so they cannot be used "
+"again\n"
+"    // println!(\"First element of vec2 is: {}\", vec2[0]);\n"
+"    // println!(\"vec2 len: {}\", vec2.len());\n"
+"    // TODO: uncomment two lines above and see compiler errors.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:43
+msgid "// `iter()` for arrays yields `&i32`.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:44
+msgid "\"2 in array1: {}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:45
+msgid "// `into_iter()` for arrays yields `i32`.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:46
+msgid "\"2 in array2: {}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_any.md:52
+msgid ""
+"[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.any)"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:3
+msgid ""
+"`Iterator::find` is a function which iterates over an iterator and searches "
+"for the first value which satisfies some condition. If none of the values "
+"satisfy the condition, it returns `None`. Its signature:"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:12
+msgid ""
+"// `find` takes `&mut self` meaning the caller may be borrowed\n"
+"    // and modified, but not consumed.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:15
+msgid ""
+"// `FnMut` meaning any captured variable may at most be\n"
+"        // modified, not consumed. `&Self::Item` states it takes\n"
+"        // arguments to the closure by reference.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:27
+msgid "// `iter()` for vecs yields `&i32`.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:29
+msgid "// `into_iter()` for vecs yields `i32`.\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:32
+msgid ""
+"// `iter()` for vecs yields `&i32`, and we want to reference one of its\n"
+"    // items, so we have to destructure `&&i32` to `i32`\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:34
+msgid "\"Find 2 in vec1: {:?}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:35
+msgid ""
+"// `into_iter()` for vecs yields `i32`, and we want to reference one of\n"
+"    // its items, so we have to destructure `&i32` to `i32`\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:37
+msgid "\"Find 2 in vec2: {:?}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:42
+msgid "// `iter()` for arrays yields `&&i32`\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:43
+msgid "\"Find 2 in array1: {:?}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:44
+msgid "// `into_iter()` for arrays yields `&i32`\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:45
+msgid "\"Find 2 in array2: {:?}\""
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:49
+msgid ""
+"`Iterator::find` gives you a reference to the item. But if you want the "
+"_index_ of the item, use `Iterator::position`."
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:56
+msgid ""
+"// `iter()` for vecs yields `&i32` and `position()` does not take a "
+"reference, so\n"
+"    // we have to destructure `&i32` to `i32`\n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:61
+msgid ""
+"// `into_iter()` for vecs yields `i32` and `position()` does not take a "
+"reference, so\n"
+"    // we do not have to destructure    \n"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:70
+msgid ""
+"[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find)"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:72
+msgid ""
+"[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find_map)"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:74
+msgid ""
+"[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.position)"
+msgstr ""
+
+#: src/fn/closures/closure_examples/iter_find.md:76
+msgid ""
+"[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.rposition)"
+msgstr ""
+
+#: src/fn/hof.md:3
+msgid ""
+"Rust provides Higher Order Functions (HOF). These are functions that take one "
+"or more functions and/or produce a more useful function. HOFs and lazy "
+"iterators give Rust its functional flavor."
+msgstr ""
+
+#: src/fn/hof.md:13
+msgid "\"Find the sum of all the numbers with odd squares under 1000\""
+msgstr ""
+
+#: src/fn/hof.md:16
+msgid ""
+"// Imperative approach\n"
+"    // Declare accumulator variable\n"
+msgstr ""
+
+#: src/fn/hof.md:19
+msgid "// Iterate: 0, 1, 2, ... to infinity\n"
+msgstr ""
+
+#: src/fn/hof.md:21
+msgid "// Square the number\n"
+msgstr ""
+
+#: src/fn/hof.md:25
+msgid "// Break loop if exceeded the upper limit\n"
+msgstr ""
+
+#: src/fn/hof.md:28
+msgid "// Accumulate value, if it's odd\n"
+msgstr ""
+
+#: src/fn/hof.md:32
+msgid "\"imperative style: {}\""
+msgstr ""
+
+#: src/fn/hof.md:34
+msgid "// Functional approach\n"
+msgstr ""
+
+#: src/fn/hof.md:36
+msgid "// All natural numbers squared\n"
+msgstr ""
+
+#: src/fn/hof.md:37
+msgid "// Below upper limit\n"
+msgstr ""
+
+#: src/fn/hof.md:38
+msgid "// That are odd\n"
+msgstr ""
+
+#: src/fn/hof.md:39
+msgid "// Sum them\n"
+msgstr ""
+
+#: src/fn/hof.md:40
+msgid "\"functional style: {}\""
+msgstr ""
+
+#: src/fn/hof.md:44
+msgid ""
+"[Option](https://doc.rust-lang.org/core/option/enum.Option.html) and "
+"[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) implement "
+"their fair share of HOFs."
+msgstr ""
+
+#: src/fn/diverging.md:3
+msgid ""
+"Diverging functions never return. They are marked using `!`, which is an "
+"empty type."
+msgstr ""
+
+#: src/fn/diverging.md:7 src/fn/diverging.md:35
+msgid "\"This call never returns.\""
+msgstr ""
+
+#: src/fn/diverging.md:11
+msgid ""
+"As opposed to all the other types, this one cannot be instantiated, because "
+"the set of all possible values this type can have is empty. Note that, it is "
+"different from the `()` type, which has exactly one possible value."
+msgstr ""
+
+#: src/fn/diverging.md:15
+msgid ""
+"For example, this function returns as usual, although there is no information "
+"in the return value."
+msgstr ""
+
+#: src/fn/diverging.md:25
+msgid "\"This function returns and you can see this line.\""
+msgstr ""
+
+#: src/fn/diverging.md:29
+msgid ""
+"As opposed to this function, which will never return the control back to the "
+"caller."
+msgstr ""
+
+#: src/fn/diverging.md:36
+msgid "\"You will never see this line!\""
+msgstr ""
+
+#: src/fn/diverging.md:40
+msgid ""
+"Although this might seem like an abstract concept, it is actually very useful "
+"and often handy. The main advantage of this type is that it can be cast to "
+"any other type, making it versatile in situations where an exact type is "
+"required, such as in match branches. This flexibility allows us to write code "
+"like this:"
+msgstr ""
+
+#: src/fn/diverging.md:50
+msgid ""
+"// Notice that the return type of this match expression must be u32\n"
+"            // because of the type of the \"addition\" variable.\n"
+msgstr ""
+
+#: src/fn/diverging.md:53
+msgid "// The \"i\" variable is of type u32, which is perfectly fine.\n"
+msgstr ""
+
+#: src/fn/diverging.md:55
+msgid ""
+"// On the other hand, the \"continue\" expression does not return\n"
+"                // u32, but it is still fine, because it never returns and "
+"therefore\n"
+"                // does not violate the type requirements of the match "
+"expression.\n"
+msgstr ""
+
+#: src/fn/diverging.md:64
+msgid "\"Sum of odd numbers up to 9 (excluding): {}\""
+msgstr ""
+
+#: src/fn/diverging.md:68
+msgid ""
+"It is also the return type of functions that loop forever (e.g. `loop {}`) "
+"like network servers or functions that terminate the process (e.g. `exit()`)."
+msgstr ""
+
+#: src/mod.md:3
+msgid ""
+"Rust provides a powerful module system that can be used to hierarchically "
+"split code in logical units (modules), and manage visibility (public/private) "
+"between them."
+msgstr ""
+
+#: src/mod.md:7
+msgid ""
+"A module is a collection of items: functions, structs, traits, `impl` blocks, "
+"and even other modules."
+msgstr ""
+
+#: src/mod/visibility.md:3
+msgid ""
+"By default, the items in a module have private visibility, but this can be "
+"overridden with the `pub` modifier. Only the public items of a module can be "
+"accessed from outside the module scope."
+msgstr ""
+
+#: src/mod/visibility.md:8
+msgid "// A module named `my_mod`\n"
+msgstr ""
+
+#: src/mod/visibility.md:10
+msgid "// Items in modules default to private visibility.\n"
+msgstr ""
+
+#: src/mod/visibility.md:12
+msgid "\"called `my_mod::private_function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:15
+msgid "// Use the `pub` modifier to override default visibility.\n"
+msgstr ""
+
+#: src/mod/visibility.md:17
+msgid "\"called `my_mod::function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:20
+msgid ""
+"// Items can access other items in the same module,\n"
+"    // even when private.\n"
+msgstr ""
+
+#: src/mod/visibility.md:23
+msgid "\"called `my_mod::indirect_access()`, that\\n> \""
+msgstr ""
+
+#: src/mod/visibility.md:27
+msgid "// Modules can also be nested\n"
+msgstr ""
+
+#: src/mod/visibility.md:30
+msgid "\"called `my_mod::nested::function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:35
+msgid "\"called `my_mod::nested::private_function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:38
+msgid ""
+"// Functions declared using `pub(in path)` syntax are only visible\n"
+"        // within the given path. `path` must be a parent or ancestor module\n"
+msgstr ""
+
+#: src/mod/visibility.md:41
+msgid "\"called `my_mod::nested::public_function_in_my_mod()`, that\\n> \""
+msgstr ""
+
+#: src/mod/visibility.md:45
+msgid ""
+"// Functions declared using `pub(self)` syntax are only visible within\n"
+"        // the current module, which is the same as leaving them private\n"
+msgstr ""
+
+#: src/mod/visibility.md:48
+msgid "\"called `my_mod::nested::public_function_in_nested()`\""
+msgstr ""
+
+#: src/mod/visibility.md:51
+msgid ""
+"// Functions declared using `pub(super)` syntax are only visible within\n"
+"        // the parent module\n"
+msgstr ""
+
+#: src/mod/visibility.md:54
+msgid "\"called `my_mod::nested::public_function_in_super_mod()`\""
+msgstr ""
+
+#: src/mod/visibility.md:59
+msgid "\"called `my_mod::call_public_function_in_my_mod()`, that\\n> \""
+msgstr ""
+
+#: src/mod/visibility.md:61
+msgid "\"> \""
+msgstr ""
+
+#: src/mod/visibility.md:65
+msgid "// pub(crate) makes functions visible only within the current crate\n"
+msgstr ""
+
+#: src/mod/visibility.md:67
+msgid "\"called `my_mod::public_function_in_crate()`\""
+msgstr ""
+
+#: src/mod/visibility.md:70
+msgid "// Nested modules follow the same rules for visibility\n"
+msgstr ""
+
+#: src/mod/visibility.md:74
+msgid "\"called `my_mod::private_nested::function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:77
+msgid ""
+"// Private parent items will still restrict the visibility of a child item,\n"
+"        // even if it is declared as visible within a bigger scope.\n"
+msgstr ""
+
+#: src/mod/visibility.md:81
+msgid "\"called `my_mod::private_nested::restricted_function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:87 src/mod/use.md:25 src/mod/super.md:8
+#: src/mod/split.md:24
+msgid "\"called `function()`\""
+msgstr ""
+
+#: src/mod/visibility.md:91
+msgid "// Modules allow disambiguation between items that have the same name.\n"
+msgstr ""
+
+#: src/mod/visibility.md:95
+msgid ""
+"// Public items, including those inside nested modules, can be\n"
+"    // accessed from outside the parent module.\n"
+msgstr ""
+
+#: src/mod/visibility.md:101
+msgid "// pub(crate) items can be called from anywhere in the same crate\n"
+msgstr ""
+
+#: src/mod/visibility.md:104
+msgid ""
+"// pub(in path) items can only be called from within the module specified\n"
+"    // Error! function `public_function_in_my_mod` is private\n"
+"    //my_mod::nested::public_function_in_my_mod();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/visibility.md:109
+msgid ""
+"// Private items of a module cannot be directly accessed, even if\n"
+"    // nested in a public module:\n"
+msgstr ""
+
+#: src/mod/visibility.md:112
+msgid ""
+"// Error! `private_function` is private\n"
+"    //my_mod::private_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/visibility.md:116
+msgid ""
+"// Error! `private_function` is private\n"
+"    //my_mod::nested::private_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/visibility.md:120
+msgid ""
+"// Error! `private_nested` is a private module\n"
+"    //my_mod::private_nested::function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/visibility.md:124
+msgid ""
+"// Error! `private_nested` is a private module\n"
+"    //my_mod::private_nested::restricted_function();\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:3
+msgid ""
+"Structs have an extra level of visibility with their fields. The visibility "
+"defaults to private, and can be overridden with the `pub` modifier. This "
+"visibility only matters when a struct is accessed from outside the module "
+"where it is defined, and has the goal of hiding information (encapsulation)."
+msgstr ""
+
+#: src/mod/struct_visibility.md:10
+msgid "// A public struct with a public field of generic type `T`\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:15
+msgid "// A public struct with a private field of generic type `T`\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:21
+msgid "// A public constructor method\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:31
+msgid "// Public structs with public fields can be constructed as usual\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:32
+msgid "\"public information\""
+msgstr ""
+
+#: src/mod/struct_visibility.md:34
+msgid "// and their fields can be normally accessed.\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:35
+msgid "\"The open box contains: {}\""
+msgstr ""
+
+#: src/mod/struct_visibility.md:37
+msgid ""
+"// Public structs with private fields cannot be constructed using field "
+"names.\n"
+"    // Error! `ClosedBox` has private fields\n"
+"    //let closed_box = my::ClosedBox { contents: \"classified "
+"information\" };\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:42
+msgid ""
+"// However, structs with private fields can be created using\n"
+"    // public constructors\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:44
+msgid "\"classified information\""
+msgstr ""
+
+#: src/mod/struct_visibility.md:46
+msgid ""
+"// and the private fields of a public struct cannot be accessed.\n"
+"    // Error! The `contents` field is private\n"
+"    //println!(\"The closed box contains: {}\", _closed_box.contents);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/mod/struct_visibility.md:55
+msgid "[generics](../generics.md) and [methods](../fn/methods.md)"
+msgstr ""
+
+#: src/mod/use.md:3
+msgid ""
+"The `use` declaration can be used to bind a full path to a new name, for "
+"easier access. It is often used like this:"
+msgstr ""
+
+#: src/mod/use.md:18
+msgid "You can use the `as` keyword to bind imports to a different name:"
+msgstr ""
+
+#: src/mod/use.md:21
+msgid "// Bind the `deeply::nested::function` path to `other_function`.\n"
+msgstr ""
+
+#: src/mod/use.md:31
+msgid "\"called `deeply::nested::function()`\""
+msgstr ""
+
+#: src/mod/use.md:37
+msgid "// Easier access to `deeply::nested::function`\n"
+msgstr ""
+
+#: src/mod/use.md:40
+msgid "\"Entering block\""
+msgstr ""
+
+#: src/mod/use.md:42
+msgid ""
+"// This is equivalent to `use deeply::nested::function as function`.\n"
+"        // This `function()` will shadow the outer one.\n"
+msgstr ""
+
+#: src/mod/use.md:46
+msgid ""
+"// `use` bindings have a local scope. In this case, the\n"
+"        // shadowing of `function()` is only in this block.\n"
+msgstr ""
+
+#: src/mod/use.md:50
+msgid "\"Leaving block\""
+msgstr ""
+
+#: src/mod/super.md:3
+msgid ""
+"The `super` and `self` keywords can be used in the path to remove ambiguity "
+"when accessing items and to prevent unnecessary hardcoding of paths."
+msgstr ""
+
+#: src/mod/super.md:13
+msgid "\"called `cool::function()`\""
+msgstr ""
+
+#: src/mod/super.md:19 src/mod/split.md:49
+msgid "\"called `my::function()`\""
+msgstr ""
+
+#: src/mod/super.md:24
+msgid "\"called `my::cool::function()`\""
+msgstr ""
+
+#: src/mod/super.md:29
+msgid "// Let's access all the functions named `function` from this scope!\n"
+msgstr ""
+
+#: src/mod/super.md:30
+msgid "\"called `my::indirect_call()`, that\\n> \""
+msgstr ""
+
+#: src/mod/super.md:32
+msgid ""
+"// The `self` keyword refers to the current module scope - in this case "
+"`my`.\n"
+"        // Calling `self::function()` and calling `function()` directly both "
+"give\n"
+"        // the same result, because they refer to the same function.\n"
+msgstr ""
+
+#: src/mod/super.md:38
+msgid "// We can also use `self` to access another module inside `my`:\n"
+msgstr ""
+
+#: src/mod/super.md:41
+msgid ""
+"// The `super` keyword refers to the parent scope (outside the `my` module).\n"
+msgstr ""
+
+#: src/mod/super.md:44
+msgid ""
+"// This will bind to the `cool::function` in the *crate* scope.\n"
+"        // In this case the crate scope is the outermost scope.\n"
+msgstr ""
+
+#: src/mod/split.md:3
+msgid ""
+"Modules can be mapped to a file/directory hierarchy. Let's break down the "
+"[visibility example](visibility.md) in files:"
+msgstr ""
+
+#: src/mod/split.md:16
+msgid "In `split.rs`:"
+msgstr ""
+
+#: src/mod/split.md:19
+msgid ""
+"// This declaration will look for a file named `my.rs` and will\n"
+"// insert its contents inside a module named `my` under this scope\n"
+msgstr ""
+
+#: src/mod/split.md:39
+msgid "In `my.rs`:"
+msgstr ""
+
+#: src/mod/split.md:42
+msgid ""
+"// Similarly `mod inaccessible` and `mod nested` will locate the `nested.rs`\n"
+"// and `inaccessible.rs` files and insert them here under their respective\n"
+"// modules\n"
+msgstr ""
+
+#: src/mod/split.md:53
+msgid "\"called `my::private_function()`\""
+msgstr ""
+
+#: src/mod/split.md:57
+msgid "\"called `my::indirect_access()`, that\\n> \""
+msgstr ""
+
+#: src/mod/split.md:63
+msgid "In `my/nested.rs`:"
+msgstr ""
+
+#: src/mod/split.md:67
+msgid "\"called `my::nested::function()`\""
+msgstr ""
+
+#: src/mod/split.md:72
+msgid "\"called `my::nested::private_function()`\""
+msgstr ""
+
+#: src/mod/split.md:76
+msgid "In `my/inaccessible.rs`:"
+msgstr ""
+
+#: src/mod/split.md:81
+msgid "\"called `my::inaccessible::public_function()`\""
+msgstr ""
+
+#: src/mod/split.md:85
+msgid "Let's check that things still work as before:"
+msgstr ""
+
+#: src/crates.md:3
+msgid ""
+"A crate is a compilation unit in Rust. Whenever `rustc some_file.rs` is "
+"called, `some_file.rs` is treated as the _crate file_. If `some_file.rs` has "
+"`mod` declarations in it, then the contents of the module files would be "
+"inserted in places where `mod` declarations in the crate file are found, "
+"_before_ running the compiler over it. In other words, modules do _not_ get "
+"compiled individually, only crates get compiled."
+msgstr ""
+
+#: src/crates.md:10
+msgid ""
+"A crate can be compiled into a binary or into a library. By default, `rustc` "
+"will produce a binary from a crate. This behavior can be overridden by "
+"passing the `--crate-type` flag to `lib`."
+msgstr ""
+
+#: src/crates/lib.md:3
+msgid "Let's create a library, and then see how to link it to another crate."
+msgstr ""
+
+#: src/crates/lib.md:5
+msgid "In `rary.rs`:"
+msgstr ""
+
+#: src/crates/lib.md:9 src/attribute/crate.md:19
+msgid "\"called rary's `public_function()`\""
+msgstr ""
+
+#: src/crates/lib.md:13 src/attribute/crate.md:23
+msgid "\"called rary's `private_function()`\""
+msgstr ""
+
+#: src/crates/lib.md:17 src/attribute/crate.md:27
+msgid "\"called rary's `indirect_access()`, that\\n> \""
+msgstr ""
+
+#: src/crates/lib.md:29
+msgid ""
+"Libraries get prefixed with \"lib\", and by default they get named after "
+"their crate file, but this default name can be overridden by passing the `--"
+"crate-name` option to `rustc` or by using the [`crate_name` attribute](../"
+"attribute/crate.md)."
+msgstr ""
+
+#: src/crates/using_lib.md:3
+msgid ""
+"To link a crate to this new library you may use `rustc`'s `--extern` flag. "
+"All of its items will then be imported under a module named the same as the "
+"library. This module generally behaves the same way as any other module."
+msgstr ""
+
+#: src/crates/using_lib.md:8
+msgid ""
+"// extern crate rary; // May be required for Rust 2015 edition or earlier\n"
+msgstr ""
+
+#: src/crates/using_lib.md:13
+msgid ""
+"// Error! `private_function` is private\n"
+"    //rary::private_function();\n"
+msgstr ""
+
+#: src/cargo.md:3
+msgid ""
+"`cargo` is the official Rust package management tool. It has lots of really "
+"useful features to improve code quality and developer velocity! These include"
+msgstr ""
+
+#: src/cargo.md:6
+msgid ""
+"Dependency management and integration with [crates.io](https://crates.io) "
+"(the official Rust package registry)"
+msgstr ""
+
+#: src/cargo.md:8
+msgid "Awareness of unit tests"
+msgstr ""
+
+#: src/cargo.md:9
+msgid "Awareness of benchmarks"
+msgstr ""
+
+#: src/cargo.md:11
+msgid ""
+"This chapter will go through some quick basics, but you can find the "
+"comprehensive docs in [The Cargo Book](https://doc.rust-lang.org/cargo/)."
+msgstr ""
+
+#: src/cargo/deps.md:3
+msgid ""
+"Most programs have dependencies on some libraries. If you have ever managed "
+"dependencies by hand, you know how much of a pain this can be. Luckily, the "
+"Rust ecosystem comes standard with `cargo`! `cargo` can manage dependencies "
+"for a project."
+msgstr ""
+
+#: src/cargo/deps.md:8
+msgid "To create a new Rust project,"
+msgstr ""
+
+#: src/cargo/deps.md:11
+msgid "# A binary\n"
+msgstr ""
+
+#: src/cargo/deps.md:13
+msgid "# A library\n"
+msgstr ""
+
+#: src/cargo/deps.md:18
+msgid ""
+"For the rest of this chapter, let's assume we are making a binary, rather "
+"than a library, but all of the concepts are the same."
+msgstr ""
+
+#: src/cargo/deps.md:21
+msgid "After the above commands, you should see a file hierarchy like this:"
+msgstr ""
+
+#: src/cargo/deps.md:35
+msgid ""
+"The `main.rs` is the root source file for your new `foo` project -- nothing "
+"new there. The `Cargo.toml` is the config file for `cargo` for this project. "
+"If you look inside it, you should see something like this:"
+msgstr ""
+
+#: src/cargo/deps.md:39
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"```"
+msgstr ""
+
+#: src/cargo/deps.md:48
+msgid ""
+"The `name` field under `[package]` determines the name of the project. This "
+"is used by `crates.io` if you publish the crate (more later). It is also the "
+"name of the output binary when you compile."
+msgstr ""
+
+#: src/cargo/deps.md:52
+msgid ""
+"The `version` field is a crate version number using [Semantic Versioning]"
+"(http://semver.org/)."
+msgstr ""
+
+#: src/cargo/deps.md:55
+msgid "The `authors` field is a list of authors used when publishing the crate."
+msgstr ""
+
+#: src/cargo/deps.md:57
+msgid "The `[dependencies]` section lets you add dependencies for your project."
+msgstr ""
+
+#: src/cargo/deps.md:59
+msgid ""
+"For example, suppose that we want our program to have a great CLI. You can "
+"find lots of great packages on [crates.io](https://crates.io) (the official "
+"Rust package registry). One popular choice is [clap](https://crates.io/crates/"
+"clap). As of this writing, the most recent published version of `clap` is "
+"`2.27.1`. To add a dependency to our program, we can simply add the following "
+"to our `Cargo.toml` under `[dependencies]`: `clap = \"2.27.1\"`. And that's "
+"it! You can start using `clap` in your program."
+msgstr ""
+
+#: src/cargo/deps.md:67
+msgid ""
+"`cargo` also supports [other types of dependencies](https://doc.rust-lang.org/"
+"cargo/reference/specifying-dependencies.html). Here is just a small sampling:"
+msgstr ""
+
+#: src/cargo/deps.md:70
+msgid ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"clap = \"2.27.1\" # from crates.io\n"
+"rand = { git = \"https://github.com/rust-lang-nursery/rand\" } # from online "
+"repo\n"
+"bar = { path = \"../bar\" } # from a path in the local filesystem\n"
+"```"
+msgstr ""
+
+#: src/cargo/deps.md:82
+msgid ""
+"`cargo` is more than a dependency manager. All of the available configuration "
+"options are listed in the [format specification](https://doc.rust-lang.org/"
+"cargo/reference/manifest.html) of `Cargo.toml`."
+msgstr ""
+
+#: src/cargo/deps.md:86
+msgid ""
+"To build our project we can execute `cargo build` anywhere in the project "
+"directory (including subdirectories!). We can also do `cargo run` to build "
+"and run. Notice that these commands will resolve all dependencies, download "
+"crates if needed, and build everything, including your crate. (Note that it "
+"only rebuilds what it has not already built, similar to `make`)."
+msgstr ""
+
+#: src/cargo/deps.md:92
+msgid "Voila! That's all there is to it!"
+msgstr ""
+
+#: src/cargo/conventions.md:3
+msgid "In the previous chapter, we saw the following directory hierarchy:"
+msgstr ""
+
+#: src/cargo/conventions.md:12
+msgid ""
+"Suppose that we wanted to have two binaries in the same project, though. What "
+"then?"
+msgstr ""
+
+#: src/cargo/conventions.md:15
+msgid ""
+"It turns out that `cargo` supports this. The default binary name is `main`, "
+"as we saw before, but you can add additional binaries by placing them in a "
+"`bin/` directory:"
+msgstr ""
+
+#: src/cargo/conventions.md:28
+msgid ""
+"To tell `cargo` to only compile or run this binary, we just pass `cargo` the "
+"`--bin my_other_bin` flag, where `my_other_bin` is the name of the binary we "
+"want to work with."
+msgstr ""
+
+#: src/cargo/conventions.md:32
+msgid ""
+"In addition to extra binaries, `cargo` supports [more features](https://doc."
+"rust-lang.org/cargo/guide/project-layout.html) such as benchmarks, tests, and "
+"examples."
+msgstr ""
+
+#: src/cargo/conventions.md:35
+msgid "In the next chapter, we will look more closely at tests."
+msgstr ""
+
+#: src/cargo/test.md:3
+msgid ""
+"As we know testing is integral to any piece of software! Rust has first-class "
+"support for unit and integration testing ([see this chapter](https://doc.rust-"
+"lang.org/book/ch11-00-testing.html) in TRPL)."
+msgstr ""
+
+#: src/cargo/test.md:8
+msgid ""
+"From the testing chapters linked above, we see how to write unit tests and "
+"integration tests. Organizationally, we can place unit tests in the modules "
+"they test and integration tests in their own `tests/` directory:"
+msgstr ""
+
+#: src/cargo/test.md:23
+msgid ""
+"Each file in `tests` is a separate [integration test](https://doc.rust-lang."
+"org/book/ch11-03-test-organization.html#integration-tests), i.e. a test that "
+"is meant to test your library as if it were being called from a dependent "
+"crate."
+msgstr ""
+
+#: src/cargo/test.md:28
+msgid ""
+"The [Testing](../testing.md) chapter elaborates on the three different "
+"testing styles: [Unit](../testing/unit_testing.md), [Doc](../testing/"
+"doc_testing.md), and [Integration](../testing/integration_testing.md)."
+msgstr ""
+
+#: src/cargo/test.md:31
+msgid "`cargo` naturally provides an easy way to run all of your tests!"
+msgstr ""
+
+#: src/cargo/test.md:37
+msgid "You should see output like this:"
+msgstr ""
+
+#: src/cargo/test.md:39
+msgid ""
+"```shell\n"
+"$ cargo test\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 4 tests\n"
+"test test_bar ... ok\n"
+"test test_baz ... ok\n"
+"test test_foo_bar ... ok\n"
+"test test_foo ... ok\n"
+"\n"
+"test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+"```"
+msgstr ""
+
+#: src/cargo/test.md:54
+msgid "You can also run tests whose name matches a pattern:"
+msgstr ""
+
+#: src/cargo/test.md:60
+msgid ""
+"```shell\n"
+"$ cargo test test_foo\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.35 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 2 tests\n"
+"test test_foo ... ok\n"
+"test test_foo_bar ... ok\n"
+"\n"
+"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
+"```"
+msgstr ""
+
+#: src/cargo/test.md:73
+msgid ""
+"One word of caution: Cargo may run multiple tests concurrently, so make sure "
+"that they don't race with each other."
+msgstr ""
+
+#: src/cargo/test.md:76
+msgid ""
+"One example of this concurrency causing issues is if two tests output to a "
+"file, such as below:"
+msgstr ""
+
+#: src/cargo/test.md:82
+msgid "// Import the necessary modules\n"
+msgstr ""
+
+#: src/cargo/test.md:86
+msgid "// This test writes to a file\n"
+msgstr ""
+
+#: src/cargo/test.md:89 src/cargo/test.md:106
+msgid "// Opens the file ferris.txt or creates one if it doesn't exist.\n"
+msgstr ""
+
+#: src/cargo/test.md:93 src/cargo/test.md:110
+msgid "\"ferris.txt\""
+msgstr ""
+
+#: src/cargo/test.md:94 src/cargo/test.md:111
+msgid "\"Failed to open ferris.txt\""
+msgstr ""
+
+#: src/cargo/test.md:96
+msgid "// Print \"Ferris\" 5 times.\n"
+msgstr ""
+
+#: src/cargo/test.md:98
+msgid "\"Ferris\\n\""
+msgstr ""
+
+#: src/cargo/test.md:99 src/cargo/test.md:116
+msgid "\"Could not write to ferris.txt\""
+msgstr ""
+
+#: src/cargo/test.md:103
+msgid "// This test tries to write to the same file\n"
+msgstr ""
+
+#: src/cargo/test.md:113
+msgid "// Print \"Corro\" 5 times.\n"
+msgstr ""
+
+#: src/cargo/test.md:115
+msgid "\"Corro\\n\""
+msgstr ""
+
+#: src/cargo/test.md:122
+msgid "Although the intent is to get the following:"
+msgstr ""
+
+#: src/cargo/test.md:136
+msgid "What actually gets put into `ferris.txt` is this:"
+msgstr ""
+
+#: src/cargo/build_scripts.md:3
+msgid ""
+"Sometimes a normal build from `cargo` is not enough. Perhaps your crate needs "
+"some pre-requisites before `cargo` will successfully compile, things like "
+"code generation, or some native code that needs to be compiled. To solve this "
+"problem we have build scripts that Cargo can run."
+msgstr ""
+
+#: src/cargo/build_scripts.md:8
+msgid ""
+"To add a build script to your package it can either be specified in the "
+"`Cargo.toml` as follows:"
+msgstr ""
+
+#: src/cargo/build_scripts.md:11
+msgid ""
+"```toml\n"
+"[package]\n"
+"...\n"
+"build = \"build.rs\"\n"
+"```"
+msgstr ""
+
+#: src/cargo/build_scripts.md:17
+msgid ""
+"Otherwise Cargo will look for a `build.rs` file in the project directory by "
+"default."
+msgstr ""
+
+#: src/cargo/build_scripts.md:20
+msgid "How to use a build script"
+msgstr ""
+
+#: src/cargo/build_scripts.md:22
+msgid ""
+"The build script is simply another Rust file that will be compiled and "
+"invoked prior to compiling anything else in the package. Hence it can be used "
+"to fulfill pre-requisites of your crate."
+msgstr ""
+
+#: src/cargo/build_scripts.md:26
+msgid ""
+"Cargo provides the script with inputs via environment variables [specified "
+"here](https://doc.rust-lang.org/cargo/reference/environment-variables."
+"html#environment-variables-cargo-sets-for-build-scripts) that can be used."
+msgstr ""
+
+#: src/cargo/build_scripts.md:29
+msgid ""
+"The script provides output via stdout. All lines printed are written to "
+"`target/debug/build/<pkg>/output`. Further, lines prefixed with `cargo:` will "
+"be interpreted by Cargo directly and hence can be used to define parameters "
+"for the package's compilation."
+msgstr ""
+
+#: src/cargo/build_scripts.md:34
+msgid ""
+"For further specification and examples have a read of the [Cargo "
+"specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)."
+msgstr ""
+
+#: src/attribute.md:3
+msgid ""
+"An attribute is metadata applied to some module, crate or item. This metadata "
+"can be used to/for:"
+msgstr ""
+
+#: src/attribute.md:8
+msgid "[conditional compilation of code](attribute/cfg.md)"
+msgstr ""
+
+#: src/attribute.md:9
+msgid ""
+"[set crate name, version and type (binary or library)](attribute/crate.md)"
+msgstr ""
+
+#: src/attribute.md:10
+msgid ""
+"disable [lints](https://en.wikipedia.org/wiki/Lint_%28software%29) (warnings)"
+msgstr ""
+
+#: src/attribute.md:11
+msgid "enable compiler features (macros, glob imports, etc.)"
+msgstr ""
+
+#: src/attribute.md:12
+msgid "link to a foreign library"
+msgstr ""
+
+#: src/attribute.md:13
+msgid "mark functions as unit tests"
+msgstr ""
+
+#: src/attribute.md:14
+msgid "mark functions that will be part of a benchmark"
+msgstr ""
+
+#: src/attribute.md:15
+msgid ""
+"[attribute like macros](https://doc.rust-lang.org/book/ch19-06-macros."
+"html#attribute-like-macros)"
+msgstr ""
+
+#: src/attribute.md:17
+msgid ""
+"Attributes look like `#[outer_attribute]` or `#![inner_attribute]`, with the "
+"difference between them being where they apply."
+msgstr ""
+
+#: src/attribute.md:20
+msgid ""
+"`#[outer_attribute]` applies to the [item](https://doc.rust-lang.org/stable/"
+"reference/items.html) immediately following it. Some examples of items are: a "
+"function, a module declaration, a constant, a structure, an enum. Here is an "
+"example where attribute `#[derive(Debug)]` applies to the struct `Rectangle`:"
+msgstr ""
+
+#: src/attribute.md:33
+msgid ""
+"`#![inner_attribute]` applies to the enclosing [item](https://doc.rust-lang."
+"org/stable/reference/items.html) (typically a module or a crate). In other "
+"words, this attribute is interpreted as applying to the entire scope in which "
+"it's placed. Here is an example where `#![allow(unused_variables)]` applies "
+"to the whole crate (if placed in `main.rs`):"
+msgstr ""
+
+#: src/attribute.md:42
+msgid "// This would normally warn about an unused variable.\n"
+msgstr ""
+
+#: src/attribute.md:46
+msgid "Attributes can take arguments with different syntaxes:"
+msgstr ""
+
+#: src/attribute.md:48
+msgid "`#[attribute = \"value\"]`"
+msgstr ""
+
+#: src/attribute.md:49
+msgid "`#[attribute(key = \"value\")]`"
+msgstr ""
+
+#: src/attribute.md:50
+msgid "`#[attribute(value)]`"
+msgstr ""
+
+#: src/attribute.md:52
+msgid ""
+"Attributes can have multiple values and can be separated over multiple lines, "
+"too:"
+msgstr ""
+
+#: src/attribute/unused.md:3
+msgid ""
+"The compiler provides a `dead_code` [_lint_](https://en.wikipedia.org/wiki/"
+"Lint_%28software%29) that will warn about unused functions. An _attribute_ "
+"can be used to disable the lint."
+msgstr ""
+
+#: src/attribute/unused.md:9
+msgid ""
+"// `#[allow(dead_code)]` is an attribute that disables the `dead_code` lint\n"
+msgstr ""
+
+#: src/attribute/unused.md:14
+msgid "// FIXME ^ Add an attribute to suppress the warning\n"
+msgstr ""
+
+#: src/attribute/unused.md:22
+msgid ""
+"Note that in real programs, you should eliminate dead code. In these examples "
+"we'll allow dead code in some places because of the interactive nature of the "
+"examples."
+msgstr ""
+
+#: src/attribute/crate.md:3
+msgid ""
+"The `crate_type` attribute can be used to tell the compiler whether a crate "
+"is a binary or a library (and even which type of library), and the "
+"`crate_name` attribute can be used to set the name of the crate."
+msgstr ""
+
+#: src/attribute/crate.md:7
+msgid ""
+"However, it is important to note that both the `crate_type` and `crate_name` "
+"attributes have **no** effect whatsoever when using Cargo, the Rust package "
+"manager. Since Cargo is used for the majority of Rust projects, this means "
+"real-world uses of `crate_type` and `crate_name` are relatively limited."
+msgstr ""
+
+#: src/attribute/crate.md:13
+msgid "// This crate is a library\n"
+msgstr ""
+
+#: src/attribute/crate.md:14
+msgid "\"lib\""
+msgstr ""
+
+#: src/attribute/crate.md:14
+msgid "// The library is named \"rary\"\n"
+msgstr ""
+
+#: src/attribute/crate.md:16
+msgid "\"rary\""
+msgstr ""
+
+#: src/attribute/crate.md:33
+msgid ""
+"When the `crate_type` attribute is used, we no longer need to pass the `--"
+"crate-type` flag to `rustc`."
+msgstr ""
+
+#: src/attribute/cfg.md:3
+msgid ""
+"Configuration conditional checks are possible through two different operators:"
+msgstr ""
+
+#: src/attribute/cfg.md:5
+msgid "the `cfg` attribute: `#[cfg(...)]` in attribute position"
+msgstr ""
+
+#: src/attribute/cfg.md:6
+msgid "the `cfg!` macro: `cfg!(...)` in boolean expressions"
+msgstr ""
+
+#: src/attribute/cfg.md:8
+msgid ""
+"While the former enables conditional compilation, the latter conditionally "
+"evaluates to `true` or `false` literals allowing for checks at run-time. Both "
+"utilize identical argument syntax."
+msgstr ""
+
+#: src/attribute/cfg.md:12
+msgid ""
+"`cfg!`, unlike `#[cfg]`, does not remove any code and only evaluates to true "
+"or false. For example, all blocks in an if/else expression need to be valid "
+"when `cfg!` is used for the condition, regardless of what `cfg!` is "
+"evaluating."
+msgstr ""
+
+#: src/attribute/cfg.md:15
+msgid "// This function only gets compiled if the target OS is linux\n"
+msgstr ""
+
+#: src/attribute/cfg.md:16 src/attribute/cfg.md:22 src/attribute/cfg.md:31
+msgid "\"linux\""
+msgstr ""
+
+#: src/attribute/cfg.md:18
+msgid "\"You are running linux!\""
+msgstr ""
+
+#: src/attribute/cfg.md:20
+msgid ""
+"// And this function only gets compiled if the target OS is *not* linux\n"
+msgstr ""
+
+#: src/attribute/cfg.md:24
+msgid "\"You are *not* running linux!\""
+msgstr ""
+
+#: src/attribute/cfg.md:30
+msgid "\"Are you sure?\""
+msgstr ""
+
+#: src/attribute/cfg.md:32
+msgid "\"Yes. It's definitely linux!\""
+msgstr ""
+
+#: src/attribute/cfg.md:34
+msgid "\"Yes. It's definitely *not* linux!\""
+msgstr ""
+
+#: src/attribute/cfg.md:41
+msgid ""
+"[the reference](https://doc.rust-lang.org/reference/attributes."
+"html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro."
+"cfg!.html), and [macros](../macros.md)."
+msgstr ""
+
+#: src/attribute/cfg/custom.md:3
+msgid ""
+"Some conditionals like `target_os` are implicitly provided by `rustc`, but "
+"custom conditionals must be passed to `rustc` using the `--cfg` flag."
+msgstr ""
+
+#: src/attribute/cfg/custom.md:9
+msgid "\"condition met!\""
+msgstr ""
+
+#: src/attribute/cfg/custom.md:17
+msgid "Try to run this to see what happens without the custom `cfg` flag."
+msgstr ""
+
+#: src/attribute/cfg/custom.md:19
+msgid "With the custom `cfg` flag:"
+msgstr ""
+
+#: src/generics.md:3
+msgid ""
+"_Generics_ is the topic of generalizing types and functionalities to broader "
+"cases. This is extremely useful for reducing code duplication in many ways, "
+"but can call for rather involved syntax. Namely, being generic requires "
+"taking great care to specify over which types a generic type is actually "
+"considered valid. The simplest and most common use of generics is for type "
+"parameters."
+msgstr ""
+
+#: src/generics.md:10
+msgid ""
+"A type parameter is specified as generic by the use of angle brackets and "
+"upper [camel case](https://en.wikipedia.org/wiki/CamelCase): `<Aaa, Bbb, ..."
+">`. \"Generic type parameters\" are typically represented as `<T>`. In Rust, "
+"\"generic\" also describes anything that accepts one or more generic type "
+"parameters `<T>`. Any type specified as a generic type parameter is generic, "
+"and everything else is concrete (non-generic)."
+msgstr ""
+
+#: src/generics.md:16
+msgid ""
+"For example, defining a _generic function_ named `foo` that takes an argument "
+"`T` of any type:"
+msgstr ""
+
+#: src/generics.md:23
+msgid ""
+"Because `T` has been specified as a generic type parameter using `<T>`, it is "
+"considered generic when used here as `(arg: T)`. This is the case even if `T` "
+"has previously been defined as a `struct`."
+msgstr ""
+
+#: src/generics.md:27
+msgid "This example shows some of the syntax in action:"
+msgstr ""
+
+#: src/generics.md:30
+msgid "// A concrete type `A`.\n"
+msgstr ""
+
+#: src/generics.md:32
+msgid ""
+"// In defining the type `Single`, the first use of `A` is not preceded by "
+"`<A>`.\n"
+"// Therefore, `Single` is a concrete type, and `A` is defined as above.\n"
+msgstr ""
+
+#: src/generics.md:35
+msgid "//            ^ Here is `Single`s first use of the type `A`.\n"
+msgstr ""
+
+#: src/generics.md:37
+msgid ""
+"// Here, `<T>` precedes the first use of `T`, so `SingleGen` is a generic "
+"type.\n"
+"// Because the type parameter `T` is generic, it could be anything, "
+"including\n"
+"// the concrete type `A` defined at the top.\n"
+msgstr ""
+
+#: src/generics.md:44
+msgid "// `Single` is concrete and explicitly takes `A`.\n"
+msgstr ""
+
+#: src/generics.md:47
+msgid ""
+"// Create a variable `_char` of type `SingleGen<char>`\n"
+"    // and give it the value `SingleGen('a')`.\n"
+"    // Here, `SingleGen` has a type parameter explicitly specified.\n"
+msgstr ""
+
+#: src/generics.md:52
+msgid "// `SingleGen` can also have a type parameter implicitly specified:\n"
+msgstr ""
+
+#: src/generics.md:53
+msgid "// Uses `A` defined at the top.\n"
+msgstr ""
+
+#: src/generics.md:54
+msgid "// Uses `i32`.\n"
+msgstr ""
+
+#: src/generics.md:55
+msgid "// Uses `char`.\n"
+msgstr ""
+
+#: src/generics.md:61
+msgid "[`structs`](custom_types/structs.md)"
+msgstr ""
+
+#: src/generics/gen_fn.md:3
+msgid ""
+"The same set of rules can be applied to functions: a type `T` becomes generic "
+"when preceded by `<T>`."
+msgstr ""
+
+#: src/generics/gen_fn.md:6
+msgid ""
+"Using generic functions sometimes requires explicitly specifying type "
+"parameters. This may be the case if the function is called where the return "
+"type is generic, or if the compiler doesn't have enough information to infer "
+"the necessary type parameters."
+msgstr ""
+
+#: src/generics/gen_fn.md:11
+msgid ""
+"A function call with explicitly specified type parameters looks like: `fun::"
+"<A, B, ...>()`."
+msgstr ""
+
+#: src/generics/gen_fn.md:15
+msgid "// Concrete type `A`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:16
+msgid "// Concrete type `S`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:17
+msgid "// Generic type `SGen`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:18
+msgid ""
+"// The following functions all take ownership of the variable passed into\n"
+"// them and immediately go out of scope, freeing the variable.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:21
+msgid ""
+"// Define a function `reg_fn` that takes an argument `_s` of type `S`.\n"
+"// This has no `<T>` so this is not a generic function.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:25
+msgid ""
+"// Define a function `gen_spec_t` that takes an argument `_s` of type "
+"`SGen<T>`.\n"
+"// It has been explicitly given the type parameter `A`, but because `A` has "
+"not \n"
+"// been specified as a generic type parameter for `gen_spec_t`, it is not "
+"generic.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:30
+msgid ""
+"// Define a function `gen_spec_i32` that takes an argument `_s` of type "
+"`SGen<i32>`.\n"
+"// It has been explicitly given the type parameter `i32`, which is a specific "
+"type.\n"
+"// Because `i32` is not a generic type, this function is also not generic.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:35
+msgid ""
+"// Define a function `generic` that takes an argument `_s` of type "
+"`SGen<T>`.\n"
+"// Because `SGen<T>` is preceded by `<T>`, this function is generic over "
+"`T`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:41
+msgid "// Using the non-generic functions\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:42
+msgid "// Concrete type.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:43
+msgid "// Implicitly specified type parameter `A`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:44
+msgid "// Implicitly specified type parameter `i32`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:46
+msgid "// Explicitly specified type parameter `char` to `generic()`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:49
+msgid "// Implicitly specified type parameter `char` to `generic()`.\n"
+msgstr ""
+
+#: src/generics/gen_fn.md:50
+msgid "'c'"
+msgstr ""
+
+#: src/generics/gen_fn.md:56
+msgid "[functions](../fn.md) and [`struct`s](../custom_types/structs.md)"
+msgstr ""
+
+#: src/generics/impl.md:3
+msgid "Similar to functions, implementations require care to remain generic."
+msgstr ""
+
+#: src/generics/impl.md:6
+msgid "// Concrete type `S`\n"
+msgstr ""
+
+#: src/generics/impl.md:7
+msgid "// Generic type `GenericVal`\n"
+msgstr ""
+
+#: src/generics/impl.md:8
+msgid "// impl of GenericVal where we explicitly specify type parameters:\n"
+msgstr ""
+
+#: src/generics/impl.md:10
+msgid "// Specify `f32`\n"
+msgstr ""
+
+#: src/generics/impl.md:11
+msgid "// Specify `S` as defined above\n"
+msgstr ""
+
+#: src/generics/impl.md:12
+msgid "// `<T>` Must precede the type to remain generic\n"
+msgstr ""
+
+#: src/generics/impl.md:25
+msgid "// impl of Val\n"
+msgstr ""
+
+#: src/generics/impl.md:32
+msgid "// impl of GenVal for a generic type `T`\n"
+msgstr ""
+
+#: src/generics/impl.md:50
+msgid ""
+"[functions returning references](../scope/lifetime/fn.md), [`impl`](../fn/"
+"methods.md), and [`struct`](../custom_types/structs.md)"
+msgstr ""
+
+#: src/generics/gen_trait.md:3
+msgid ""
+"Of course `trait`s can also be generic. Here we define one which reimplements "
+"the `Drop` `trait` as a generic method to `drop` itself and an input."
+msgstr ""
+
+#: src/generics/gen_trait.md:7
+msgid "// Non-copyable types.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:10
+msgid "// A trait generic over `T`.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:13
+msgid ""
+"// Define a method on the caller type which takes an\n"
+"    // additional single parameter `T` and does nothing with it.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:17
+msgid ""
+"// Implement `DoubleDrop<T>` for any generic parameter `T` and\n"
+"// caller `U`.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:21
+msgid ""
+"// This method takes ownership of both passed arguments,\n"
+"    // deallocating both.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:30
+msgid "// Deallocate `empty` and `null`.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:33
+msgid ""
+"//empty;\n"
+"    //null;\n"
+"    // ^ TODO: Try uncommenting these lines.\n"
+msgstr ""
+
+#: src/generics/gen_trait.md:41
+msgid ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [`struct`](../"
+"custom_types/structs.md), and [`trait`](../trait.md)"
+msgstr ""
+
+#: src/generics/bounds.md:3
+msgid ""
+"When working with generics, the type parameters often must use traits as "
+"_bounds_ to stipulate what functionality a type implements. For example, the "
+"following example uses the trait `Display` to print and so it requires `T` to "
+"be bound by `Display`; that is, `T` _must_ implement `Display`."
+msgstr ""
+
+#: src/generics/bounds.md:9
+msgid ""
+"// Define a function `printer` that takes a generic type `T` which\n"
+"// must implement trait `Display`.\n"
+msgstr ""
+
+#: src/generics/bounds.md:16
+msgid ""
+"Bounding restricts the generic to types that conform to the bounds. That is:"
+msgstr ""
+
+#: src/generics/bounds.md:20
+msgid ""
+"// Error! `Vec<T>` does not implement `Display`. This\n"
+"// specialization will fail.\n"
+msgstr ""
+
+#: src/generics/bounds.md:26
+msgid ""
+"Another effect of bounding is that generic instances are allowed to access "
+"the [methods](../fn/methods.md) of traits specified in the bounds. For "
+"example:"
+msgstr ""
+
+#: src/generics/bounds.md:30
+msgid "// A trait which implements the print marker: `{:?}`.\n"
+msgstr ""
+
+#: src/generics/bounds.md:45
+msgid ""
+"// The generic `T` must implement `Debug`. Regardless\n"
+"// of the type, this will work properly.\n"
+msgstr ""
+
+#: src/generics/bounds.md:51
+msgid ""
+"// `T` must implement `HasArea`. Any type which meets\n"
+"// the bound can access `HasArea`'s function `area`.\n"
+msgstr ""
+
+#: src/generics/bounds.md:61
+msgid "\"Area: {}\""
+msgstr ""
+
+#: src/generics/bounds.md:63
+msgid ""
+"//print_debug(&_triangle);\n"
+"    //println!(\"Area: {}\", area(&_triangle));\n"
+"    // ^ TODO: Try uncommenting these.\n"
+"    // | Error: Does not implement either `Debug` or `HasArea`. \n"
+msgstr ""
+
+#: src/generics/bounds.md:70
+msgid ""
+"As an additional note, [`where`](../generics/where.md) clauses can also be "
+"used to apply bounds in some cases to be more expressive."
+msgstr ""
+
+#: src/generics/bounds.md:75
+msgid ""
+"[`std::fmt`](../hello/print.md), [`struct`s](../custom_types/structs.md), and "
+"[`trait`s](../trait.md)"
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:3
+msgid ""
+"A consequence of how bounds work is that even if a `trait` doesn't include "
+"any functionality, you can still use it as a bound. `Eq` and `Copy` are "
+"examples of such `trait`s from the `std` library."
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:17
+msgid ""
+"// These functions are only valid for types which implement these\n"
+"// traits. The fact that the traits are empty is irrelevant.\n"
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:20
+msgid "\"red\""
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:21
+msgid "\"blue\""
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:28
+msgid ""
+"// `red()` won't work on a blue jay nor vice versa\n"
+"    // because of the bounds.\n"
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:30
+msgid "\"A cardinal is {}\""
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:31
+msgid "\"A blue jay is {}\""
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:32
+msgid ""
+"//println!(\"A turkey is {}\", red(&_turkey));\n"
+"    // ^ TODO: Try uncommenting this line.\n"
+msgstr ""
+
+#: src/generics/bounds/testcase_empty.md:39
+msgid ""
+"[`std::cmp::Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), [`std::"
+"marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html), and "
+"[`trait`s](../../trait.md)"
+msgstr ""
+
+#: src/generics/multi_bounds.md:3
+msgid ""
+"Multiple bounds for a single type can be applied with a `+`. Like normal, "
+"different types are separated with `,`."
+msgstr ""
+
+#: src/generics/multi_bounds.md:10
+msgid "\"Debug: `{:?}`\""
+msgstr ""
+
+#: src/generics/multi_bounds.md:11
+msgid "\"Display: `{}`\""
+msgstr ""
+
+#: src/generics/multi_bounds.md:15
+msgid "\"t: `{:?}`\""
+msgstr ""
+
+#: src/generics/multi_bounds.md:16
+msgid "\"u: `{:?}`\""
+msgstr ""
+
+#: src/generics/multi_bounds.md:20
+msgid "\"words\""
+msgstr ""
+
+#: src/generics/multi_bounds.md:25
+msgid ""
+"//compare_prints(&array);\n"
+"    // TODO ^ Try uncommenting this.\n"
+msgstr ""
+
+#: src/generics/multi_bounds.md:34
+msgid "[`std::fmt`](../hello/print.md) and [`trait`s](../trait.md)"
+msgstr ""
+
+#: src/generics/where.md:3
+msgid ""
+"A bound can also be expressed using a `where` clause immediately before the "
+"opening `{`, rather than at the type's first mention. Additionally, `where` "
+"clauses can apply bounds to arbitrary types, rather than just to type "
+"parameters."
+msgstr ""
+
+#: src/generics/where.md:8
+msgid "Some cases that a `where` clause is useful:"
+msgstr ""
+
+#: src/generics/where.md:10
+msgid "When specifying generic types and bounds separately is clearer:"
+msgstr ""
+
+#: src/generics/where.md:14
+msgid "// Expressing bounds with a `where` clause\n"
+msgstr ""
+
+#: src/generics/where.md:21
+msgid ""
+"When using a `where` clause is more expressive than using normal syntax. The "
+"`impl` in this example cannot be directly expressed without a `where` clause:"
+msgstr ""
+
+#: src/generics/where.md:30
+msgid ""
+"// Because we would otherwise have to express this as `T: Debug` or \n"
+"// use another method of indirect approach, this requires a `where` clause:\n"
+msgstr ""
+
+#: src/generics/where.md:35
+msgid ""
+"// We want `Option<T>: Debug` as our bound because that is what's\n"
+"    // being printed. Doing otherwise would be using the wrong bound.\n"
+msgstr ""
+
+#: src/generics/where.md:51
+msgid ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md), "
+"[`struct`](../custom_types/structs.md), and [`trait`](../trait.md)"
+msgstr ""
+
+#: src/generics/new_types.md:3
+msgid ""
+"The `newtype` idiom gives compile time guarantees that the right type of "
+"value is supplied to a program."
+msgstr ""
+
+#: src/generics/new_types.md:6
+msgid ""
+"For example, an age verification function that checks age in years, _must_ be "
+"given a value of type `Years`."
+msgstr ""
+
+#: src/generics/new_types.md:22
+msgid "/// truncates partial years\n"
+msgstr ""
+
+#: src/generics/new_types.md:35 src/generics/new_types.md:36
+msgid "\"Is an adult? {}\""
+msgstr ""
+
+#: src/generics/new_types.md:37
+msgid "// println!(\"Is an adult? {}\", is_adult(&age_days));\n"
+msgstr ""
+
+#: src/generics/new_types.md:41
+msgid ""
+"Uncomment the last print statement to observe that the type supplied must be "
+"`Years`."
+msgstr ""
+
+#: src/generics/new_types.md:43
+msgid ""
+"To obtain the `newtype`'s value as the base type, you may use the tuple or "
+"destructuring syntax like so:"
+msgstr ""
+
+#: src/generics/new_types.md:49
+msgid "// Tuple\n"
+msgstr ""
+
+#: src/generics/new_types.md:50
+msgid "// Destructuring\n"
+msgstr ""
+
+#: src/generics/new_types.md:56
+msgid "[`structs`](../custom_types/structs.md)"
+msgstr ""
+
+#: src/generics/assoc_items.md:3
+msgid ""
+"\"Associated Items\" refers to a set of rules pertaining to [`item`](https://"
+"doc.rust-lang.org/reference/items.html)s of various types. It is an extension "
+"to `trait` generics, and allows `trait`s to internally define new items."
+msgstr ""
+
+#: src/generics/assoc_items.md:7
+msgid ""
+"One such item is called an _associated type_, providing simpler usage "
+"patterns when the `trait` is generic over its container type."
+msgstr ""
+
+#: src/generics/assoc_items.md:12
+msgid ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-"
+"items.md)"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:3
+msgid ""
+"A `trait` that is generic over its container type has type specification "
+"requirements - users of the `trait` _must_ specify all of its generic types."
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:6
+msgid ""
+"In the example below, the `Contains` `trait` allows the use of the generic "
+"types `A` and `B`. The trait is then implemented for the `Container` type, "
+"specifying `i32` for `A` and `B` so that it can be used with `fn "
+"difference()`."
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:10
+msgid ""
+"Because `Contains` is generic, we are forced to explicitly state _all_ of the "
+"generic types for `fn difference()`. In practice, we want a way to express "
+"that `A` and `B` are determined by the _input_ `C`. As you will see in the "
+"next section, associated types provide exactly that capability."
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:17
+#: src/generics/assoc_items/types.md:36
+msgid ""
+"// A trait which checks if 2 items are stored inside of container.\n"
+"// Also retrieves first or last value.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:21
+msgid "// Explicitly requires `A` and `B`.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:22
+#: src/generics/assoc_items/the_problem.md:23
+msgid "// Doesn't explicitly require `A` or `B`.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:27
+msgid "// True if the numbers stored are equal.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:32
+#: src/generics/assoc_items/types.md:60
+msgid "// Grab the first number.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:35
+#: src/generics/assoc_items/types.md:63
+msgid "// Grab the last number.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:38
+msgid ""
+"// `C` contains `A` and `B`. In light of that, having to express `A` and\n"
+"// `B` again is a nuisance.\n"
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:52
+#: src/generics/assoc_items/types.md:77
+msgid "\"Does container contain {} and {}: {}\""
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:55
+#: src/generics/assoc_items/types.md:80
+msgid "\"First number: {}\""
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:56
+#: src/generics/assoc_items/types.md:81
+msgid "\"Last number: {}\""
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:58
+#: src/generics/assoc_items/types.md:83
+msgid "\"The difference is: {}\""
+msgstr ""
+
+#: src/generics/assoc_items/the_problem.md:64
+msgid ""
+"[`struct`s](../../custom_types/structs.md), and [`trait`s](../../trait.md)"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:3
+msgid ""
+"The use of \"Associated types\" improves the overall readability of code by "
+"moving inner types locally into a trait as _output_ types. Syntax for the "
+"`trait` definition is as follows:"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:8
+msgid ""
+"// `A` and `B` are defined in the trait via the `type` keyword.\n"
+"// (Note: `type` in this context is different from `type` when used for\n"
+"// aliases).\n"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:15
+msgid "// Updated syntax to refer to these new types generically.\n"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:20
+msgid ""
+"Note that functions that use the `trait` `Contains` are no longer required to "
+"express `A` or `B` at all:"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:24
+msgid "// Without using associated types\n"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:27
+msgid "// Using associated types\n"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:32
+msgid ""
+"Let's rewrite the example from the previous section using associated types:"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:40
+msgid "// Define generic types here which methods will be able to utilize.\n"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:50
+msgid ""
+"// Specify what types `A` and `B` are. If the `input` type\n"
+"    // is `Container(i32, i32)`, the `output` types are determined\n"
+"    // as `i32` and `i32`.\n"
+msgstr ""
+
+#: src/generics/assoc_items/types.md:56
+msgid "// `&Self::A` and `&Self::B` are also valid here.\n"
+msgstr ""
+
+#: src/generics/phantom.md:3
+msgid ""
+"A phantom type parameter is one that doesn't show up at runtime, but is "
+"checked statically (and only) at compile time."
+msgstr ""
+
+#: src/generics/phantom.md:6
+msgid ""
+"Data types can use extra generic type parameters to act as markers or to "
+"perform type checking at compile time. These extra parameters hold no storage "
+"values, and have no runtime behavior."
+msgstr ""
+
+#: src/generics/phantom.md:10
+msgid ""
+"In the following example, we combine [std::marker::PhantomData](https://doc."
+"rust-lang.org/std/marker/struct.PhantomData.html) with the phantom type "
+"parameter concept to create tuples containing different data types."
+msgstr ""
+
+#: src/generics/phantom.md:16
+msgid ""
+"// A phantom tuple struct which is generic over `A` with hidden parameter "
+"`B`.\n"
+msgstr ""
+
+#: src/generics/phantom.md:18 src/generics/phantom.md:22
+msgid "// Allow equality test for this type.\n"
+msgstr ""
+
+#: src/generics/phantom.md:20
+msgid ""
+"// A phantom type struct which is generic over `A` with hidden parameter "
+"`B`.\n"
+msgstr ""
+
+#: src/generics/phantom.md:24
+msgid ""
+"// Note: Storage is allocated for generic type `A`, but not for `B`.\n"
+"//       Therefore, `B` cannot be used in computations.\n"
+msgstr ""
+
+#: src/generics/phantom.md:29
+msgid ""
+"// Here, `f32` and `f64` are the hidden parameters.\n"
+"    // PhantomTuple type specified as `<char, f32>`.\n"
+msgstr ""
+
+#: src/generics/phantom.md:31 src/generics/phantom.md:33
+#: src/generics/phantom.md:37 src/generics/phantom.md:42
+#: src/scope/borrow/ref.md:12
+msgid "'Q'"
+msgstr ""
+
+#: src/generics/phantom.md:32
+msgid "// PhantomTuple type specified as `<char, f64>`.\n"
+msgstr ""
+
+#: src/generics/phantom.md:35
+msgid "// Type specified as `<char, f32>`.\n"
+msgstr ""
+
+#: src/generics/phantom.md:40
+msgid "// Type specified as `<char, f64>`.\n"
+msgstr ""
+
+#: src/generics/phantom.md:46
+msgid ""
+"// Compile-time Error! Type mismatch so these cannot be compared:\n"
+"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"    //           _tuple1 == _tuple2);\n"
+msgstr ""
+
+#: src/generics/phantom.md:50
+msgid ""
+"// Compile-time Error! Type mismatch so these cannot be compared:\n"
+"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"    //           _struct1 == _struct2);\n"
+msgstr ""
+
+#: src/generics/phantom.md:58
+msgid ""
+"[Derive](../trait/derive.md), [struct](../custom_types/structs.md), and "
+"[TupleStructs](../custom_types/structs.md)"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:3
+msgid ""
+"A useful method of unit conversions can be examined by implementing `Add` "
+"with a phantom type parameter. The `Add` `trait` is examined below:"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:7
+msgid ""
+"// This construction would impose: `Self + RHS = Output`\n"
+"// where RHS defaults to Self if not specified in the implementation.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:14
+msgid "// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:22
+msgid "The whole implementation:"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:27
+msgid "/// Create void enumerations to define unit types.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:33
+msgid ""
+"/// `Length` is a type with phantom type parameter `Unit`,\n"
+"/// and is not generic over the length type (that is `f64`).\n"
+"///\n"
+"/// `f64` already implements the `Clone` and `Copy` traits.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:40
+msgid "/// The `Add` trait defines the behavior of the `+` operator.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:45
+msgid "// add() returns a new `Length` struct containing the sum.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:47
+msgid "// `+` calls the `Add` implementation for `f64`.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:53
+msgid "// Specifies `one_foot` to have phantom type parameter `Inch`.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:55
+msgid "// `one_meter` has phantom type parameter `Mm`.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:58
+msgid ""
+"// `+` calls the `add()` method we implemented for `Length<Unit>`.\n"
+"    //\n"
+"    // Since `Length` implements `Copy`, `add()` does not consume\n"
+"    // `one_foot` and `one_meter` but copies them into `self` and `rhs`.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:65
+msgid "// Addition works.\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:66
+msgid "\"one foot + one_foot = {:?} in\""
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:67
+msgid "\"one meter + one_meter = {:?} mm\""
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:69
+msgid ""
+"// Nonsensical operations fail as they should:\n"
+"    // Compile-time Error: type mismatch.\n"
+"    //let one_feter = one_foot + one_meter;\n"
+msgstr ""
+
+#: src/generics/phantom/testcase_units.md:77
+msgid ""
+"[Borrowing (`&`)](../../scope/borrow.md), [Bounds (`X: Y`)](../../generics/"
+"bounds.md), [enum](../../custom_types/enum.md), [impl & self](../../fn/"
+"methods.md), [Overloading](../../trait/ops.md), [ref](../../scope/borrow/ref."
+"md), [Traits (`X for Y`)](../../trait.md), and [TupleStructs](../../"
+"custom_types/structs.md)."
+msgstr ""
+
+#: src/scope.md:3
+msgid ""
+"Scopes play an important part in ownership, borrowing, and lifetimes. That "
+"is, they indicate to the compiler when borrows are valid, when resources can "
+"be freed, and when variables are created or destroyed."
+msgstr ""
+
+#: src/scope/raii.md:3
+msgid ""
+"Variables in Rust do more than just hold data in the stack: they also _own_ "
+"resources, e.g. `Box<T>` owns memory in the heap. Rust enforces [RAII]"
+"(https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization) "
+"(Resource Acquisition Is Initialization), so whenever an object goes out of "
+"scope, its destructor is called and its owned resources are freed."
+msgstr ""
+
+#: src/scope/raii.md:8
+msgid ""
+"This behavior shields against _resource leak_ bugs, so you'll never have to "
+"manually free memory or worry about memory leaks again! Here's a quick "
+"showcase:"
+msgstr ""
+
+#: src/scope/raii.md:12
+msgid "// raii.rs\n"
+msgstr ""
+
+#: src/scope/raii.md:14 src/scope/raii.md:21 src/scope/raii.md:26
+msgid "// Allocate an integer on the heap\n"
+msgstr ""
+
+#: src/scope/raii.md:17
+msgid "// `_box1` is destroyed here, and memory gets freed\n"
+msgstr ""
+
+#: src/scope/raii.md:24
+msgid "// A nested scope:\n"
+msgstr ""
+
+#: src/scope/raii.md:29
+msgid "// `_box3` is destroyed here, and memory gets freed\n"
+msgstr ""
+
+#: src/scope/raii.md:32
+msgid ""
+"// Creating lots of boxes just for fun\n"
+"    // There's no need to manually free memory!\n"
+msgstr ""
+
+#: src/scope/raii.md:38
+msgid "// `_box2` is destroyed here, and memory gets freed\n"
+msgstr ""
+
+#: src/scope/raii.md:42
+msgid ""
+"Of course, we can double check for memory errors using [`valgrind`](http://"
+"valgrind.org/info/):"
+msgstr ""
+
+#: src/scope/raii.md:65
+msgid "No leaks here!"
+msgstr ""
+
+#: src/scope/raii.md:67
+msgid "Destructor"
+msgstr ""
+
+#: src/scope/raii.md:69
+msgid ""
+"The notion of a destructor in Rust is provided through the [`Drop`](https://"
+"doc.rust-lang.org/std/ops/trait.Drop.html) trait. The destructor is called "
+"when the resource goes out of scope. This trait is not required to be "
+"implemented for every type, only implement it for your type if you require "
+"its own destructor logic."
+msgstr ""
+
+#: src/scope/raii.md:74
+msgid ""
+"Run the below example to see how the [`Drop`](https://doc.rust-lang.org/std/"
+"ops/trait.Drop.html) trait works. When the variable in the `main` function "
+"goes out of scope the custom destructor will be invoked."
+msgstr ""
+
+#: src/scope/raii.md:82
+msgid "\"ToDrop is being dropped\""
+msgstr ""
+
+#: src/scope/raii.md:88
+msgid "\"Made a ToDrop!\""
+msgstr ""
+
+#: src/scope/raii.md:94
+msgid "[Box](../std/box.md)"
+msgstr ""
+
+#: src/scope/move.md:3
+msgid ""
+"Because variables are in charge of freeing their own resources, **resources "
+"can only have one owner**. This prevents resources from being freed more than "
+"once. Note that not all variables own resources (e.g. [references](../"
+"flow_control/match/destructuring/destructure_pointers.md))."
+msgstr ""
+
+#: src/scope/move.md:8
+msgid ""
+"When doing assignments (`let x = y`) or passing function arguments by value "
+"(`foo(x)`), the _ownership_ of the resources is transferred. In Rust-speak, "
+"this is known as a _move_."
+msgstr ""
+
+#: src/scope/move.md:12
+msgid ""
+"After moving resources, the previous owner can no longer be used. This avoids "
+"creating dangling pointers."
+msgstr ""
+
+#: src/scope/move.md:16
+msgid "// This function takes ownership of the heap allocated memory\n"
+msgstr ""
+
+#: src/scope/move.md:18
+msgid "\"Destroying a box that contains {}\""
+msgstr ""
+
+#: src/scope/move.md:20
+msgid "// `c` is destroyed and the memory freed\n"
+msgstr ""
+
+#: src/scope/move.md:24
+msgid "// _Stack_ allocated integer\n"
+msgstr ""
+
+#: src/scope/move.md:27
+msgid "// *Copy* `x` into `y` - no resources are moved\n"
+msgstr ""
+
+#: src/scope/move.md:30
+msgid "// Both values can be independently used\n"
+msgstr ""
+
+#: src/scope/move.md:31
+msgid "\"x is {}, and y is {}\""
+msgstr ""
+
+#: src/scope/move.md:33
+msgid "// `a` is a pointer to a _heap_ allocated integer\n"
+msgstr ""
+
+#: src/scope/move.md:36
+msgid "\"a contains: {}\""
+msgstr ""
+
+#: src/scope/move.md:38
+msgid "// *Move* `a` into `b`\n"
+msgstr ""
+
+#: src/scope/move.md:40
+msgid ""
+"// The pointer address of `a` is copied (not the data) into `b`.\n"
+"    // Both are now pointers to the same heap allocated data, but\n"
+"    // `b` now owns it.\n"
+msgstr ""
+
+#: src/scope/move.md:44
+msgid ""
+"// Error! `a` can no longer access the data, because it no longer owns the\n"
+"    // heap memory\n"
+"    //println!(\"a contains: {}\", a);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/scope/move.md:49
+msgid "// This function takes ownership of the heap allocated memory from `b`\n"
+msgstr ""
+
+#: src/scope/move.md:52
+msgid ""
+"// Since the heap memory has been freed at this point, this action would\n"
+"    // result in dereferencing freed memory, but it's forbidden by the "
+"compiler\n"
+"    // Error! Same reason as the previous Error\n"
+"    //println!(\"b contains: {}\", b);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/scope/move/mut.md:3
+msgid "Mutability of data can be changed when ownership is transferred."
+msgstr ""
+
+#: src/scope/move/mut.md:9
+msgid "\"immutable_box contains {}\""
+msgstr ""
+
+#: src/scope/move/mut.md:11
+msgid ""
+"// Mutability error\n"
+"    //*immutable_box = 4;\n"
+msgstr ""
+
+#: src/scope/move/mut.md:14
+msgid "// *Move* the box, changing the ownership (and mutability)\n"
+msgstr ""
+
+#: src/scope/move/mut.md:17
+msgid "\"mutable_box contains {}\""
+msgstr ""
+
+#: src/scope/move/mut.md:19
+msgid "// Modify the contents of the box\n"
+msgstr ""
+
+#: src/scope/move/mut.md:22
+msgid "\"mutable_box now contains {}\""
+msgstr ""
+
+#: src/scope/move/partial_move.md:3
+msgid ""
+"Within the [destructuring](../../flow_control/match/destructuring.md) of a "
+"single variable, both `by-move` and `by-reference` pattern bindings can be "
+"used at the same time. Doing this will result in a _partial move_ of the "
+"variable, which means that parts of the variable will be moved while other "
+"parts stay. In such a case, the parent variable cannot be used afterwards as "
+"a whole, however the parts that are only referenced (and not moved) can still "
+"be used."
+msgstr ""
+
+#: src/scope/move/partial_move.md:24
+msgid "// `name` is moved out of person, but `age` is referenced\n"
+msgstr ""
+
+#: src/scope/move/partial_move.md:27
+msgid "\"The person's age is {}\""
+msgstr ""
+
+#: src/scope/move/partial_move.md:29
+msgid "\"The person's name is {}\""
+msgstr ""
+
+#: src/scope/move/partial_move.md:31
+msgid ""
+"// Error! borrow of partially moved value: `person` partial move occurs\n"
+"    //println!(\"The person struct is {:?}\", person);\n"
+msgstr ""
+
+#: src/scope/move/partial_move.md:34
+msgid ""
+"// `person` cannot be used but `person.age` can be used as it is not moved\n"
+msgstr ""
+
+#: src/scope/move/partial_move.md:35
+msgid "\"The person's age from person struct is {}\""
+msgstr ""
+
+#: src/scope/move/partial_move.md:38
+msgid ""
+"(In this example, we store the `age` variable on the heap to illustrate the "
+"partial move: deleting `ref` in the above code would give an error as the "
+"ownership of `person.age` would be moved to the variable `age`. If `Person."
+"age` were stored on the stack, `ref` would not be required as the definition "
+"of `age` would copy the data from `person.age` without moving it.)"
+msgstr ""
+
+#: src/scope/move/partial_move.md:46
+msgid "[destructuring](../../flow_control/match/destructuring.md)"
+msgstr ""
+
+#: src/scope/borrow.md:3
+msgid ""
+"Most of the time, we'd like to access data without taking ownership over it. "
+"To accomplish this, Rust uses a _borrowing_ mechanism. Instead of passing "
+"objects by value (`T`), objects can be passed by reference (`&T`)."
+msgstr ""
+
+#: src/scope/borrow.md:7
+msgid ""
+"The compiler statically guarantees (via its borrow checker) that references "
+"_always_ point to valid objects. That is, while references to an object "
+"exist, the object cannot be destroyed."
+msgstr ""
+
+#: src/scope/borrow.md:12
+msgid "// This function takes ownership of a box and destroys it\n"
+msgstr ""
+
+#: src/scope/borrow.md:14
+msgid "\"Destroying box that contains {}\""
+msgstr ""
+
+#: src/scope/borrow.md:16
+msgid "// This function borrows an i32\n"
+msgstr ""
+
+#: src/scope/borrow.md:19
+msgid "\"This int is: {}\""
+msgstr ""
+
+#: src/scope/borrow.md:23
+msgid ""
+"// Create a boxed i32 in the heap, and a i32 on the stack\n"
+"    // Remember: numbers can have arbitrary underscores added for "
+"readability\n"
+"    // 5_i32 is the same as 5i32\n"
+msgstr ""
+
+#: src/scope/borrow.md:29
+msgid ""
+"// Borrow the contents of the box. Ownership is not taken,\n"
+"    // so the contents can be borrowed again.\n"
+msgstr ""
+
+#: src/scope/borrow.md:35
+msgid "// Take a reference to the data contained inside the box\n"
+msgstr ""
+
+#: src/scope/borrow.md:38
+msgid ""
+"// Error!\n"
+"        // Can't destroy `boxed_i32` while the inner value is borrowed later "
+"in scope.\n"
+msgstr ""
+
+#: src/scope/borrow.md:43
+msgid "// Attempt to borrow `_ref_to_i32` after inner value is destroyed\n"
+msgstr ""
+
+#: src/scope/borrow.md:45
+msgid "// `_ref_to_i32` goes out of scope and is no longer borrowed.\n"
+msgstr ""
+
+#: src/scope/borrow.md:48
+msgid ""
+"// `boxed_i32` can now give up ownership to `eat_box_i32` and be destroyed\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:3
+msgid ""
+"Mutable data can be mutably borrowed using `&mut T`. This is called a "
+"_mutable reference_ and gives read/write access to the borrower. In contrast, "
+"`&T` borrows the data via an immutable reference, and the borrower can read "
+"the data but not modify it:"
+msgstr ""
+
+#: src/scope/borrow/mut.md:12
+msgid ""
+"// `&'static str` is a reference to a string allocated in read only memory\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:17
+msgid "// This function takes a reference to a book\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:20
+msgid "\"I immutably borrowed {} - {} edition\""
+msgstr ""
+
+#: src/scope/borrow/mut.md:22
+msgid ""
+"// This function takes a reference to a mutable book and changes `year` to "
+"2014\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:26
+msgid "\"I mutably borrowed {} - {} edition\""
+msgstr ""
+
+#: src/scope/borrow/mut.md:30
+msgid "// Create an immutable Book named `immutabook`\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:32
+msgid "// string literals have type `&'static str`\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:33
+msgid "\"Douglas Hofstadter\""
+msgstr ""
+
+#: src/scope/borrow/mut.md:34
+msgid "\"Gödel, Escher, Bach\""
+msgstr ""
+
+#: src/scope/borrow/mut.md:38
+msgid "// Create a mutable copy of `immutabook` and call it `mutabook`\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:41
+msgid "// Immutably borrow an immutable object\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:44
+msgid "// Immutably borrow a mutable object\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:47
+msgid "// Borrow a mutable object as mutable\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:50
+msgid "// Error! Cannot borrow an immutable object as mutable\n"
+msgstr ""
+
+#: src/scope/borrow/mut.md:57
+msgid "[`static`](../lifetime/static_lifetime.md)"
+msgstr ""
+
+#: src/scope/borrow/alias.md:3
+msgid ""
+"Data can be immutably borrowed any number of times, but while immutably "
+"borrowed, the original data can't be mutably borrowed. On the other hand, "
+"only _one_ mutable borrow is allowed at a time. The original data can be "
+"borrowed again only _after_ the mutable reference has been used for the last "
+"time."
+msgstr ""
+
+#: src/scope/borrow/alias.md:17
+msgid "// Data can be accessed via the references and the original owner\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:18 src/scope/borrow/alias.md:27
+#: src/scope/borrow/alias.md:49
+msgid "\"Point has coordinates: ({}, {}, {})\""
+msgstr ""
+
+#: src/scope/borrow/alias.md:21
+msgid ""
+"// Error! Can't borrow `point` as mutable because it's currently\n"
+"    // borrowed as immutable.\n"
+"    // let mutable_borrow = &mut point;\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:26
+msgid "// The borrowed values are used again here\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:30
+msgid ""
+"// The immutable references are no longer used for the rest of the code so\n"
+"    // it is possible to reborrow with a mutable reference.\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:34
+msgid "// Change data via mutable reference\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:39
+msgid ""
+"// Error! Can't borrow `point` as immutable because it's currently\n"
+"    // borrowed as mutable.\n"
+"    // let y = &point.y;\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:44
+msgid ""
+"// Error! Can't print because `println!` takes an immutable reference.\n"
+"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:48
+msgid "// Ok! Mutable references can be passed as immutable to `println!`\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:52
+msgid ""
+"// The mutable reference is no longer used for the rest of the code so it\n"
+"    // is possible to reborrow\n"
+msgstr ""
+
+#: src/scope/borrow/alias.md:55
+msgid "\"Point now has coordinates: ({}, {}, {})\""
+msgstr ""
+
+#: src/scope/borrow/ref.md:3
+msgid ""
+"When doing pattern matching or destructuring via the `let` binding, the `ref` "
+"keyword can be used to take references to the fields of a struct/tuple. The "
+"example below shows a few instances where this can be useful:"
+msgstr ""
+
+#: src/scope/borrow/ref.md:14
+msgid ""
+"// A `ref` borrow on the left side of an assignment is equivalent to\n"
+"    // an `&` borrow on the right side.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:19
+msgid "\"ref_c1 equals ref_c2: {}\""
+msgstr ""
+
+#: src/scope/borrow/ref.md:23
+msgid "// `ref` is also valid when destructuring a struct.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:25
+msgid "// `ref_to_x` is a reference to the `x` field of `point`.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:28
+msgid "// Return a copy of the `x` field of `point`.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:32
+msgid "// A mutable copy of `point`\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:36
+msgid "// `ref` can be paired with `mut` to take mutable references.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:39
+msgid "// Mutate the `y` field of `mutable_point` via a mutable reference.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:43
+msgid "\"point is ({}, {})\""
+msgstr ""
+
+#: src/scope/borrow/ref.md:44
+msgid "\"mutable_point is ({}, {})\""
+msgstr ""
+
+#: src/scope/borrow/ref.md:46
+msgid "// A mutable tuple that includes a pointer\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:50
+msgid "// Destructure `mutable_tuple` to change the value of `last`.\n"
+msgstr ""
+
+#: src/scope/borrow/ref.md:55
+msgid "\"tuple is {:?}\""
+msgstr ""
+
+#: src/scope/lifetime.md:3
+msgid ""
+"A _lifetime_ is a construct the compiler (or more specifically, its _borrow "
+"checker_) uses to ensure all borrows are valid. Specifically, a variable's "
+"lifetime begins when it is created and ends when it is destroyed. While "
+"lifetimes and scopes are often referred to together, they are not the same."
+msgstr ""
+
+#: src/scope/lifetime.md:8
+msgid ""
+"Take, for example, the case where we borrow a variable via `&`. The borrow "
+"has a lifetime that is determined by where it is declared. As a result, the "
+"borrow is valid as long as it ends before the lender is destroyed. However, "
+"the scope of the borrow is determined by where the reference is used."
+msgstr ""
+
+#: src/scope/lifetime.md:13
+msgid ""
+"In the following example and in the rest of this section, we will see how "
+"lifetimes relate to scopes, as well as how the two differ."
+msgstr ""
+
+#: src/scope/lifetime.md:17
+msgid ""
+"// Lifetimes are annotated below with lines denoting the creation\n"
+"// and destruction of each variable.\n"
+"// `i` has the longest lifetime because its scope entirely encloses \n"
+"// both `borrow1` and `borrow2`. The duration of `borrow1` compared \n"
+"// to `borrow2` is irrelevant since they are disjoint.\n"
+msgstr ""
+
+#: src/scope/lifetime.md:23
+msgid ""
+"// Lifetime for `i` starts. ────────────────┐\n"
+"    //                                                     │\n"
+msgstr ""
+
+#: src/scope/lifetime.md:25 src/scope/lifetime.md:32
+msgid "//                                                   │\n"
+msgstr ""
+
+#: src/scope/lifetime.md:26
+msgid ""
+"// `borrow1` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+msgstr ""
+
+#: src/scope/lifetime.md:28
+msgid "\"borrow1: {}\""
+msgstr ""
+
+#: src/scope/lifetime.md:28 src/scope/lifetime.md:35
+msgid "//              ││\n"
+msgstr ""
+
+#: src/scope/lifetime.md:29
+msgid ""
+"// `borrow1` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+"    //                                                     │\n"
+msgstr ""
+
+#: src/scope/lifetime.md:33
+msgid ""
+"// `borrow2` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
+msgstr ""
+
+#: src/scope/lifetime.md:35
+msgid "\"borrow2: {}\""
+msgstr ""
+
+#: src/scope/lifetime.md:36
+msgid ""
+"// `borrow2` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+msgstr ""
+
+#: src/scope/lifetime.md:38
+msgid "// Lifetime ends. ─────────────────────────────────────┘\n"
+msgstr ""
+
+#: src/scope/lifetime.md:41
+msgid ""
+"Note that no names or types are assigned to label lifetimes. This restricts "
+"how lifetimes will be able to be used as we will see."
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:3
+msgid ""
+"The borrow checker uses explicit lifetime annotations to determine how long "
+"references should be valid. In cases where lifetimes are not elided[^1], Rust "
+"requires explicit annotations to determine what the lifetime of a reference "
+"should be. The syntax for explicitly annotating a lifetime uses an apostrophe "
+"character as follows:"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:10
+msgid "// `foo` has a lifetime parameter `'a`\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:14
+msgid ""
+"Similar to [closures](../../fn/closures/anonymity.md), using lifetimes "
+"requires generics. Additionally, this lifetime syntax indicates that the "
+"lifetime of `foo` may not exceed that of `'a`. Explicit annotation of a type "
+"has the form `&'a T` where `'a` has already been introduced."
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:19
+msgid "In cases with multiple lifetimes, the syntax is similar:"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:22
+msgid "// `foo` has lifetime parameters `'a` and `'b`\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:26
+msgid ""
+"In this case, the lifetime of `foo` cannot exceed that of either `'a` _or_ "
+"`'b`."
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:28
+msgid "See the following example for explicit lifetime annotation in use:"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:31
+msgid ""
+"// `print_refs` takes two references to `i32` which have different\n"
+"// lifetimes `'a` and `'b`. These two lifetimes must both be at\n"
+"// least as long as the function `print_refs`.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:35
+msgid "\"x is {} and y is {}\""
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:37
+msgid ""
+"// A function which takes no arguments, but has a lifetime parameter `'a`.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:42
+msgid "// ERROR: `_x` does not live long enough\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:44
+msgid ""
+"// Attempting to use the lifetime `'a` as an explicit type annotation \n"
+"    // inside the function will fail because the lifetime of `&_x` is "
+"shorter\n"
+"    // than that of `_y`. A short lifetime cannot be coerced into a longer "
+"one.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:50
+msgid "// Create variables to be borrowed below.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:53
+msgid "// Borrows (`&`) of both variables are passed into the function.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:55
+msgid ""
+"// Any input which is borrowed must outlive the borrower. \n"
+"    // In other words, the lifetime of `four` and `nine` must \n"
+"    // be longer than that of `print_refs`.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:60
+msgid ""
+"// `failed_borrow` contains no references to force `'a` to be \n"
+"    // longer than the lifetime of the function, but `'a` is longer.\n"
+"    // Because the lifetime is never constrained, it defaults to `'static`.\n"
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:66
+msgid ""
+"[elision](elision.md) implicitly annotates lifetimes and so is different."
+msgstr ""
+
+#: src/scope/lifetime/explicit.md:70
+msgid "[generics](../../generics.md) and [closures](../../fn/closures.md)"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:3
+msgid ""
+"Ignoring [elision](elision.md), function signatures with lifetimes have a few "
+"constraints:"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:5
+msgid "any reference _must_ have an annotated lifetime."
+msgstr ""
+
+#: src/scope/lifetime/fn.md:6
+msgid ""
+"any reference being returned _must_ have the same lifetime as an input or be "
+"`static`."
+msgstr ""
+
+#: src/scope/lifetime/fn.md:9
+msgid ""
+"Additionally, note that returning references without input is banned if it "
+"would result in returning references to invalid data. The following example "
+"shows off some valid forms of functions with lifetimes:"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:14
+msgid ""
+"// One input reference with lifetime `'a` which must live\n"
+"// at least as long as the function.\n"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:17
+msgid "\"`print_one`: x is {}\""
+msgstr ""
+
+#: src/scope/lifetime/fn.md:19
+msgid "// Mutable references are possible with lifetimes as well.\n"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:24
+msgid ""
+"// Multiple elements with different lifetimes. In this case, it\n"
+"// would be fine for both to have the same lifetime `'a`, but\n"
+"// in more complex cases, different lifetimes may be required.\n"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:29
+msgid "\"`print_multi`: x is {}, y is {}\""
+msgstr ""
+
+#: src/scope/lifetime/fn.md:31
+msgid ""
+"// Returning references that have been passed in is acceptable.\n"
+"// However, the correct lifetime must be returned.\n"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:35
+msgid ""
+"//fn invalid_output<'a>() -> &'a String { &String::from(\"foo\") }\n"
+"// The above is invalid: `'a` must live longer than the function.\n"
+"// Here, `&String::from(\"foo\")` would create a `String`, followed by a\n"
+"// reference. Then the data is dropped upon exiting the scope, leaving\n"
+"// a reference to invalid data to be returned.\n"
+msgstr ""
+
+#: src/scope/lifetime/fn.md:60
+msgid "[Functions](../../fn.md)"
+msgstr ""
+
+#: src/scope/lifetime/methods.md:3
+msgid "Methods are annotated similarly to functions:"
+msgstr ""
+
+#: src/scope/lifetime/methods.md:9
+msgid "// Annotate lifetimes as in a standalone function.\n"
+msgstr ""
+
+#: src/scope/lifetime/methods.md:12
+msgid "\"`print`: {}\""
+msgstr ""
+
+#: src/scope/lifetime/methods.md:26
+msgid "[methods](../../fn/methods.md)"
+msgstr ""
+
+#: src/scope/lifetime/struct.md:3
+msgid "Annotation of lifetimes in structures are also similar to functions:"
+msgstr ""
+
+#: src/scope/lifetime/struct.md:6
+msgid ""
+"// A type `Borrowed` which houses a reference to an\n"
+"// `i32`. The reference to `i32` must outlive `Borrowed`.\n"
+msgstr ""
+
+#: src/scope/lifetime/struct.md:10
+msgid "// Similarly, both references here must outlive this structure.\n"
+msgstr ""
+
+#: src/scope/lifetime/struct.md:17
+msgid "// An enum which is either an `i32` or a reference to one.\n"
+msgstr ""
+
+#: src/scope/lifetime/struct.md:34 src/scope/lifetime/struct.md:36
+msgid "\"x is borrowed in {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/struct.md:35
+msgid "\"x and y are borrowed in {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/struct.md:37
+msgid "\"y is *not* borrowed in {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/struct.md:43
+msgid "[`struct`s](../../custom_types/structs.md)"
+msgstr ""
+
+#: src/scope/lifetime/trait.md:3
+msgid ""
+"Annotation of lifetimes in trait methods basically are similar to functions. "
+"Note that `impl` may have annotation of lifetimes too."
+msgstr ""
+
+#: src/scope/lifetime/trait.md:7
+msgid "// A struct with annotation of lifetimes.\n"
+msgstr ""
+
+#: src/scope/lifetime/trait.md:12
+msgid "// Annotate lifetimes to impl.\n"
+msgstr ""
+
+#: src/scope/lifetime/trait.md:24
+msgid "\"b is {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/trait.md:30
+msgid "[`trait`s](../../trait.md)"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:3
+msgid ""
+"Just like generic types can be bounded, lifetimes (themselves generic) use "
+"bounds as well. The `:` character has a slightly different meaning here, but "
+"`+` is the same. Note how the following read:"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:7
+msgid "`T: 'a`: _All_ references in `T` must outlive lifetime `'a`."
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:8
+msgid ""
+"`T: Trait + 'a`: Type `T` must implement trait `Trait` and _all_ references "
+"in `T` must outlive `'a`."
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:11
+msgid ""
+"The example below shows the above syntax in action used after keyword `where`:"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:14
+msgid "// Trait to bound with.\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:17
+msgid ""
+"// `Ref` contains a reference to a generic type `T` that has\n"
+"// some lifetime `'a` unknown by `Ref`. `T` is bounded such that any\n"
+"// *references* in `T` must outlive `'a`. Additionally, the lifetime\n"
+"// of `Ref` may not exceed `'a`.\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:22
+msgid "// A generic function which prints using the `Debug` trait.\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:26
+msgid "\"`print`: t is {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:28
+msgid ""
+"// Here a reference to `T` is taken where `T` implements\n"
+"// `Debug` and all *references* in `T` outlive `'a`. In\n"
+"// addition, `'a` must outlive the function.\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:34
+msgid "\"`print_ref`: t is {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/lifetime_bounds.md:48
+msgid ""
+"[generics](../../generics.md), [bounds in generics](../../generics/bounds."
+"md), and [multiple bounds in generics](../../generics/multi_bounds.md)"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:3
+msgid ""
+"A longer lifetime can be coerced into a shorter one so that it works inside a "
+"scope it normally wouldn't work in. This comes in the form of inferred "
+"coercion by the Rust compiler, and also in the form of declaring a lifetime "
+"difference:"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:9
+msgid ""
+"// Here, Rust infers a lifetime that is as short as possible.\n"
+"// The two references are then coerced to that lifetime.\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:14
+msgid ""
+"// `<'a: 'b, 'b>` reads as lifetime `'a` is at least as long as `'b`.\n"
+"// Here, we take in an `&'a i32` and return a `&'b i32` as a result of "
+"coercion.\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:22
+msgid "// Longer lifetime\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:25
+msgid "// Shorter lifetime\n"
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:27
+msgid "\"The product is {}\""
+msgstr ""
+
+#: src/scope/lifetime/lifetime_coercion.md:28
+msgid "\"{} is the first\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:3
+msgid ""
+"Rust has a few reserved lifetime names. One of those is `'static`. You might "
+"encounter it in two situations:"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:7
+msgid "// A reference with 'static lifetime:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:8
+msgid "\"hello world\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:9
+msgid "// 'static as part of a trait bound:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:14
+msgid ""
+"Both are related but subtly different and this is a common source for "
+"confusion when learning Rust. Here are some examples for each situation:"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:17
+msgid "Reference lifetime"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:19
+msgid ""
+"As a reference lifetime `'static` indicates that the data pointed to by the "
+"reference lives for the remaining lifetime of the running program. It can "
+"still be coerced to a shorter lifetime."
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:23
+msgid ""
+"There are two common ways to make a variable with `'static` lifetime, and "
+"both are stored in the read-only memory of the binary:"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:26
+msgid "Make a constant with the `static` declaration."
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:27
+msgid "Make a `string` literal which has type: `&'static str`."
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:29
+msgid "See the following example for a display of each method:"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:32
+msgid "// Make a constant with `'static` lifetime.\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:34
+msgid ""
+"// Returns a reference to `NUM` where its `'static`\n"
+"// lifetime is coerced to that of the input argument.\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:43
+msgid "// Make a `string` literal and print it:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:44
+msgid "\"I'm in read-only memory\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:45
+msgid "\"static_string: {}\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:47
+msgid ""
+"// When `static_string` goes out of scope, the reference\n"
+"        // can no longer be used, but the data remains in the binary.\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:52
+msgid "// Make an integer to use for `coerce_static`:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:55
+msgid "// Coerce `NUM` to lifetime of `lifetime_num`:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:58
+msgid "\"coerced_static: {}\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:61
+msgid "\"NUM: {} stays accessible!\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:65
+msgid ""
+"Since `'static` references only need to be valid for the _remainder_ of a "
+"program's life, they can be created while the program is executed. Just to "
+"demonstrate, the below example uses [`Box::leak`](https://doc.rust-lang.org/"
+"std/boxed/struct.Box.html#method.leak) to dynamically create `'static` "
+"references. In that case it definitely doesn't live for the entire duration, "
+"but only for the leaking point onward."
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:90
+msgid "Trait bound"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:92
+msgid ""
+"As a trait bound, it means the type does not contain any non-static "
+"references. Eg. the receiver can hold on to the type for as long as they want "
+"and it will never become invalid until they drop it."
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:96
+msgid ""
+"It's important to understand this means that any owned data always passes a "
+"`'static` lifetime bound, but a reference to that owned data generally does "
+"not:"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:104
+msgid "\"'static value passed in is: {:?}\""
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:108
+msgid "// i is owned and contains no references, thus it's 'static:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:112
+msgid ""
+"// oops, &i only has the lifetime defined by the scope of\n"
+"    // main(), so it's not 'static:\n"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:117
+msgid "The compiler will tell you:"
+msgstr ""
+
+#: src/scope/lifetime/static_lifetime.md:133
+msgid "[`'static` constants](../../custom_types/constants.md)"
+msgstr ""
+
+#: src/scope/lifetime/elision.md:3
+msgid ""
+"Some lifetime patterns are overwhelmingly common and so the borrow checker "
+"will allow you to omit them to save typing and to improve readability. This "
+"is known as elision. Elision exists in Rust solely because these patterns are "
+"common."
+msgstr ""
+
+#: src/scope/lifetime/elision.md:8
+msgid ""
+"The following code shows a few examples of elision. For a more comprehensive "
+"description of elision, see [lifetime elision](https://doc.rust-lang.org/book/"
+"ch10-03-lifetime-syntax.html#lifetime-elision) in the book."
+msgstr ""
+
+#: src/scope/lifetime/elision.md:12
+msgid ""
+"// `elided_input` and `annotated_input` essentially have identical "
+"signatures\n"
+"// because the lifetime of `elided_input` is inferred by the compiler:\n"
+msgstr ""
+
+#: src/scope/lifetime/elision.md:15
+msgid "\"`elided_input`: {}\""
+msgstr ""
+
+#: src/scope/lifetime/elision.md:19
+msgid "\"`annotated_input`: {}\""
+msgstr ""
+
+#: src/scope/lifetime/elision.md:21
+msgid ""
+"// Similarly, `elided_pass` and `annotated_pass` have identical signatures\n"
+"// because the lifetime is added implicitly to `elided_pass`:\n"
+msgstr ""
+
+#: src/scope/lifetime/elision.md:34
+msgid "\"`elided_pass`: {}\""
+msgstr ""
+
+#: src/scope/lifetime/elision.md:35
+msgid "\"`annotated_pass`: {}\""
+msgstr ""
+
+#: src/scope/lifetime/elision.md:41
+msgid ""
+"[elision](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax."
+"html#lifetime-elision)"
+msgstr ""
+
+#: src/trait.md:3
+msgid ""
+"A `trait` is a collection of methods defined for an unknown type: `Self`. "
+"They can access other methods declared in the same trait."
+msgstr ""
+
+#: src/trait.md:6
+msgid ""
+"Traits can be implemented for any data type. In the example below, we define "
+"`Animal`, a group of methods. The `Animal` `trait` is then implemented for "
+"the `Sheep` data type, allowing the use of methods from `Animal` with a "
+"`Sheep`."
+msgstr ""
+
+#: src/trait.md:15
+msgid ""
+"// Associated function signature; `Self` refers to the implementor type.\n"
+msgstr ""
+
+#: src/trait.md:18
+msgid "// Method signatures; these will return a string.\n"
+msgstr ""
+
+#: src/trait.md:22
+msgid "// Traits can provide default method definitions.\n"
+msgstr ""
+
+#: src/trait.md:24
+msgid "\"{} says {}\""
+msgstr ""
+
+#: src/trait.md:35
+msgid "// Implementor methods can use the implementor's trait methods.\n"
+msgstr ""
+
+#: src/trait.md:36
+msgid "\"{} is already naked...\""
+msgstr ""
+
+#: src/trait.md:38
+msgid "\"{} gets a haircut!\""
+msgstr ""
+
+#: src/trait.md:44 src/trait/dyn.md:17
+msgid "// Implement the `Animal` trait for `Sheep`.\n"
+msgstr ""
+
+#: src/trait.md:47
+msgid "// `Self` is the implementor type: `Sheep`.\n"
+msgstr ""
+
+#: src/trait.md:58
+msgid "\"baaaaah?\""
+msgstr ""
+
+#: src/trait.md:60 src/trait/dyn.md:21
+msgid "\"baaaaah!\""
+msgstr ""
+
+#: src/trait.md:64
+msgid "// Default trait methods can be overridden.\n"
+msgstr ""
+
+#: src/trait.md:66
+msgid "// For example, we can add some quiet contemplation.\n"
+msgstr ""
+
+#: src/trait.md:67
+msgid "\"{} pauses briefly... {}\""
+msgstr ""
+
+#: src/trait.md:72
+msgid "// Type annotation is necessary in this case.\n"
+msgstr ""
+
+#: src/trait.md:73
+msgid "\"Dolly\""
+msgstr ""
+
+#: src/trait.md:74
+msgid "// TODO ^ Try removing the type annotations.\n"
+msgstr ""
+
+#: src/trait/derive.md:3
+msgid ""
+"The compiler is capable of providing basic implementations for some traits "
+"via the `#[derive]` [attribute](../attribute.md). These traits can still be "
+"manually implemented if a more complex behavior is required."
+msgstr ""
+
+#: src/trait/derive.md:7
+msgid "The following is a list of derivable traits:"
+msgstr ""
+
+#: src/trait/derive.md:8
+msgid ""
+"Comparison traits: [`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html), "
+"[`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html), [`Ord`]"
+"(https://doc.rust-lang.org/std/cmp/trait.Ord.html), [`PartialOrd`](https://"
+"doc.rust-lang.org/std/cmp/trait.PartialOrd.html)."
+msgstr ""
+
+#: src/trait/derive.md:10
+msgid ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), to create "
+"`T` from `&T` via a copy."
+msgstr ""
+
+#: src/trait/derive.md:11
+msgid ""
+"[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html), to give a "
+"type 'copy semantics' instead of 'move semantics'."
+msgstr ""
+
+#: src/trait/derive.md:12
+msgid ""
+"[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html), to compute a "
+"hash from `&T`."
+msgstr ""
+
+#: src/trait/derive.md:13
+msgid ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html), to "
+"create an empty instance of a data type."
+msgstr ""
+
+#: src/trait/derive.md:14
+msgid ""
+"[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html), to format a "
+"value using the `{:?}` formatter."
+msgstr ""
+
+#: src/trait/derive.md:17
+msgid "// `Centimeters`, a tuple struct that can be compared\n"
+msgstr ""
+
+#: src/trait/derive.md:20
+msgid "// `Inches`, a tuple struct that can be printed\n"
+msgstr ""
+
+#: src/trait/derive.md:32
+msgid "// `Seconds`, a tuple struct with no additional attributes\n"
+msgstr ""
+
+#: src/trait/derive.md:39
+msgid ""
+"// Error: `Seconds` can't be printed; it doesn't implement the `Debug` trait\n"
+"    //println!(\"One second looks like: {:?}\", _one_second);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/trait/derive.md:43
+msgid ""
+"// Error: `Seconds` can't be compared; it doesn't implement the `PartialEq` "
+"trait\n"
+"    //let _this_is_true = (_one_second == _one_second);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/trait/derive.md:49
+msgid "\"One foot equals {:?}\""
+msgstr ""
+
+#: src/trait/derive.md:55
+msgid "\"smaller\""
+msgstr ""
+
+#: src/trait/derive.md:57
+msgid "\"bigger\""
+msgstr ""
+
+#: src/trait/derive.md:60
+msgid "\"One foot is {} than one meter.\""
+msgstr ""
+
+#: src/trait/derive.md:65
+msgid "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
+msgstr ""
+
+#: src/trait/dyn.md:3
+msgid ""
+"The Rust compiler needs to know how much space every function's return type "
+"requires. This means all your functions have to return a concrete type. "
+"Unlike other languages, if you have a trait like `Animal`, you can't write a "
+"function that returns `Animal`, because its different implementations will "
+"need different amounts of memory."
+msgstr ""
+
+#: src/trait/dyn.md:5
+msgid ""
+"However, there's an easy workaround. Instead of returning a trait object "
+"directly, our functions return a `Box` which _contains_ some `Animal`. A "
+"`box` is just a reference to some memory in the heap. Because a reference has "
+"a statically-known size, and the compiler can guarantee it points to a heap-"
+"allocated `Animal`, we can return a trait from our function!"
+msgstr ""
+
+#: src/trait/dyn.md:7
+msgid ""
+"Rust tries to be as explicit as possible whenever it allocates memory on the "
+"heap. So if your function returns a pointer-to-trait-on-heap in this way, you "
+"need to write the return type with the `dyn` keyword, e.g. `Box<dyn Animal>`."
+msgstr ""
+
+#: src/trait/dyn.md:14
+msgid "// Instance method signature\n"
+msgstr ""
+
+#: src/trait/dyn.md:24
+msgid "// Implement the `Animal` trait for `Cow`.\n"
+msgstr ""
+
+#: src/trait/dyn.md:28
+msgid "\"moooooo!\""
+msgstr ""
+
+#: src/trait/dyn.md:31
+msgid ""
+"// Returns some struct that implements Animal, but we don't know which one at "
+"compile time.\n"
+msgstr ""
+
+#: src/trait/dyn.md:44
+msgid "\"You've randomly chosen an animal, and it says {}\""
+msgstr ""
+
+#: src/trait/ops.md:3
+msgid ""
+"In Rust, many of the operators can be overloaded via traits. That is, some "
+"operators can be used to accomplish different tasks based on their input "
+"arguments. This is possible because operators are syntactic sugar for method "
+"calls. For example, the `+` operator in `a + b` calls the `add` method (as in "
+"`a.add(b)`). This `add` method is part of the `Add` trait. Hence, the `+` "
+"operator can be used by any implementor of the `Add` trait."
+msgstr ""
+
+#: src/trait/ops.md:9
+msgid ""
+"A list of the traits, such as `Add`, that overload operators can be found in "
+"[`core::ops`](https://doc.rust-lang.org/core/ops/)."
+msgstr ""
+
+#: src/trait/ops.md:22
+msgid ""
+"// The `std::ops::Add` trait is used to specify the functionality of `+`.\n"
+"// Here, we make `Add<Bar>` - the trait for addition with a RHS of type "
+"`Bar`.\n"
+"// The following block implements the operation: Foo + Bar = FooBar\n"
+msgstr ""
+
+#: src/trait/ops.md:30
+msgid "\"> Foo.add(Bar) was called\""
+msgstr ""
+
+#: src/trait/ops.md:35
+msgid ""
+"// By reversing the types, we end up implementing non-commutative addition.\n"
+"// Here, we make `Add<Foo>` - the trait for addition with a RHS of type "
+"`Foo`.\n"
+"// This block implements the operation: Bar + Foo = BarFoo\n"
+msgstr ""
+
+#: src/trait/ops.md:43
+msgid "\"> Bar.add(Foo) was called\""
+msgstr ""
+
+#: src/trait/ops.md:50
+msgid "\"Foo + Bar = {:?}\""
+msgstr ""
+
+#: src/trait/ops.md:51
+msgid "\"Bar + Foo = {:?}\""
+msgstr ""
+
+#: src/trait/ops.md:55 src/testing.md:16 src/testing/doc_testing.md:104
+#: src/testing/dev_dependencies.md:36
+msgid "See Also"
+msgstr ""
+
+#: src/trait/ops.md:57
+msgid ""
+"[Add](https://doc.rust-lang.org/core/ops/trait.Add.html), [Syntax Index]"
+"(https://doc.rust-lang.org/book/appendix-02-operators.html)"
+msgstr ""
+
+#: src/trait/drop.md:3
+msgid ""
+"The [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait only "
+"has one method: `drop`, which is called automatically when an object goes out "
+"of scope. The main use of the `Drop` trait is to free the resources that the "
+"implementor instance owns."
+msgstr ""
+
+#: src/trait/drop.md:7
+msgid ""
+"`Box`, `Vec`, `String`, `File`, and `Process` are some examples of types that "
+"implement the `Drop` trait to free resources. The `Drop` trait can also be "
+"manually implemented for any custom data type."
+msgstr ""
+
+#: src/trait/drop.md:11
+msgid ""
+"The following example adds a print to console to the `drop` function to "
+"announce when it is called."
+msgstr ""
+
+#: src/trait/drop.md:18
+msgid "// This trivial implementation of `drop` adds a print to console.\n"
+msgstr ""
+
+#: src/trait/drop.md:22
+msgid "\"> Dropping {}\""
+msgstr ""
+
+#: src/trait/drop.md:27 src/std_misc/path.md:33 src/std_misc/fs.md:44
+#: src/std_misc/fs.md:87
+msgid "\"a\""
+msgstr ""
+
+#: src/trait/drop.md:29
+msgid "// block A\n"
+msgstr ""
+
+#: src/trait/drop.md:31 src/std_misc/path.md:33
+msgid "\"b\""
+msgstr ""
+
+#: src/trait/drop.md:33
+msgid "// block B\n"
+msgstr ""
+
+#: src/trait/drop.md:35 src/std_misc/path.md:36
+msgid "\"c\""
+msgstr ""
+
+#: src/trait/drop.md:36
+msgid "\"d\""
+msgstr ""
+
+#: src/trait/drop.md:38
+msgid "\"Exiting block B\""
+msgstr ""
+
+#: src/trait/drop.md:40
+msgid "\"Just exited block B\""
+msgstr ""
+
+#: src/trait/drop.md:42
+msgid "\"Exiting block A\""
+msgstr ""
+
+#: src/trait/drop.md:44
+msgid "\"Just exited block A\""
+msgstr ""
+
+#: src/trait/drop.md:46
+msgid "// Variable can be manually dropped using the `drop` function\n"
+msgstr ""
+
+#: src/trait/drop.md:48
+msgid "// TODO ^ Try commenting this line\n"
+msgstr ""
+
+#: src/trait/drop.md:50
+msgid "\"end of the main function\""
+msgstr ""
+
+#: src/trait/drop.md:52
+msgid ""
+"// `_a` *won't* be `drop`ed again here, because it already has been\n"
+"    // (manually) `drop`ed\n"
+msgstr ""
+
+#: src/trait/iter.md:3
+msgid ""
+"The [`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
+"trait is used to implement iterators over collections such as arrays."
+msgstr ""
+
+#: src/trait/iter.md:6
+msgid ""
+"The trait requires only a method to be defined for the `next` element, which "
+"may be manually defined in an `impl` block or automatically defined (as in "
+"arrays and ranges)."
+msgstr ""
+
+#: src/trait/iter.md:10
+msgid ""
+"As a point of convenience for common situations, the `for` construct turns "
+"some collections into iterators using the [`.into_iter()`](https://doc.rust-"
+"lang.org/std/iter/trait.IntoIterator.html) method."
+msgstr ""
+
+#: src/trait/iter.md:18
+msgid ""
+"// Implement `Iterator` for `Fibonacci`.\n"
+"// The `Iterator` trait only requires a method to be defined for the `next` "
+"element.\n"
+msgstr ""
+
+#: src/trait/iter.md:22
+msgid "// We can refer to this type using Self::Item\n"
+msgstr ""
+
+#: src/trait/iter.md:25
+msgid ""
+"// Here, we define the sequence using `.curr` and `.next`.\n"
+"    // The return type is `Option<T>`:\n"
+"    //     * When the `Iterator` is finished, `None` is returned.\n"
+"    //     * Otherwise, the next value is wrapped in `Some` and returned.\n"
+"    // We use Self::Item in the return type, so we can change\n"
+"    // the type without having to update the function signatures.\n"
+msgstr ""
+
+#: src/trait/iter.md:37
+msgid ""
+"// Since there's no endpoint to a Fibonacci sequence, the `Iterator` \n"
+"        // will never return `None`, and `Some` is always returned.\n"
+msgstr ""
+
+#: src/trait/iter.md:42
+msgid "// Returns a Fibonacci sequence generator\n"
+msgstr ""
+
+#: src/trait/iter.md:49
+msgid "// `0..3` is an `Iterator` that generates: 0, 1, and 2.\n"
+msgstr ""
+
+#: src/trait/iter.md:52
+msgid "\"Four consecutive `next` calls on 0..3\""
+msgstr ""
+
+#: src/trait/iter.md:53 src/trait/iter.md:54 src/trait/iter.md:55
+#: src/trait/iter.md:56 src/std_misc/fs.md:90
+msgid "\"> {:?}\""
+msgstr ""
+
+#: src/trait/iter.md:58
+msgid ""
+"// `for` works through an `Iterator` until it returns `None`.\n"
+"    // Each `Some` value is unwrapped and bound to a variable (here, `i`).\n"
+msgstr ""
+
+#: src/trait/iter.md:60
+msgid "\"Iterate through 0..3 using `for`\""
+msgstr ""
+
+#: src/trait/iter.md:62 src/trait/iter.md:68 src/trait/iter.md:74
+#: src/trait/iter.md:82 src/std/vec.md:49 src/std/str.md:22
+#: src/std_misc/fs.md:82
+msgid "\"> {}\""
+msgstr ""
+
+#: src/trait/iter.md:65
+msgid "// The `take(n)` method reduces an `Iterator` to its first `n` terms.\n"
+msgstr ""
+
+#: src/trait/iter.md:66
+msgid "\"The first four terms of the Fibonacci sequence are: \""
+msgstr ""
+
+#: src/trait/iter.md:71
+msgid ""
+"// The `skip(n)` method shortens an `Iterator` by dropping its first `n` "
+"terms.\n"
+msgstr ""
+
+#: src/trait/iter.md:72
+msgid "\"The next four terms of the Fibonacci sequence are: \""
+msgstr ""
+
+#: src/trait/iter.md:79
+msgid "// The `iter` method produces an `Iterator` over an array/slice.\n"
+msgstr ""
+
+#: src/trait/iter.md:80
+msgid "\"Iterate the following array {:?}\""
+msgstr ""
+
+#: src/trait/impl_trait.md:3
+msgid "`impl Trait` can be used in two locations:"
+msgstr ""
+
+#: src/trait/impl_trait.md:5
+msgid "as an argument type"
+msgstr ""
+
+#: src/trait/impl_trait.md:6
+msgid "as a return type"
+msgstr ""
+
+#: src/trait/impl_trait.md:8
+msgid "As an argument type"
+msgstr ""
+
+#: src/trait/impl_trait.md:10
+msgid ""
+"If your function is generic over a trait but you don't mind the specific "
+"type, you can simplify the function declaration using `impl Trait` as the "
+"type of the argument."
+msgstr ""
+
+#: src/trait/impl_trait.md:12
+msgid "For example, consider the following code:"
+msgstr ""
+
+#: src/trait/impl_trait.md:18 src/trait/impl_trait.md:37
+msgid "// For each line in the source\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:20 src/trait/impl_trait.md:39
+msgid ""
+"// If the line was read successfully, process it, if not, return the error\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40 src/std/str.md:41
+msgid "','"
+msgstr ""
+
+#: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40
+msgid "// Split the line separated by commas\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:22 src/trait/impl_trait.md:41
+msgid "// Remove leading and trailing whitespace\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:23 src/trait/impl_trait.md:42
+msgid "// Collect all strings in a row into a Vec<String>\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:26 src/trait/impl_trait.md:45
+msgid "// Collect all lines into a Vec<Vec<String>>\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:30
+msgid ""
+"`parse_csv_document` is generic, allowing it to take any type which "
+"implements BufRead, such as `BufReader<File>` or `[u8]`, but it's not "
+"important what type `R` is, and `R` is only used to declare the type of "
+"`src`, so the function can also be written as:"
+msgstr ""
+
+#: src/trait/impl_trait.md:49
+msgid ""
+"Note that using `impl Trait` as an argument type means that you cannot "
+"explicitly state what form of the function you use, i.e. `parse_csv_document::"
+"<std::io::Empty>(std::io::empty())` will not work with the second example."
+msgstr ""
+
+#: src/trait/impl_trait.md:52
+msgid "As a return type"
+msgstr ""
+
+#: src/trait/impl_trait.md:54
+msgid ""
+"If your function returns a type that implements `MyTrait`, you can write its "
+"return type as `-> impl MyTrait`. This can help simplify your type signatures "
+"quite a lot!"
+msgstr ""
+
+#: src/trait/impl_trait.md:60
+msgid ""
+"// This function combines two `Vec<i32>` and returns an iterator over it.\n"
+"// Look how complicated its return type is!\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:69
+msgid ""
+"// This is the exact same function, but its return type uses `impl Trait`.\n"
+"// Look how much simpler it is!\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:88
+msgid "\"all done\""
+msgstr ""
+
+#: src/trait/impl_trait.md:92
+msgid ""
+"More importantly, some Rust types can't be written out. For example, every "
+"closure has its own unnamed concrete type. Before `impl Trait` syntax, you "
+"had to allocate on the heap in order to return a closure. But now you can do "
+"it all statically, like this:"
+msgstr ""
+
+#: src/trait/impl_trait.md:98
+msgid "// Returns a function that adds `y` to its input\n"
+msgstr ""
+
+#: src/trait/impl_trait.md:110
+msgid ""
+"You can also use `impl Trait` to return an iterator that uses `map` or "
+"`filter` closures! This makes using `map` and `filter` easier. Because "
+"closure types don't have names, you can't write out an explicit return type "
+"if your function returns iterators with closures. But with `impl Trait` you "
+"can do this easily:"
+msgstr ""
+
+#: src/trait/clone.md:3
+msgid ""
+"When dealing with resources, the default behavior is to transfer them during "
+"assignments or function calls. However, sometimes we need to make a copy of "
+"the resource as well."
+msgstr ""
+
+#: src/trait/clone.md:7
+msgid ""
+"The [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait "
+"helps us do exactly this. Most commonly, we can use the `.clone()` method "
+"defined by the `Clone` trait."
+msgstr ""
+
+#: src/trait/clone.md:11
+msgid "// A unit struct without resources\n"
+msgstr ""
+
+#: src/trait/clone.md:14
+msgid "// A tuple struct with resources that implements the `Clone` trait\n"
+msgstr ""
+
+#: src/trait/clone.md:20
+msgid "// Instantiate `Unit`\n"
+msgstr ""
+
+#: src/trait/clone.md:22
+msgid "// Copy `Unit`, there are no resources to move\n"
+msgstr ""
+
+#: src/trait/clone.md:25
+msgid "// Both `Unit`s can be used independently\n"
+msgstr ""
+
+#: src/trait/clone.md:26 src/trait/clone.md:31
+msgid "\"original: {:?}\""
+msgstr ""
+
+#: src/trait/clone.md:27
+msgid "\"copy: {:?}\""
+msgstr ""
+
+#: src/trait/clone.md:29
+msgid "// Instantiate `Pair`\n"
+msgstr ""
+
+#: src/trait/clone.md:33
+msgid "// Move `pair` into `moved_pair`, moves resources\n"
+msgstr ""
+
+#: src/trait/clone.md:35
+msgid "\"moved: {:?}\""
+msgstr ""
+
+#: src/trait/clone.md:37
+msgid ""
+"// Error! `pair` has lost its resources\n"
+"    //println!(\"original: {:?}\", pair);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/trait/clone.md:41
+msgid "// Clone `moved_pair` into `cloned_pair` (resources are included)\n"
+msgstr ""
+
+#: src/trait/clone.md:43
+msgid "// Drop the moved original pair using std::mem::drop\n"
+msgstr ""
+
+#: src/trait/clone.md:46
+msgid ""
+"// Error! `moved_pair` has been dropped\n"
+"    //println!(\"moved and dropped: {:?}\", moved_pair);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/trait/clone.md:50
+msgid "// The result from .clone() can still be used!\n"
+msgstr ""
+
+#: src/trait/clone.md:51
+msgid "\"clone: {:?}\""
+msgstr ""
+
+#: src/trait/supertraits.md:3
+msgid ""
+"Rust doesn't have \"inheritance\", but you can define a trait as being a "
+"superset of another trait. For example:"
+msgstr ""
+
+#: src/trait/supertraits.md:10
+msgid ""
+"// Person is a supertrait of Student.\n"
+"// Implementing Student requires you to also impl Person.\n"
+msgstr ""
+
+#: src/trait/supertraits.md:20
+msgid ""
+"// CompSciStudent (computer science student) is a subtrait of both "
+"Programmer \n"
+"// and Student. Implementing CompSciStudent requires you to impl both "
+"supertraits.\n"
+msgstr ""
+
+#: src/trait/supertraits.md:29
+msgid ""
+"\"My name is {} and I attend {}. My favorite language is {}. My Git username "
+"is {}\""
+msgstr ""
+
+#: src/trait/supertraits.md:42
+msgid ""
+"[The Rust Programming Language chapter on supertraits](https://doc.rust-lang."
+"org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-"
+"functionality-within-another-trait)"
+msgstr ""
+
+#: src/trait/disambiguating.md:3
+msgid ""
+"A type can implement many different traits. What if two traits both require "
+"the same name for a function? For example, many traits might have a method "
+"named `get()`. They might even have different return types!"
+msgstr ""
+
+#: src/trait/disambiguating.md:7
+msgid ""
+"Good news: because each trait implementation gets its own `impl` block, it's "
+"clear which trait's `get` method you're implementing."
+msgstr ""
+
+#: src/trait/disambiguating.md:10
+msgid ""
+"What about when it comes time to _call_ those methods? To disambiguate "
+"between them, we have to use Fully Qualified Syntax."
+msgstr ""
+
+#: src/trait/disambiguating.md:15
+msgid "// Get the selected username out of this widget\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:20
+msgid "// Get the selected age out of this widget\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:23
+msgid "// A form with both a UsernameWidget and an AgeWidget\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:44 src/trait/disambiguating.md:54
+msgid "\"rustacean\""
+msgstr ""
+
+#: src/trait/disambiguating.md:48
+msgid ""
+"// If you uncomment this line, you'll get an error saying\n"
+"    // \"multiple `get` found\". Because, after all, there are multiple "
+"methods\n"
+"    // named `get`.\n"
+"    // println!(\"{}\", form.get());\n"
+msgstr ""
+
+#: src/trait/disambiguating.md:62
+msgid ""
+"[The Rust Programming Language chapter on Fully Qualified syntax](https://doc."
+"rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-"
+"disambiguation-calling-methods-with-the-same-name)"
+msgstr ""
+
+#: src/macros.md:3
+msgid ""
+"Rust provides a powerful macro system that allows metaprogramming. As you've "
+"seen in previous chapters, macros look like functions, except that their name "
+"ends with a bang `!`, but instead of generating a function call, macros are "
+"expanded into source code that gets compiled with the rest of the program. "
+"However, unlike macros in C and other languages, Rust macros are expanded "
+"into abstract syntax trees, rather than string preprocessing, so you don't "
+"get unexpected precedence bugs."
+msgstr ""
+
+#: src/macros.md:11
+msgid "Macros are created using the `macro_rules!` macro."
+msgstr ""
+
+#: src/macros.md:14
+msgid "// This is a simple macro named `say_hello`.\n"
+msgstr ""
+
+#: src/macros.md:16
+msgid "// `()` indicates that the macro takes no argument.\n"
+msgstr ""
+
+#: src/macros.md:18
+msgid "// The macro will expand into the contents of this block.\n"
+msgstr ""
+
+#: src/macros.md:19
+msgid "\"Hello!\""
+msgstr ""
+
+#: src/macros.md:24
+msgid "// This call will expand into `println!(\"Hello!\")`\n"
+msgstr ""
+
+#: src/macros.md:29
+msgid "So why are macros useful?"
+msgstr ""
+
+#: src/macros.md:31
+msgid ""
+"Don't repeat yourself. There are many cases where you may need similar "
+"functionality in multiple places but with different types. Often, writing a "
+"macro is a useful way to avoid repeating code. (More on this later)"
+msgstr ""
+
+#: src/macros.md:35
+msgid ""
+"Domain-specific languages. Macros allow you to define special syntax for a "
+"specific purpose. (More on this later)"
+msgstr ""
+
+#: src/macros.md:38
+msgid ""
+"Variadic interfaces. Sometimes you want to define an interface that takes a "
+"variable number of arguments. An example is `println!` which could take any "
+"number of arguments, depending on the format string. (More on this later)"
+msgstr ""
+
+#: src/macros/syntax.md:3
+msgid ""
+"In following subsections, we will show how to define macros in Rust. There "
+"are three basic ideas:"
+msgstr ""
+
+#: src/macros/syntax.md:6
+msgid "[Patterns and Designators](designators.md)"
+msgstr ""
+
+#: src/macros/syntax.md:7
+msgid "[Overloading](overload.md)"
+msgstr ""
+
+#: src/macros/syntax.md:8
+msgid "[Repetition](repeat.md)"
+msgstr ""
+
+#: src/macros/designators.md:3
+msgid ""
+"The arguments of a macro are prefixed by a dollar sign `$` and type annotated "
+"with a _designator_:"
+msgstr ""
+
+#: src/macros/designators.md:8
+msgid ""
+"// This macro takes an argument of designator `ident` and\n"
+"    // creates a function named `$func_name`.\n"
+"    // The `ident` designator is used for variable/function names.\n"
+msgstr ""
+
+#: src/macros/designators.md:13
+msgid "// The `stringify!` macro converts an `ident` into a string.\n"
+msgstr ""
+
+#: src/macros/designators.md:14
+msgid "\"You called {:?}()\""
+msgstr ""
+
+#: src/macros/designators.md:19
+msgid "// Create functions named `foo` and `bar` with the above macro.\n"
+msgstr ""
+
+#: src/macros/designators.md:25
+msgid ""
+"// This macro takes an expression of type `expr` and prints\n"
+"    // it as a string along with its result.\n"
+"    // The `expr` designator is used for expressions.\n"
+msgstr ""
+
+#: src/macros/designators.md:29
+msgid "// `stringify!` will convert the expression *as it is* into a string.\n"
+msgstr ""
+
+#: src/macros/designators.md:30
+msgid "\"{:?} = {:?}\""
+msgstr ""
+
+#: src/macros/designators.md:42
+msgid "// Recall that blocks are expressions too!\n"
+msgstr ""
+
+#: src/macros/designators.md:51
+msgid "These are some of the available designators:"
+msgstr ""
+
+#: src/macros/designators.md:53
+msgid "`block`"
+msgstr ""
+
+#: src/macros/designators.md:54
+msgid "`expr` is used for expressions"
+msgstr ""
+
+#: src/macros/designators.md:55
+msgid "`ident` is used for variable/function names"
+msgstr ""
+
+#: src/macros/designators.md:56
+msgid "`item`"
+msgstr ""
+
+#: src/macros/designators.md:57
+msgid "`literal` is used for literal constants"
+msgstr ""
+
+#: src/macros/designators.md:58
+msgid "`pat` (_pattern_)"
+msgstr ""
+
+#: src/macros/designators.md:59
+msgid "`path`"
+msgstr ""
+
+#: src/macros/designators.md:60
+msgid "`stmt` (_statement_)"
+msgstr ""
+
+#: src/macros/designators.md:61
+msgid "`tt` (_token tree_)"
+msgstr ""
+
+#: src/macros/designators.md:62
+msgid "`ty` (_type_)"
+msgstr ""
+
+#: src/macros/designators.md:63
+msgid "`vis` (_visibility qualifier_)"
+msgstr ""
+
+#: src/macros/designators.md:65
+msgid ""
+"For a complete list, see the [Rust Reference](https://doc.rust-lang.org/"
+"reference/macros-by-example.html)."
+msgstr ""
+
+#: src/macros/overload.md:3
+msgid ""
+"Macros can be overloaded to accept different combinations of arguments. In "
+"that regard, `macro_rules!` can work similarly to a match block:"
+msgstr ""
+
+#: src/macros/overload.md:7
+msgid ""
+"// `test!` will compare `$left` and `$right`\n"
+"// in different ways depending on how you invoke it:\n"
+msgstr ""
+
+#: src/macros/overload.md:10
+msgid ""
+"// Arguments don't need to be separated by a comma.\n"
+"    // Any template can be used!\n"
+msgstr ""
+
+#: src/macros/overload.md:13
+msgid "\"{:?} and {:?} is {:?}\""
+msgstr ""
+
+#: src/macros/overload.md:18
+msgid "// ^ each arm must end with a semicolon.\n"
+msgstr ""
+
+#: src/macros/overload.md:20
+msgid "\"{:?} or {:?} is {:?}\""
+msgstr ""
+
+#: src/macros/repeat.md:3
+msgid ""
+"Macros can use `+` in the argument list to indicate that an argument may "
+"repeat at least once, or `*`, to indicate that the argument may repeat zero "
+"or more times."
+msgstr ""
+
+#: src/macros/repeat.md:7
+msgid ""
+"In the following example, surrounding the matcher with `$(...),+` will match "
+"one or more expression, separated by commas. Also note that the semicolon is "
+"optional on the last case."
+msgstr ""
+
+#: src/macros/repeat.md:12
+msgid "// `find_min!` will calculate the minimum of any number of arguments.\n"
+msgstr ""
+
+#: src/macros/repeat.md:14
+msgid "// Base case:\n"
+msgstr ""
+
+#: src/macros/repeat.md:16
+msgid "// `$x` followed by at least one `$y,`\n"
+msgstr ""
+
+#: src/macros/repeat.md:18
+msgid "// Call `find_min!` on the tail `$y`\n"
+msgstr ""
+
+#: src/macros/dry.md:3
+msgid ""
+"Macros allow writing DRY code by factoring out the common parts of functions "
+"and/or test suites. Here is an example that implements and tests the `+=`, "
+"`*=` and `-=` operators on `Vec<T>`:"
+msgstr ""
+
+#: src/macros/dry.md:11
+msgid ""
+"// The `tt` (token tree) designator is used for\n"
+"    // operators and tokens.\n"
+msgstr ""
+
+#: src/macros/dry.md:15
+msgid "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
+msgstr ""
+
+#: src/macros/dry.md:30
+msgid "// *x = x.$method(*y);\n"
+msgstr ""
+
+#: src/macros/dry.md:35
+msgid "// Implement `add_assign`, `mul_assign`, and `sub_assign` functions.\n"
+msgstr ""
+
+#: src/macros/dry.md:60
+msgid "// Test `add_assign`, `mul_assign`, and `sub_assign`.\n"
+msgstr ""
+
+#: src/macros/dsl.md:1
+msgid "Domain Specific Languages (DSLs)"
+msgstr ""
+
+#: src/macros/dsl.md:3
+msgid ""
+"A DSL is a mini \"language\" embedded in a Rust macro. It is completely valid "
+"Rust because the macro system expands into normal Rust constructs, but it "
+"looks like a small language. This allows you to define concise or intuitive "
+"syntax for some special functionality (within bounds)."
+msgstr ""
+
+#: src/macros/dsl.md:8
+msgid ""
+"Suppose that I want to define a little calculator API. I would like to supply "
+"an expression and have the output printed to console."
+msgstr ""
+
+#: src/macros/dsl.md:15
+msgid "// Force types to be unsigned integers\n"
+msgstr ""
+
+#: src/macros/dsl.md:16 src/macros/variadics.md:15
+msgid "\"{} = {}\""
+msgstr ""
+
+#: src/macros/dsl.md:23
+msgid "// hehehe `eval` is _not_ a Rust keyword!\n"
+msgstr ""
+
+#: src/macros/dsl.md:32 src/macros/variadics.md:35
+msgid "Output:"
+msgstr ""
+
+#: src/macros/dsl.md:39
+msgid ""
+"This was a very simple example, but much more complex interfaces have been "
+"developed, such as [`lazy_static`](https://crates.io/crates/lazy_static) or "
+"[`clap`](https://crates.io/crates/clap)."
+msgstr ""
+
+#: src/macros/dsl.md:43
+msgid ""
+"Also, note the two pairs of braces in the macro. The outer ones are part of "
+"the syntax of `macro_rules!`, in addition to `()` or `[]`."
+msgstr ""
+
+#: src/macros/variadics.md:1
+msgid "Variadic Interfaces"
+msgstr ""
+
+#: src/macros/variadics.md:3
+msgid ""
+"A _variadic_ interface takes an arbitrary number of arguments. For example, "
+"`println!` can take an arbitrary number of arguments, as determined by the "
+"format string."
+msgstr ""
+
+#: src/macros/variadics.md:7
+msgid ""
+"We can extend our `calculate!` macro from the previous section to be variadic:"
+msgstr ""
+
+#: src/macros/variadics.md:11
+msgid "// The pattern for a single `eval`\n"
+msgstr ""
+
+#: src/macros/variadics.md:14
+msgid "// Force types to be integers\n"
+msgstr ""
+
+#: src/macros/variadics.md:19
+msgid "// Decompose multiple `eval`s recursively\n"
+msgstr ""
+
+#: src/macros/variadics.md:27
+msgid "// Look ma! Variadic `calculate!`!\n"
+msgstr ""
+
+#: src/error.md:3
+msgid ""
+"Error handling is the process of handling the possibility of failure. For "
+"example, failing to read a file and then continuing to use that _bad_ input "
+"would clearly be problematic. Noticing and explicitly managing those errors "
+"saves the rest of the program from various pitfalls."
+msgstr ""
+
+#: src/error.md:8
+msgid ""
+"There are various ways to deal with errors in Rust, which are described in "
+"the following subchapters. They all have more or less subtle differences and "
+"different use cases. As a rule of thumb:"
+msgstr ""
+
+#: src/error.md:12
+msgid ""
+"An explicit `panic` is mainly useful for tests and dealing with unrecoverable "
+"errors. For prototyping it can be useful, for example when dealing with "
+"functions that haven't been implemented yet, but in those cases the more "
+"descriptive `unimplemented` is better. In tests `panic` is a reasonable way "
+"to explicitly fail."
+msgstr ""
+
+#: src/error.md:17
+msgid ""
+"The `Option` type is for when a value is optional or when the lack of a value "
+"is not an error condition. For example the parent of a directory - `/` and `C:"
+"` don't have one. When dealing with `Option`s, `unwrap` is fine for "
+"prototyping and cases where it's absolutely certain that there is guaranteed "
+"to be a value. However `expect` is more useful since it lets you specify an "
+"error message in case something goes wrong anyway."
+msgstr ""
+
+#: src/error.md:24
+msgid ""
+"When there is a chance that things do go wrong and the caller has to deal "
+"with the problem, use `Result`. You can `unwrap` and `expect` them as well "
+"(please don't do that unless it's a test or quick prototype)."
+msgstr ""
+
+#: src/error.md:28
+msgid ""
+"For a more rigorous discussion of error handling, refer to the error handling "
+"section in the [official book](https://doc.rust-lang.org/book/ch09-00-error-"
+"handling.html)."
+msgstr ""
+
+#: src/error/panic.md:3
+msgid ""
+"The simplest error handling mechanism we will see is `panic`. It prints an "
+"error message, starts unwinding the stack, and usually exits the program. "
+"Here, we explicitly call `panic` on our error condition:"
+msgstr ""
+
+#: src/error/panic.md:9 src/error/abort_unwind.md:10
+msgid "// You shouldn't drink too much sugary beverages.\n"
+msgstr ""
+
+#: src/error/panic.md:10 src/error/panic.md:17 src/error/abort_unwind.md:11
+#: src/error/abort_unwind.md:24 src/error/abort_unwind.md:42
+#: src/error/abort_unwind.md:51 src/error/option_unwrap.md:32
+#: src/error/option_unwrap.md:43 src/error/option_unwrap.md:50
+msgid "\"lemonade\""
+msgstr ""
+
+#: src/error/panic.md:10 src/error/option_unwrap.md:43
+msgid "\"AAAaaaaa!!!!\""
+msgstr ""
+
+#: src/error/panic.md:12 src/error/abort_unwind.md:18
+#: src/error/abort_unwind.md:45
+msgid "\"Some refreshing {} is all I need.\""
+msgstr ""
+
+#: src/error/panic.md:16 src/error/abort_unwind.md:23
+#: src/error/abort_unwind.md:50 src/error/option_unwrap.md:49
+msgid "\"water\""
+msgstr ""
+
+#: src/error/panic.md:18
+msgid "\"still water\""
+msgstr ""
+
+#: src/error/panic.md:22
+msgid ""
+"The first call to `drink` works. The second panics and thus the third is "
+"never called."
+msgstr ""
+
+#: src/error/abort_unwind.md:1
+msgid "`abort` and `unwind`"
+msgstr ""
+
+#: src/error/abort_unwind.md:3
+msgid ""
+"The previous section illustrates the error handling mechanism `panic`.  "
+"Different code paths can be conditionally compiled based on the panic "
+"setting. The current values available are `unwind` and `abort`."
+msgstr ""
+
+#: src/error/abort_unwind.md:6
+msgid ""
+"Building on the prior lemonade example, we explicitly use the panic strategy "
+"to exercise different lines of code."
+msgstr ""
+
+#: src/error/abort_unwind.md:12
+msgid "\"abort\""
+msgstr ""
+
+#: src/error/abort_unwind.md:13 src/error/abort_unwind.md:38
+msgid "\"This is not your party. Run!!!!\""
+msgstr ""
+
+#: src/error/abort_unwind.md:15 src/error/abort_unwind.md:33
+msgid "\"Spit it out!!!!\""
+msgstr ""
+
+#: src/error/abort_unwind.md:28
+msgid ""
+"Here is another example focusing on rewriting `drink()` and explicitly use "
+"the `unwind` keyword."
+msgstr ""
+
+#: src/error/abort_unwind.md:31 src/error/abort_unwind.md:36
+msgid "\"unwind\""
+msgstr ""
+
+#: src/error/abort_unwind.md:55
+msgid ""
+"The panic strategy can be set from the command line by using `abort` or "
+"`unwind`."
+msgstr ""
+
+#: src/error/option_unwrap.md:3
+msgid ""
+"In the last example, we showed that we can induce program failure at will. We "
+"told our program to `panic` if we drink a sugary lemonade. But what if we "
+"expect _some_ drink but don't receive one? That case would be just as bad, so "
+"it needs to be handled!"
+msgstr ""
+
+#: src/error/option_unwrap.md:8
+msgid ""
+"We _could_ test this against the null string (`\"\"`) as we do with a "
+"lemonade. Since we're using Rust, let's instead have the compiler point out "
+"cases where there's no drink."
+msgstr ""
+
+#: src/error/option_unwrap.md:12
+msgid ""
+"An `enum` called `Option<T>` in the `std` library is used when absence is a "
+"possibility. It manifests itself as one of two \"options\":"
+msgstr ""
+
+#: src/error/option_unwrap.md:15
+msgid "`Some(T)`: An element of type `T` was found"
+msgstr ""
+
+#: src/error/option_unwrap.md:16
+msgid "`None`: No element was found"
+msgstr ""
+
+#: src/error/option_unwrap.md:18
+msgid ""
+"These cases can either be explicitly handled via `match` or implicitly with "
+"`unwrap`. Implicit handling will either return the inner element or `panic`."
+msgstr ""
+
+#: src/error/option_unwrap.md:21
+msgid ""
+"Note that it's possible to manually customize `panic` with [expect](https://"
+"doc.rust-lang.org/std/option/enum.Option.html#method.expect), but `unwrap` "
+"otherwise leaves us with a less meaningful output than explicit handling. In "
+"the following example, explicit handling yields a more controlled result "
+"while retaining the option to `panic` if desired."
+msgstr ""
+
+#: src/error/option_unwrap.md:27
+msgid ""
+"// The adult has seen it all, and can handle any drink well.\n"
+"// All drinks are handled explicitly using `match`.\n"
+msgstr ""
+
+#: src/error/option_unwrap.md:30
+msgid "// Specify a course of action for each case.\n"
+msgstr ""
+
+#: src/error/option_unwrap.md:32
+msgid "\"Yuck! Too sugary.\""
+msgstr ""
+
+#: src/error/option_unwrap.md:33
+msgid "\"{}? How nice.\""
+msgstr ""
+
+#: src/error/option_unwrap.md:34
+msgid "\"No drink? Oh well.\""
+msgstr ""
+
+#: src/error/option_unwrap.md:37
+msgid ""
+"// Others will `panic` before drinking sugary drinks.\n"
+"// All drinks are handled implicitly using `unwrap`.\n"
+msgstr ""
+
+#: src/error/option_unwrap.md:41
+msgid "// `unwrap` returns a `panic` when it receives a `None`.\n"
+msgstr ""
+
+#: src/error/option_unwrap.md:45
+msgid "\"I love {}s!!!!!\""
+msgstr ""
+
+#: src/error/option_unwrap.md:57
+msgid "\"coffee\""
+msgstr ""
+
+#: src/error/option_unwrap/question_mark.md:3
+msgid ""
+"You can unpack `Option`s by using `match` statements, but it's often easier "
+"to use the `?` operator. If `x` is an `Option`, then evaluating `x?` will "
+"return the underlying value if `x` is `Some`, otherwise it will terminate "
+"whatever function is being executed and return `None`."
+msgstr ""
+
+#: src/error/option_unwrap/question_mark.md:10
+msgid ""
+"// If `current_age` is `None`, this returns `None`.\n"
+"\t// If `current_age` is `Some`, the inner `u8` value + 1\n"
+"    // gets assigned to `next_age`\n"
+msgstr ""
+
+#: src/error/option_unwrap/question_mark.md:14
+msgid "\"Next year I will be {}\""
+msgstr ""
+
+#: src/error/option_unwrap/question_mark.md:18
+msgid "You can chain many `?`s together to make your code much more readable."
+msgstr ""
+
+#: src/error/option_unwrap/question_mark.md:38
+msgid ""
+"// Gets the area code of the phone number of the person's job, if it exists.\n"
+msgstr ""
+
+#: src/error/option_unwrap/question_mark.md:40
+msgid ""
+"// This would need many nested `match` statements without the `?` operator.\n"
+"        // It would take a lot more code - try writing it yourself and see "
+"which\n"
+"        // is easier.\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:3
+msgid ""
+"`match` is a valid method for handling `Option`s. However, you may eventually "
+"find heavy usage tedious, especially with operations only valid with an "
+"input. In these cases, [combinators](https://doc.rust-lang.org/reference/"
+"glossary.html#combinator) can be used to manage control flow in a modular "
+"fashion."
+msgstr ""
+
+#: src/error/option_unwrap/map.md:8
+msgid ""
+"`Option` has a built in method called `map()`, a combinator for the simple "
+"mapping of `Some -> Some` and `None -> None`. Multiple `map()` calls can be "
+"chained together for even more flexibility."
+msgstr ""
+
+#: src/error/option_unwrap/map.md:12
+msgid ""
+"In the following example, `process()` replaces all functions previous to it "
+"while staying compact."
+msgstr ""
+
+#: src/error/option_unwrap/map.md:23
+msgid ""
+"// Peeling food. If there isn't any, then return `None`.\n"
+"// Otherwise, return the peeled food.\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:32
+msgid ""
+"// Chopping food. If there isn't any, then return `None`.\n"
+"// Otherwise, return the chopped food.\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:41
+msgid ""
+"// Cooking food. Here, we showcase `map()` instead of `match` for case "
+"handling.\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:46
+msgid ""
+"// A function to peel, chop, and cook food all in sequence.\n"
+"// We chain multiple uses of `map()` to simplify the code.\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:54
+msgid "// Check whether there's food or not before trying to eat it!\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:58
+msgid "\"Mmm. I love {:?}\""
+msgstr ""
+
+#: src/error/option_unwrap/map.md:59
+msgid "\"Oh no! It wasn't edible.\""
+msgstr ""
+
+#: src/error/option_unwrap/map.md:70
+msgid "// Let's try the simpler looking `process()` now.\n"
+msgstr ""
+
+#: src/error/option_unwrap/map.md:81
+msgid ""
+"[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html#method.map)"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:3
+msgid ""
+"`map()` was described as a chainable way to simplify `match` statements. "
+"However, using `map()` on a function that returns an `Option<T>` results in "
+"the nested `Option<Option<T>>`. Chaining multiple calls together can then "
+"become confusing. That's where another combinator called `and_then()`, known "
+"in some languages as flatmap, comes in."
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:9
+msgid ""
+"`and_then()` calls its function input with the wrapped value and returns the "
+"result. If the `Option` is `None`, then it returns `None` instead."
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:11
+msgid ""
+"In the following example, `cookable_v3()` results in an `Option<Food>`. Using "
+"`map()` instead of `and_then()` would have given an `Option<Option<Food>>`, "
+"which is an invalid type for `eat()`."
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:20
+msgid "// We don't have the ingredients to make Sushi.\n"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:28
+msgid "// We have the recipe for everything except Cordon Bleu.\n"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:36
+msgid ""
+"// To make a dish, we need both the recipe and the ingredients.\n"
+"// We can represent the logic with a chain of `match`es:\n"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:45
+msgid ""
+"// This can conveniently be rewritten more compactly with `and_then()`:\n"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:50
+msgid ""
+"// Otherwise we'd need to `flatten()` an `Option<Option<Food>>`\n"
+"// to get an `Option<Food>`:\n"
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:59
+msgid "\"Yay! On {:?} we get to eat {:?}.\""
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:60
+msgid "\"Oh no. We don't get to eat on {:?}?\""
+msgstr ""
+
+#: src/error/option_unwrap/and_then.md:75
+msgid ""
+"[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/"
+"std/option/enum.Option.html#method.and_then), and [`Option::flatten()`]"
+"(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:1
+msgid "Unpacking options and defaults"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:3
+msgid ""
+"There is more than one way to unpack an `Option` and fall back on a default "
+"if it is `None`. To choose the one that meets our needs, we need to consider "
+"the following:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:4
+msgid "do we need eager or lazy evaluation?"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:5
+msgid ""
+"do we need to keep the original empty value intact, or modify it in place?"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:7
+msgid "`or()` is chainable, evaluates eagerly, keeps empty value intact"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:9
+msgid ""
+"`or()`is chainable and eagerly evaluates its argument, as is shown in the "
+"following example. Note that because `or`'s arguments are evaluated eagerly, "
+"the variable passed to `or` is moved."
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:21 src/error/option_unwrap/defaults.md:54
+msgid "\"first_available_fruit: {:?}\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:22
+msgid "// first_available_fruit: Some(Orange)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:24
+msgid ""
+"// `or` moves its argument.\n"
+"    // In the example above, `or(orange)` returned a `Some`, so `or(apple)` "
+"was not invoked.\n"
+"    // But the variable named `apple` has been moved regardless, and cannot "
+"be used anymore.\n"
+"    // println!(\"Variable apple was moved, so this line won't compile: "
+"{:?}\", apple);\n"
+"    // TODO: uncomment the line above to see the compiler error\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:32
+msgid "`or_else()` is chainable, evaluates lazily, keeps empty value intact"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:34
+msgid ""
+"Another alternative is to use `or_else`, which is also chainable, and "
+"evaluates lazily, as is shown in the following example:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:43
+msgid "\"Providing kiwi as fallback\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:47 src/error/option_unwrap/defaults.md:91
+msgid "\"Providing lemon as fallback\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:55
+msgid ""
+"// Providing kiwi as fallback\n"
+"    // first_available_fruit: Some(Kiwi)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:60
+msgid "`get_or_insert()` evaluates eagerly, modifies empty value in place"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:62
+msgid ""
+"To make sure that an `Option` contains a value, we can use `get_or_insert` to "
+"modify it in place with a fallback value, as is shown in the following "
+"example. Note that `get_or_insert` eagerly evaluates its parameter, so "
+"variable `apple` is moved:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:72 src/error/option_unwrap/defaults.md:96
+msgid "\"first_available_fruit is: {:?}\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:73 src/error/option_unwrap/defaults.md:97
+msgid "\"my_fruit is: {:?}\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:74
+msgid ""
+"// first_available_fruit is: Apple\n"
+"    // my_fruit is: Some(Apple)\n"
+"    //println!(\"Variable named `apple` is moved: {:?}\", apple);\n"
+"    // TODO: uncomment the line above to see the compiler error\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:81
+msgid "`get_or_insert_with()` evaluates lazily, modifies empty value in place"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:83
+msgid ""
+"Instead of explicitly providing a value to fall back on, we can pass a "
+"closure to `get_or_insert_with`, as follows:"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:98
+msgid ""
+"// Providing lemon as fallback\n"
+"    // first_available_fruit is: Lemon\n"
+"    // my_fruit is: Some(Lemon)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:102
+msgid ""
+"// If the Option has a value, it is left unchanged, and the closure is not "
+"invoked\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:105
+msgid "\"should_be_apple is: {:?}\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:106
+msgid "\"my_apple is unchanged: {:?}\""
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:107
+msgid ""
+"// The output is a follows. Note that the closure `get_lemon_as_fallback` is "
+"not invoked\n"
+"    // should_be_apple is: Apple\n"
+"    // my_apple is unchanged: Some(Apple)\n"
+msgstr ""
+
+#: src/error/option_unwrap/defaults.md:115
+msgid ""
+"[`closures`](https://doc.rust-lang.org/book/ch13-01-closures.html), "
+"[`get_or_insert`](https://doc.rust-lang.org/core/option/enum.Option."
+"html#method.get_or_insert), [`get_or_insert_with`](https://doc.rust-lang.org/"
+"core/option/enum.Option.html#method.get_or_insert_with), [`moved variables`]"
+"(https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html), [`or`]"
+"(https://doc.rust-lang.org/core/option/enum.Option.html#method.or), "
+"[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
+"or_else)"
+msgstr ""
+
+#: src/error/result.md:3
+msgid ""
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) is a richer "
+"version of the [`Option`](https://doc.rust-lang.org/std/option/enum.Option."
+"html) type that describes possible _error_ instead of possible _absence_."
+msgstr ""
+
+#: src/error/result.md:6
+msgid "That is, `Result<T, E>` could have one of two outcomes:"
+msgstr ""
+
+#: src/error/result.md:8
+msgid "`Ok(T)`: An element `T` was found"
+msgstr ""
+
+#: src/error/result.md:9
+msgid "`Err(E)`: An error was found with element `E`"
+msgstr ""
+
+#: src/error/result.md:11
+msgid ""
+"By convention, the expected outcome is `Ok` while the unexpected outcome is "
+"`Err`."
+msgstr ""
+
+#: src/error/result.md:13
+msgid ""
+"Like `Option`, `Result` has many methods associated with it. `unwrap()`, for "
+"example, either yields the element `T` or `panic`s. For case handling, there "
+"are many combinators between `Result` and `Option` that overlap."
+msgstr ""
+
+#: src/error/result.md:17
+msgid ""
+"In working with Rust, you will likely encounter methods that return the "
+"`Result` type, such as the [`parse()`](https://doc.rust-lang.org/std/"
+"primitive.str.html#method.parse) method. It might not always be possible to "
+"parse a string into the other type, so `parse()` returns a `Result` "
+"indicating possible failure."
+msgstr ""
+
+#: src/error/result.md:22
+msgid ""
+"Let's see what happens when we successfully and unsuccessfully `parse()` a "
+"string:"
+msgstr ""
+
+#: src/error/result.md:26
+msgid "// Let's try using `unwrap()` to get the number out. Will it bite us?\n"
+msgstr ""
+
+#: src/error/result.md:33 src/error/result.md:36
+#: src/error/result/result_map.md:42 src/error/result/result_map.md:46
+#: src/error/result/result_map.md:75 src/error/result/result_map.md:79
+#: src/error/result/result_alias.md:36 src/error/result/result_alias.md:37
+#: src/error/result/early_returns.md:36 src/error/result/early_returns.md:37
+#: src/error/result/enter_question_mark.md:34
+#: src/error/result/enter_question_mark.md:35
+#: src/error/result/enter_question_mark.md:67
+#: src/error/result/enter_question_mark.md:68
+msgid "\"2\""
+msgstr ""
+
+#: src/error/result.md:34 src/error/result.md:37
+msgid "\"double is {}\""
+msgstr ""
+
+#: src/error/result.md:36 src/error/result/result_map.md:46
+#: src/error/result/result_map.md:79 src/error/result/result_alias.md:37
+#: src/error/result/early_returns.md:37
+#: src/error/result/enter_question_mark.md:35
+#: src/error/result/enter_question_mark.md:68
+msgid "\"t\""
+msgstr ""
+
+#: src/error/result.md:41
+msgid ""
+"In the unsuccessful case, `parse()` leaves us with an error for `unwrap()` to "
+"`panic` on. Additionally, the `panic` exits our program and provides an "
+"unpleasant error message."
+msgstr ""
+
+#: src/error/result.md:45
+msgid ""
+"To improve the quality of our error message, we should be more specific about "
+"the return type and consider explicitly handling the error."
+msgstr ""
+
+#: src/error/result.md:48
+msgid "Using `Result` in `main`"
+msgstr ""
+
+#: src/error/result.md:50
+msgid ""
+"The `Result` type can also be the return type of the `main` function if "
+"specified explicitly. Typically the `main` function will be of the form:"
+msgstr ""
+
+#: src/error/result.md:59
+msgid ""
+"However `main` is also able to have a return type of `Result`. If an error "
+"occurs within the `main` function it will return an error code and print a "
+"debug representation of the error (using the [`Debug`](https://doc.rust-lang."
+"org/std/fmt/trait.Debug.html) trait). The following example shows such a "
+"scenario and touches on aspects covered in [the following section](result/"
+"early_returns.md)."
+msgstr ""
+
+#: src/error/result/result_map.md:3
+msgid ""
+"Panicking in the previous example's `multiply` does not make for robust code. "
+"Generally, we want to return the error to the caller so it can decide what is "
+"the right way to respond to errors."
+msgstr ""
+
+#: src/error/result/result_map.md:7
+msgid ""
+"We first need to know what kind of error type we are dealing with. To "
+"determine the `Err` type, we look to [`parse()`](https://doc.rust-lang.org/"
+"std/primitive.str.html#method.parse), which is implemented with the "
+"[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
+"[`i32`](https://doc.rust-lang.org/std/primitive.i32.html). As a result, the "
+"`Err` type is specified as [`ParseIntError`](https://doc.rust-lang.org/std/"
+"num/struct.ParseIntError.html)."
+msgstr ""
+
+#: src/error/result/result_map.md:12
+msgid ""
+"In the example below, the straightforward `match` statement leads to code "
+"that is overall more cumbersome."
+msgstr ""
+
+#: src/error/result/result_map.md:17
+msgid ""
+"// With the return type rewritten, we use pattern matching without "
+"`unwrap()`.\n"
+msgstr ""
+
+#: src/error/result/result_map.md:35 src/error/result/result_map.md:68
+#: src/error/result/result_alias.md:30 src/error/result/early_returns.md:30
+#: src/error/result/enter_question_mark.md:28
+#: src/error/result/enter_question_mark.md:61
+msgid "\"n is {}\""
+msgstr ""
+
+#: src/error/result/result_map.md:36 src/error/result/result_map.md:69
+#: src/error/result/result_alias.md:31 src/error/result/early_returns.md:31
+#: src/error/result/enter_question_mark.md:29
+#: src/error/result/enter_question_mark.md:62
+#: src/error/multiple_error_types/define_error_type.md:55
+#: src/error/multiple_error_types/boxing_errors.md:42
+#: src/error/multiple_error_types/reenter_question_mark.md:54
+#: src/error/multiple_error_types/wrap_error.md:68
+msgid "\"Error: {}\""
+msgstr ""
+
+#: src/error/result/result_map.md:41 src/error/result/result_map.md:74
+msgid "// This still presents a reasonable answer.\n"
+msgstr ""
+
+#: src/error/result/result_map.md:45 src/error/result/result_map.md:78
+msgid "// The following now provides a much more helpful error message.\n"
+msgstr ""
+
+#: src/error/result/result_map.md:51
+msgid ""
+"Luckily, `Option`'s `map`, `and_then`, and many other combinators are also "
+"implemented for `Result`. [`Result`](https://doc.rust-lang.org/std/result/"
+"enum.Result.html) contains a complete listing."
+msgstr ""
+
+#: src/error/result/result_map.md:56
+msgid ""
+"// As with `Option`, we can use combinators such as `map()`.\n"
+"// This function is otherwise identical to the one above and reads:\n"
+"// Multiply if both values can be parsed from str, otherwise pass on the "
+"error.\n"
+msgstr ""
+
+#: src/error/result/result_alias.md:3
+msgid ""
+"How about when we want to reuse a specific `Result` type many times? Recall "
+"that Rust allows us to create [aliases](../../types/alias.md). Conveniently, "
+"we can define one for the specific `Result` in question."
+msgstr ""
+
+#: src/error/result/result_alias.md:7
+msgid ""
+"At a module level, creating aliases can be particularly helpful. Errors found "
+"in a specific module often have the same `Err` type, so a single alias can "
+"succinctly define _all_ associated `Results`. This is so useful that the "
+"`std` library even supplies one: [`io::Result`](https://doc.rust-lang.org/std/"
+"io/type.Result.html)!"
+msgstr ""
+
+#: src/error/result/result_alias.md:12
+msgid "Here's a quick example to show off the syntax:"
+msgstr ""
+
+#: src/error/result/result_alias.md:16
+msgid ""
+"// Define a generic alias for a `Result` with the error type "
+"`ParseIntError`.\n"
+msgstr ""
+
+#: src/error/result/result_alias.md:19
+msgid "// Use the above alias to refer to our specific `Result` type.\n"
+msgstr ""
+
+#: src/error/result/result_alias.md:26
+msgid "// Here, the alias again allows us to save some space.\n"
+msgstr ""
+
+#: src/error/result/result_alias.md:43
+msgid "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
+msgstr ""
+
+#: src/error/result/early_returns.md:3
+msgid ""
+"In the previous example, we explicitly handled the errors using combinators. "
+"Another way to deal with this case analysis is to use a combination of "
+"`match` statements and _early returns_."
+msgstr ""
+
+#: src/error/result/early_returns.md:7
+msgid ""
+"That is, we can simply stop executing the function and return the error if "
+"one occurs. For some, this form of code can be easier to both read and write. "
+"Consider this version of the previous example, rewritten using early returns:"
+msgstr ""
+
+#: src/error/result/early_returns.md:41
+msgid ""
+"At this point, we've learned to explicitly handle errors using combinators "
+"and early returns. While we generally want to avoid panicking, explicitly "
+"handling all of our errors is cumbersome."
+msgstr ""
+
+#: src/error/result/early_returns.md:45
+msgid ""
+"In the next section, we'll introduce `?` for the cases where we simply need "
+"to `unwrap` without possibly inducing `panic`."
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:3
+msgid ""
+"Sometimes we just want the simplicity of `unwrap` without the possibility of "
+"a `panic`. Until now, `unwrap` has forced us to nest deeper and deeper when "
+"what we really wanted was to get the variable _out_. This is exactly the "
+"purpose of `?`."
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:7
+msgid "Upon finding an `Err`, there are two valid actions to take:"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:9
+msgid "`panic!` which we already decided to try to avoid if possible"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:10
+msgid "`return` because an `Err` means it cannot be handled"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:12
+msgid ""
+"`?` is _almost_[^†] exactly equivalent to an `unwrap` which `return`s instead "
+"of `panic`king on `Err`s. Let's see how we can simplify the earlier example "
+"that used combinators:"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:39
+msgid "The `try!` macro"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:41
+msgid ""
+"Before there was `?`, the same functionality was achieved with the `try!` "
+"macro. The `?` operator is now recommended, but you may still find `try!` "
+"when looking at older code. The same `multiply` function from the previous "
+"example would look like this using `try!`:"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:47
+msgid ""
+"// To compile and run this example without errors, while using Cargo, change "
+"the value \n"
+"// of the `edition` field, in the `[package]` section of the `Cargo.toml` "
+"file, to \"2015\".\n"
+msgstr ""
+
+#: src/error/result/enter_question_mark.md:73
+msgid ""
+"See [re-enter ?](../multiple_error_types/reenter_question_mark.md) for more "
+"details."
+msgstr ""
+
+#: src/error/multiple_error_types.md:3
+msgid ""
+"The previous examples have always been very convenient; `Result`s interact "
+"with other `Result`s and `Option`s interact with other `Option`s."
+msgstr ""
+
+#: src/error/multiple_error_types.md:6
+msgid ""
+"Sometimes an `Option` needs to interact with a `Result`, or a `Result<T, "
+"Error1>` needs to interact with a `Result<T, Error2>`. In those cases, we "
+"want to manage our different error types in a way that makes them composable "
+"and easy to interact with."
+msgstr ""
+
+#: src/error/multiple_error_types.md:11
+msgid ""
+"In the following code, two instances of `unwrap` generate different error "
+"types. `Vec::first` returns an `Option`, while `parse::<i32>` returns a "
+"`Result<i32, ParseIntError>`:"
+msgstr ""
+
+#: src/error/multiple_error_types.md:17
+msgid "// Generate error 1\n"
+msgstr ""
+
+#: src/error/multiple_error_types.md:18
+msgid "// Generate error 2\n"
+msgstr ""
+
+#: src/error/multiple_error_types.md:22
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:45
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/wrap_error.md:77 src/error/iter_result.md:40
+msgid "\"42\""
+msgstr ""
+
+#: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:45
+#: src/error/multiple_error_types/option_result.md:47
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:77
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"93\""
+msgstr ""
+
+#: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:16
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:45
+#: src/error/multiple_error_types/option_result.md:47
+#: src/error/multiple_error_types/define_error_type.md:60
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:47
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:59
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:77
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"18\""
+msgstr ""
+
+#: src/error/multiple_error_types.md:24
+#: src/error/multiple_error_types/option_result.md:18
+#: src/error/multiple_error_types/option_result.md:47
+#: src/error/multiple_error_types/define_error_type.md:62
+#: src/error/multiple_error_types/boxing_errors.md:49
+#: src/error/multiple_error_types/reenter_question_mark.md:61
+#: src/error/multiple_error_types/wrap_error.md:79 src/error/iter_result.md:7
+#: src/error/iter_result.md:24 src/error/iter_result.md:40
+#: src/error/iter_result.md:60 src/error/iter_result.md:75
+#: src/error/iter_result.md:90
+msgid "\"tofu\""
+msgstr ""
+
+#: src/error/multiple_error_types.md:26 src/error/multiple_error_types.md:28
+#: src/error/multiple_error_types.md:31
+#: src/error/multiple_error_types/define_error_type.md:54
+#: src/error/multiple_error_types/boxing_errors.md:41
+#: src/error/multiple_error_types/reenter_question_mark.md:53
+#: src/error/multiple_error_types/wrap_error.md:66
+msgid "\"The first doubled is {}\""
+msgstr ""
+
+#: src/error/multiple_error_types.md:29
+#: src/error/multiple_error_types/option_result.md:23
+msgid "// Error 1: the input vector is empty\n"
+msgstr ""
+
+#: src/error/multiple_error_types.md:32
+#: src/error/multiple_error_types/option_result.md:26
+msgid "// Error 2: the element doesn't parse to a number\n"
+msgstr ""
+
+#: src/error/multiple_error_types.md:36
+msgid ""
+"Over the next sections, we'll see several strategies for handling these kind "
+"of problems."
+msgstr ""
+
+#: src/error/multiple_error_types/option_result.md:3
+msgid ""
+"The most basic way of handling mixed error types is to just embed them in "
+"each other."
+msgstr ""
+
+#: src/error/multiple_error_types/option_result.md:20
+#: src/error/multiple_error_types/option_result.md:22
+#: src/error/multiple_error_types/option_result.md:25
+#: src/error/multiple_error_types/option_result.md:49
+#: src/error/multiple_error_types/option_result.md:50
+#: src/error/multiple_error_types/option_result.md:51
+msgid "\"The first doubled is {:?}\""
+msgstr ""
+
+#: src/error/multiple_error_types/option_result.md:30
+msgid ""
+"There are times when we'll want to stop processing on errors (like with [`?`]"
+"(../result/enter_question_mark.md)) but keep going when the `Option` is "
+"`None`. The `transpose` function comes in handy to swap the `Result` and "
+"`Option`."
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:3
+msgid ""
+"Sometimes it simplifies the code to mask all of the different errors with a "
+"single type of error.  We'll show this with a custom error."
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:6
+msgid ""
+"Rust allows us to define our own error types. In general, a \"good\" error "
+"type:"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:8
+msgid "Represents different errors with the same type"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:9
+msgid "Presents nice error messages to the user"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:10
+msgid "Is easy to compare with other types"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:11
+msgid "Good: `Err(EmptyVec)`"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:12
+msgid "Bad: `Err(\"Please use a vector with at least one element\".to_owned())`"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:13
+msgid "Can hold information about the error"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:14
+msgid "Good: `Err(BadChar(c, position))`"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:15
+msgid "Bad: `Err(\"+ cannot be used here\".to_owned())`"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:16
+msgid "Composes well with other errors"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:22
+msgid ""
+"// Define our error types. These may be customized for our error handling "
+"cases.\n"
+"// Now we will be able to write our own errors, defer to an underlying error\n"
+"// implementation, or do something in between.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:28
+msgid ""
+"// Generation of an error is completely separate from how it is displayed.\n"
+"// There's no need to be concerned about cluttering complex logic with the "
+"display style.\n"
+"//\n"
+"// Note that we don't store any extra info about the errors. This means we "
+"can't state\n"
+"// which string failed to parse without modifying our types to carry that "
+"information.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:36
+#: src/error/multiple_error_types/boxing_errors.md:23
+#: src/error/multiple_error_types/reenter_question_mark.md:37
+msgid "\"invalid first item to double\""
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:42
+msgid "// Change the error to our new type.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/define_error_type.md:46
+msgid "// Update to the new error type here also.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/boxing_errors.md:3
+msgid ""
+"A way to write simple code while preserving the original errors is to [`Box`]"
+"(https://doc.rust-lang.org/std/boxed/struct.Box.html) them.  The drawback is "
+"that the underlying error type is only known at runtime and not [statically "
+"determined](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-"
+"objects-perform-dynamic-dispatch)."
+msgstr ""
+
+#: src/error/multiple_error_types/boxing_errors.md:7
+msgid ""
+"The stdlib helps in boxing our errors by having `Box` implement conversion "
+"from any type that implements the `Error` trait into the trait object "
+"`Box<Error>`, via [`From`](https://doc.rust-lang.org/std/convert/trait.From."
+"html)."
+msgstr ""
+
+#: src/error/multiple_error_types/boxing_errors.md:14
+#: src/error/multiple_error_types/reenter_question_mark.md:28
+msgid "// Change the alias to use `Box<dyn error::Error>`.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/boxing_errors.md:31
+#: src/error/multiple_error_types/boxing_errors.md:34
+msgid "// Converts to Box\n"
+msgstr ""
+
+#: src/error/multiple_error_types/boxing_errors.md:59
+msgid ""
+"[Dynamic dispatch](https://doc.rust-lang.org/book/ch17-02-trait-objects."
+"html#trait-objects-perform-dynamic-dispatch) and [`Error` trait](https://doc."
+"rust-lang.org/std/error/trait.Error.html)"
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:3
+msgid ""
+"Notice in the previous example that our immediate reaction to calling `parse` "
+"is to `map` the error from a library error into a boxed error:"
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:12
+msgid ""
+"Since this is a simple and common operation, it would be convenient if it "
+"could be elided. Alas, because `and_then` is not sufficiently flexible, it "
+"cannot. However, we can instead use `?`."
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:16
+msgid ""
+"`?` was previously explained as either `unwrap` or `return Err(err)`. This is "
+"only mostly true. It actually means `unwrap` or `return Err(From::"
+"from(err))`. Since `From::from` is a conversion utility between different "
+"types, this means that if you `?` where the error is convertible to the "
+"return type, it will convert automatically."
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:22
+msgid ""
+"Here, we rewrite the previous example using `?`. As a result, the `map_err` "
+"will go away when `From::from` is implemented for our error type:"
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:42
+msgid ""
+"// The same structure as before but rather than chain all `Results`\n"
+"// and `Options` along, we `?` to get the inner value out immediately.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:69
+msgid ""
+"This is actually fairly clean now. Compared with the original `panic`, it is "
+"very similar to replacing the `unwrap` calls with `?` except that the return "
+"types are `Result`. As a result, they must be destructured at the top level."
+msgstr ""
+
+#: src/error/multiple_error_types/reenter_question_mark.md:76
+msgid ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and [`?"
+"`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
+"question-mark-operator)"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:3
+msgid "An alternative to boxing errors is to wrap them in your own error type."
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:16
+msgid ""
+"// We will defer to the parse error implementation for their error.\n"
+"    // Supplying extra info requires adding more data to the type.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:25
+msgid "\"please use a vector with at least one element\""
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:26
+msgid ""
+"// The wrapped error contains additional information and is available\n"
+"            // via the source() method.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:29
+msgid "\"the provided string could not be parsed as int\""
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:38
+msgid ""
+"// The cause is the underlying implementation error type. Is implicitly\n"
+"            // cast to the trait object `&error::Error`. This works because "
+"the\n"
+"            // underlying type already implements the `Error` trait.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:45
+msgid ""
+"// Implement the conversion from `ParseIntError` to `DoubleError`.\n"
+"// This will be automatically called by `?` if a `ParseIntError`\n"
+"// needs to be converted into a `DoubleError`.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:57
+msgid ""
+"// Here we implicitly use the `ParseIntError` implementation of `From` "
+"(which\n"
+"    // we defined above) in order to create a `DoubleError`.\n"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:70
+msgid "\"  Caused by: {}\""
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:87
+msgid ""
+"This adds a bit more boilerplate for handling errors and might not be needed "
+"in all applications. There are some libraries that can take care of the "
+"boilerplate for you."
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:93
+msgid ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
+"[`Enums`](../../custom_types/enum.md)"
+msgstr ""
+
+#: src/error/multiple_error_types/wrap_error.md:96
+msgid ""
+"[`Crates for handling errors`](https://crates.io/keywords/error-handling)"
+msgstr ""
+
+#: src/error/iter_result.md:3
+msgid "An `Iter::map` operation might fail, for example:"
+msgstr ""
+
+#: src/error/iter_result.md:12 src/error/iter_result.md:29
+#: src/error/iter_result.md:65
+msgid "\"Results: {:?}\""
+msgstr ""
+
+#: src/error/iter_result.md:16
+msgid "Let's step through strategies for handling this."
+msgstr ""
+
+#: src/error/iter_result.md:18
+msgid "Ignore the failed items with `filter_map()`"
+msgstr ""
+
+#: src/error/iter_result.md:20
+msgid ""
+"`filter_map` calls a function and filters out the results that are `None`."
+msgstr ""
+
+#: src/error/iter_result.md:33
+msgid "Collect the failed items with `map_err()` and `filter_map()`"
+msgstr ""
+
+#: src/error/iter_result.md:35
+msgid ""
+"`map_err` calls a function with the error, so by adding that to the previous "
+"`filter_map` solution we can save them off to the side while iterating."
+msgstr ""
+
+#: src/error/iter_result.md:40
+msgid "\"999\""
+msgstr ""
+
+#: src/error/iter_result.md:47 src/error/iter_result.md:80
+#: src/error/iter_result.md:97
+msgid "\"Numbers: {:?}\""
+msgstr ""
+
+#: src/error/iter_result.md:48 src/error/iter_result.md:81
+#: src/error/iter_result.md:98
+msgid "\"Errors: {:?}\""
+msgstr ""
+
+#: src/error/iter_result.md:52
+msgid "Fail the entire operation with `collect()`"
+msgstr ""
+
+#: src/error/iter_result.md:54
+msgid ""
+"`Result` implements `FromIterator` so that a vector of results "
+"(`Vec<Result<T, E>>`) can be turned into a result with a vector "
+"(`Result<Vec<T>, E>`). Once an `Result::Err` is found, the iteration will "
+"terminate."
+msgstr ""
+
+#: src/error/iter_result.md:69
+msgid "This same technique can be used with `Option`."
+msgstr ""
+
+#: src/error/iter_result.md:71
+msgid "Collect all valid values and failures with `partition()`"
+msgstr ""
+
+#: src/error/iter_result.md:85
+msgid ""
+"When you look at the results, you'll note that everything is still wrapped in "
+"`Result`.  A little more boilerplate is needed for this."
+msgstr ""
+
+#: src/std.md:3
+msgid ""
+"The `std` library provides many custom types which expands drastically on the "
+"`primitives`. Some of these include:"
+msgstr ""
+
+#: src/std.md:6
+msgid "growable `String`s like: `\"hello world\"`"
+msgstr ""
+
+#: src/std.md:7
+msgid "growable vectors: `[1, 2, 3]`"
+msgstr ""
+
+#: src/std.md:8
+msgid "optional types: `Option<i32>`"
+msgstr ""
+
+#: src/std.md:9
+msgid "error handling types: `Result<i32, i32>`"
+msgstr ""
+
+#: src/std.md:10
+msgid "heap allocated pointers: `Box<i32>`"
+msgstr ""
+
+#: src/std.md:14 src/std_misc.md:14
+msgid ""
+"[primitives](primitives.md) and [the std library](https://doc.rust-lang.org/"
+"std/)"
+msgstr ""
+
+#: src/std/box.md:3
+msgid ""
+"All values in Rust are stack allocated by default. Values can be _boxed_ "
+"(allocated on the heap) by creating a `Box<T>`. A box is a smart pointer to a "
+"heap allocated value of type `T`. When a box goes out of scope, its "
+"destructor is called, the inner object is destroyed, and the memory on the "
+"heap is freed."
+msgstr ""
+
+#: src/std/box.md:8
+msgid ""
+"Boxed values can be dereferenced using the `*` operator; this removes one "
+"layer of indirection."
+msgstr ""
+
+#: src/std/box.md:20
+msgid ""
+"// A Rectangle can be specified by where its top left and bottom right \n"
+"// corners are in space\n"
+msgstr ""
+
+#: src/std/box.md:34
+msgid "// Allocate this point on the heap, and return a pointer to it\n"
+msgstr ""
+
+#: src/std/box.md:39
+msgid ""
+"// (all the type annotations are superfluous)\n"
+"    // Stack allocated variables\n"
+msgstr ""
+
+#: src/std/box.md:47
+msgid "// Heap allocated rectangle\n"
+msgstr ""
+
+#: src/std/box.md:53
+msgid "// The output of functions can be boxed\n"
+msgstr ""
+
+#: src/std/box.md:56
+msgid "// Double indirection\n"
+msgstr ""
+
+#: src/std/box.md:59
+msgid "\"Point occupies {} bytes on the stack\""
+msgstr ""
+
+#: src/std/box.md:61
+msgid "\"Rectangle occupies {} bytes on the stack\""
+msgstr ""
+
+#: src/std/box.md:64
+msgid "// box size == pointer size\n"
+msgstr ""
+
+#: src/std/box.md:65
+msgid "\"Boxed point occupies {} bytes on the stack\""
+msgstr ""
+
+#: src/std/box.md:67
+msgid "\"Boxed rectangle occupies {} bytes on the stack\""
+msgstr ""
+
+#: src/std/box.md:69
+msgid "\"Boxed box occupies {} bytes on the stack\""
+msgstr ""
+
+#: src/std/box.md:72
+msgid "// Copy the data contained in `boxed_point` into `unboxed_point`\n"
+msgstr ""
+
+#: src/std/box.md:74
+msgid "\"Unboxed point occupies {} bytes on the stack\""
+msgstr ""
+
+#: src/std/vec.md:3
+msgid ""
+"Vectors are re-sizable arrays. Like slices, their size is not known at "
+"compile time, but they can grow or shrink at any time. A vector is "
+"represented using 3 parameters:"
+msgstr ""
+
+#: src/std/vec.md:6
+msgid "pointer to the data"
+msgstr ""
+
+#: src/std/vec.md:7
+msgid "length"
+msgstr ""
+
+#: src/std/vec.md:8
+msgid "capacity"
+msgstr ""
+
+#: src/std/vec.md:10
+msgid ""
+"The capacity indicates how much memory is reserved for the vector. The vector "
+"can grow as long as the length is smaller than the capacity. When this "
+"threshold needs to be surpassed, the vector is reallocated with a larger "
+"capacity."
+msgstr ""
+
+#: src/std/vec.md:16
+msgid "// Iterators can be collected into vectors\n"
+msgstr ""
+
+#: src/std/vec.md:18
+msgid "\"Collected (0..10) into: {:?}\""
+msgstr ""
+
+#: src/std/vec.md:20
+msgid "// The `vec!` macro can be used to initialize a vector\n"
+msgstr ""
+
+#: src/std/vec.md:22
+msgid "\"Initial vector: {:?}\""
+msgstr ""
+
+#: src/std/vec.md:24
+msgid "// Insert new element at the end of the vector\n"
+msgstr ""
+
+#: src/std/vec.md:25
+msgid "\"Push 4 into the vector\""
+msgstr ""
+
+#: src/std/vec.md:27
+msgid "\"Vector: {:?}\""
+msgstr ""
+
+#: src/std/vec.md:29
+msgid "// Error! Immutable vectors can't grow\n"
+msgstr ""
+
+#: src/std/vec.md:33
+msgid ""
+"// The `len` method yields the number of elements currently stored in a "
+"vector\n"
+msgstr ""
+
+#: src/std/vec.md:34
+msgid "\"Vector length: {}\""
+msgstr ""
+
+#: src/std/vec.md:36
+msgid "// Indexing is done using the square brackets (indexing starts at 0)\n"
+msgstr ""
+
+#: src/std/vec.md:37
+msgid "\"Second element: {}\""
+msgstr ""
+
+#: src/std/vec.md:39
+msgid "// `pop` removes the last element from the vector and returns it\n"
+msgstr ""
+
+#: src/std/vec.md:40
+msgid "\"Pop last element: {:?}\""
+msgstr ""
+
+#: src/std/vec.md:42
+msgid "// Out of bounds indexing yields a panic\n"
+msgstr ""
+
+#: src/std/vec.md:43
+msgid "\"Fourth element: {}\""
+msgstr ""
+
+#: src/std/vec.md:46
+msgid "// `Vector`s can be easily iterated over\n"
+msgstr ""
+
+#: src/std/vec.md:47
+msgid "\"Contents of xs:\""
+msgstr ""
+
+#: src/std/vec.md:52
+msgid ""
+"// A `Vector` can also be iterated over while the iteration\n"
+"    // count is enumerated in a separate variable (`i`)\n"
+msgstr ""
+
+#: src/std/vec.md:55
+msgid "\"In position {} we have value {}\""
+msgstr ""
+
+#: src/std/vec.md:58
+msgid ""
+"// Thanks to `iter_mut`, mutable `Vector`s can also be iterated\n"
+"    // over in a way that allows modifying each value\n"
+msgstr ""
+
+#: src/std/vec.md:63
+msgid "\"Updated vector: {:?}\""
+msgstr ""
+
+#: src/std/vec.md:67
+msgid ""
+"More `Vec` methods can be found under the [std::vec](https://doc.rust-lang."
+"org/std/vec/) module"
+msgstr ""
+
+#: src/std/str.md:3
+msgid "The two most used string types in Rust are `String` and `&str`."
+msgstr ""
+
+#: src/std/str.md:5
+msgid ""
+"A `String` is stored as a vector of bytes (`Vec<u8>`), but guaranteed to "
+"always be a valid UTF-8 sequence. `String` is heap allocated, growable and "
+"not null terminated."
+msgstr ""
+
+#: src/std/str.md:9
+msgid ""
+"`&str` is a slice (`&[u8]`) that always points to a valid UTF-8 sequence, and "
+"can be used to view into a `String`, just like `&[T]` is a view into `Vec<T>`."
+msgstr ""
+
+#: src/std/str.md:14
+msgid ""
+"// (all the type annotations are superfluous)\n"
+"    // A reference to a string allocated in read only memory\n"
+msgstr ""
+
+#: src/std/str.md:16
+msgid "\"the quick brown fox jumps over the lazy dog\""
+msgstr ""
+
+#: src/std/str.md:17
+msgid "\"Pangram: {}\""
+msgstr ""
+
+#: src/std/str.md:19
+msgid "// Iterate over words in reverse, no new string is allocated\n"
+msgstr ""
+
+#: src/std/str.md:20
+msgid "\"Words in reverse\""
+msgstr ""
+
+#: src/std/str.md:25
+msgid "// Copy chars into a vector, sort and remove duplicates\n"
+msgstr ""
+
+#: src/std/str.md:30
+msgid "// Create an empty and growable `String`\n"
+msgstr ""
+
+#: src/std/str.md:33
+msgid "// Insert a char at the end of string\n"
+msgstr ""
+
+#: src/std/str.md:35
+msgid "// Insert a string at the end of string\n"
+msgstr ""
+
+#: src/std/str.md:39
+msgid ""
+"// The trimmed string is a slice to the original string, hence no new\n"
+"    // allocation is performed\n"
+msgstr ""
+
+#: src/std/str.md:43
+msgid "\"Used characters: {}\""
+msgstr ""
+
+#: src/std/str.md:45
+msgid "// Heap allocate a string\n"
+msgstr ""
+
+#: src/std/str.md:46
+msgid "\"I like dogs\""
+msgstr ""
+
+#: src/std/str.md:47
+msgid "// Allocate new memory and store the modified string there\n"
+msgstr ""
+
+#: src/std/str.md:48
+msgid "\"dog\""
+msgstr ""
+
+#: src/std/str.md:48
+msgid "\"cat\""
+msgstr ""
+
+#: src/std/str.md:50
+msgid "\"Alice says: {}\""
+msgstr ""
+
+#: src/std/str.md:51
+msgid "\"Bob says: {}\""
+msgstr ""
+
+#: src/std/str.md:55
+msgid ""
+"More `str`/`String` methods can be found under the [std::str](https://doc."
+"rust-lang.org/std/str/) and [std::string](https://doc.rust-lang.org/std/"
+"string/) modules"
+msgstr ""
+
+#: src/std/str.md:60
+msgid "Literals and escapes"
+msgstr ""
+
+#: src/std/str.md:62
+msgid ""
+"There are multiple ways to write string literals with special characters in "
+"them. All result in a similar `&str` so it's best to use the form that is the "
+"most convenient to write. Similarly there are multiple ways to write byte "
+"string literals, which all result in `&[u8; N]`."
+msgstr ""
+
+#: src/std/str.md:67
+msgid ""
+"Generally special characters are escaped with a backslash character: `\\`. "
+"This way you can add any character to your string, even unprintable ones and "
+"ones that you don't know how to type. If you want a literal backslash, escape "
+"it with another one: `\\\\`"
+msgstr ""
+
+#: src/std/str.md:72
+msgid ""
+"String or character literal delimiters occurring within a literal must be "
+"escaped: `\"\\\"\"`, `'\\''`."
+msgstr ""
+
+#: src/std/str.md:76
+msgid "// You can use escapes to write bytes by their hexadecimal values...\n"
+msgstr ""
+
+#: src/std/str.md:77
+msgid "\"I'm writing \\x52\\x75\\x73\\x74!\""
+msgstr ""
+
+#: src/std/str.md:78
+msgid "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
+msgstr ""
+
+#: src/std/str.md:80
+msgid "// ...or Unicode code points.\n"
+msgstr ""
+
+#: src/std/str.md:81
+msgid "\"\\u{211D}\""
+msgstr ""
+
+#: src/std/str.md:82
+msgid "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
+msgstr ""
+
+#: src/std/str.md:84
+msgid "\"Unicode character {} (U+211D) is called {}\""
+msgstr ""
+
+#: src/std/str.md:88
+msgid ""
+"\"String literals\n"
+"                        can span multiple lines.\n"
+"                        The linebreak and indentation here ->\\\n"
+"                        <- can be escaped too!\""
+msgstr ""
+
+#: src/std/str.md:96
+msgid ""
+"Sometimes there are just too many characters that need to be escaped or it's "
+"just much more convenient to write a string out as-is. This is where raw "
+"string literals come into play."
+msgstr ""
+
+#: src/std/str.md:101
+msgid "r\"Escapes don't work here: \\x3F \\u{211D}\""
+msgstr ""
+
+#: src/std/str.md:104
+msgid "// If you need quotes in a raw string, add a pair of #s\n"
+msgstr ""
+
+#: src/std/str.md:105
+msgid "r#\"And then I said: \"There is no escape!\"\"#"
+msgstr ""
+
+#: src/std/str.md:108
+msgid ""
+"// If you need \"# in your string, just use more #s in the delimiter.\n"
+"    // You can use up to 255 #s.\n"
+msgstr ""
+
+#: src/std/str.md:110
+msgid "r###\"A string with \"# in it. And even \"##!\"###"
+msgstr ""
+
+#: src/std/str.md:115
+msgid ""
+"Want a string that's not UTF-8? (Remember, `str` and `String` must be valid "
+"UTF-8). Or maybe you want an array of bytes that's mostly text? Byte strings "
+"to the rescue!"
+msgstr ""
+
+#: src/std/str.md:122
+msgid "// Note that this is not actually a `&str`\n"
+msgstr ""
+
+#: src/std/str.md:123
+msgid "b\"this is a byte string\""
+msgstr ""
+
+#: src/std/str.md:125
+msgid ""
+"// Byte arrays don't have the `Display` trait, so printing them is a bit "
+"limited\n"
+msgstr ""
+
+#: src/std/str.md:126
+msgid "\"A byte string: {:?}\""
+msgstr ""
+
+#: src/std/str.md:128
+msgid "// Byte strings can have byte escapes...\n"
+msgstr ""
+
+#: src/std/str.md:129
+msgid "b\"\\x52\\x75\\x73\\x74 as bytes\""
+msgstr ""
+
+#: src/std/str.md:130
+msgid ""
+"// ...but no unicode escapes\n"
+"    // let escaped = b\"\\u{211D} is not allowed\";\n"
+msgstr ""
+
+#: src/std/str.md:132
+msgid "\"Some escaped bytes: {:?}\""
+msgstr ""
+
+#: src/std/str.md:135
+msgid "// Raw byte strings work just like raw strings\n"
+msgstr ""
+
+#: src/std/str.md:136
+msgid "br\"\\u{211D} is not escaped here\""
+msgstr ""
+
+#: src/std/str.md:139
+msgid "// Converting a byte array to `str` can fail\n"
+msgstr ""
+
+#: src/std/str.md:141
+msgid "\"And the same as text: '{}'\""
+msgstr ""
+
+#: src/std/str.md:144
+msgid ""
+"br#\"You can also use \"fancier\" formatting, \\\n"
+"                    like with normal raw strings\"#"
+msgstr ""
+
+#: src/std/str.md:147
+msgid "// Byte strings don't have to be UTF-8\n"
+msgstr ""
+
+#: src/std/str.md:148
+msgid "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
+msgstr ""
+
+#: src/std/str.md:148
+msgid "// \"ようこそ\" in SHIFT-JIS\n"
+msgstr ""
+
+#: src/std/str.md:150
+msgid "// But then they can't always be converted to `str`\n"
+msgstr ""
+
+#: src/std/str.md:152
+msgid "\"Conversion successful: '{}'\""
+msgstr ""
+
+#: src/std/str.md:153
+msgid "\"Conversion failed: {:?}\""
+msgstr ""
+
+#: src/std/str.md:158
+msgid ""
+"For conversions between character encodings check out the [encoding](https://"
+"crates.io/crates/encoding) crate."
+msgstr ""
+
+#: src/std/str.md:160
+msgid ""
+"A more detailed listing of the ways to write string literals and escape "
+"characters is given in the ['Tokens' chapter](https://doc.rust-lang.org/"
+"reference/tokens.html) of the Rust Reference."
+msgstr ""
+
+#: src/std/option.md:3
+msgid ""
+"Sometimes it's desirable to catch the failure of some parts of a program "
+"instead of calling `panic!`; this can be accomplished using the `Option` enum."
+msgstr ""
+
+#: src/std/option.md:6
+msgid "The `Option<T>` enum has two variants:"
+msgstr ""
+
+#: src/std/option.md:8
+msgid "`None`, to indicate failure or lack of value, and"
+msgstr ""
+
+#: src/std/option.md:9
+msgid "`Some(value)`, a tuple struct that wraps a `value` with type `T`."
+msgstr ""
+
+#: src/std/option.md:12
+msgid "// An integer division that doesn't `panic!`\n"
+msgstr ""
+
+#: src/std/option.md:15
+msgid "// Failure is represented as the `None` variant\n"
+msgstr ""
+
+#: src/std/option.md:18
+msgid "// Result is wrapped in a `Some` variant\n"
+msgstr ""
+
+#: src/std/option.md:22
+msgid "// This function handles a division that may not succeed\n"
+msgstr ""
+
+#: src/std/option.md:25
+msgid "// `Option` values can be pattern matched, just like other enums\n"
+msgstr ""
+
+#: src/std/option.md:27
+msgid "\"{} / {} failed!\""
+msgstr ""
+
+#: src/std/option.md:29
+msgid "\"{} / {} = {}\""
+msgstr ""
+
+#: src/std/option.md:38
+msgid "// Binding `None` to a variable needs to be type annotated\n"
+msgstr ""
+
+#: src/std/option.md:44
+msgid "// Unwrapping a `Some` variant will extract the value wrapped.\n"
+msgstr ""
+
+#: src/std/option.md:45 src/std/option.md:48
+msgid "\"{:?} unwraps to {:?}\""
+msgstr ""
+
+#: src/std/option.md:47
+msgid "// Unwrapping a `None` variant will `panic!`\n"
+msgstr ""
+
+#: src/std/result.md:3
+msgid ""
+"We've seen that the `Option` enum can be used as a return value from "
+"functions that may fail, where `None` can be returned to indicate failure. "
+"However, sometimes it is important to express _why_ an operation failed. To "
+"do this we have the `Result` enum."
+msgstr ""
+
+#: src/std/result.md:8
+msgid "The `Result<T, E>` enum has two variants:"
+msgstr ""
+
+#: src/std/result.md:10
+msgid ""
+"`Ok(value)` which indicates that the operation succeeded, and wraps the "
+"`value` returned by the operation. (`value` has type `T`)"
+msgstr ""
+
+#: src/std/result.md:12
+msgid ""
+"`Err(why)`, which indicates that the operation failed, and wraps `why`, which "
+"(hopefully) explains the cause of the failure. (`why` has type `E`)"
+msgstr ""
+
+#: src/std/result.md:17
+msgid "// Mathematical \"errors\" we want to catch\n"
+msgstr ""
+
+#: src/std/result.md:29
+msgid ""
+"// This operation would `fail`, instead let's return the reason of\n"
+"            // the failure wrapped in `Err`\n"
+msgstr ""
+
+#: src/std/result.md:33
+msgid "// This operation is valid, return the result wrapped in `Ok`\n"
+msgstr ""
+
+#: src/std/result.md:54
+msgid "// `op(x, y)` === `sqrt(ln(x / y))`\n"
+msgstr ""
+
+#: src/std/result.md:57
+msgid "// This is a three level match pyramid!\n"
+msgstr ""
+
+#: src/std/result.md:71
+msgid "// Will this fail?\n"
+msgstr ""
+
+#: src/std/result/question_mark.md:3
+msgid ""
+"Chaining results using match can get pretty untidy; luckily, the `?` operator "
+"can be used to make things pretty again. `?` is used at the end of an "
+"expression returning a `Result`, and is equivalent to a match expression, "
+"where the `Err(err)` branch expands to an early `return Err(From::"
+"from(err))`, and the `Ok(ok)` branch expands to an `ok` expression."
+msgstr ""
+
+#: src/std/result/question_mark.md:44
+msgid "// Intermediate function\n"
+msgstr ""
+
+#: src/std/result/question_mark.md:46
+msgid "// if `div` \"fails\", then `DivisionByZero` will be `return`ed\n"
+msgstr ""
+
+#: src/std/result/question_mark.md:49
+msgid "// if `ln` \"fails\", then `NonPositiveLogarithm` will be `return`ed\n"
+msgstr ""
+
+#: src/std/result/question_mark.md:59
+msgid "\"logarithm of non-positive number\""
+msgstr ""
+
+#: src/std/result/question_mark.md:61 src/std/panic.md:15
+msgid "\"division by zero\""
+msgstr ""
+
+#: src/std/result/question_mark.md:63
+msgid "\"square root of negative number\""
+msgstr ""
+
+#: src/std/result/question_mark.md:75
+msgid ""
+"Be sure to check the [documentation](https://doc.rust-lang.org/std/result/"
+"index.html), as there are many methods to map/compose `Result`."
+msgstr ""
+
+#: src/std/panic.md:3
+msgid ""
+"The `panic!` macro can be used to generate a panic and start unwinding its "
+"stack. While unwinding, the runtime will take care of freeing all the "
+"resources _owned_ by the thread by calling the destructor of all its objects."
+msgstr ""
+
+#: src/std/panic.md:7
+msgid ""
+"Since we are dealing with programs with only one thread, `panic!` will cause "
+"the program to report the panic message and exit."
+msgstr ""
+
+#: src/std/panic.md:11
+msgid "// Re-implementation of integer division (/)\n"
+msgstr ""
+
+#: src/std/panic.md:14
+msgid "// Division by zero triggers a panic\n"
+msgstr ""
+
+#: src/std/panic.md:20
+msgid "// The `main` task\n"
+msgstr ""
+
+#: src/std/panic.md:23
+msgid "// Heap allocated integer\n"
+msgstr ""
+
+#: src/std/panic.md:26
+msgid "// This operation will trigger a task failure\n"
+msgstr ""
+
+#: src/std/panic.md:29
+msgid "\"This point won't be reached!\""
+msgstr ""
+
+#: src/std/panic.md:31
+msgid "// `_x` should get destroyed at this point\n"
+msgstr ""
+
+#: src/std/panic.md:35
+msgid "Let's check that `panic!` doesn't leak memory."
+msgstr ""
+
+#: src/std/hash.md:3
+msgid ""
+"Where vectors store values by an integer index, `HashMap`s store values by "
+"key. `HashMap` keys can be booleans, integers, strings, or any other type "
+"that implements the `Eq` and `Hash` traits. More on this in the next section."
+msgstr ""
+
+#: src/std/hash.md:8
+msgid ""
+"Like vectors, `HashMap`s are growable, but HashMaps can also shrink "
+"themselves when they have excess space. You can create a HashMap with a "
+"certain starting capacity using `HashMap::with_capacity(uint)`, or use "
+"`HashMap::new()` to get a HashMap with a default initial capacity "
+"(recommended)."
+msgstr ""
+
+#: src/std/hash.md:19 src/std/hash.md:30
+msgid "\"798-1364\""
+msgstr ""
+
+#: src/std/hash.md:19
+msgid ""
+"\"We're sorry, the call cannot be completed as dialed. \n"
+"            Please hang up and try again.\""
+msgstr ""
+
+#: src/std/hash.md:21 src/std/hash.md:31
+msgid "\"645-7689\""
+msgstr ""
+
+#: src/std/hash.md:21
+msgid ""
+"\"Hello, this is Mr. Awesome's Pizza. My name is Fred.\n"
+"            What can I get for you today?\""
+msgstr ""
+
+#: src/std/hash.md:23
+msgid "\"Hi! Who is this again?\""
+msgstr ""
+
+#: src/std/hash.md:30 src/std/hash.md:36 src/std/hash.md:43
+msgid "\"Daniel\""
+msgstr ""
+
+#: src/std/hash.md:31 src/std/hash.md:45 src/std/hash.md:50
+msgid "\"Ashley\""
+msgstr ""
+
+#: src/std/hash.md:32
+msgid "\"Katie\""
+msgstr ""
+
+#: src/std/hash.md:32
+msgid "\"435-8291\""
+msgstr ""
+
+#: src/std/hash.md:33
+msgid "\"Robert\""
+msgstr ""
+
+#: src/std/hash.md:33
+msgid "\"956-1745\""
+msgstr ""
+
+#: src/std/hash.md:35
+msgid "// Takes a reference and returns Option<&V>\n"
+msgstr ""
+
+#: src/std/hash.md:37
+msgid "\"Calling Daniel: {}\""
+msgstr ""
+
+#: src/std/hash.md:38
+msgid "\"Don't have Daniel's number.\""
+msgstr ""
+
+#: src/std/hash.md:41
+msgid ""
+"// `HashMap::insert()` returns `None`\n"
+"    // if the inserted value is new, `Some(value)` otherwise\n"
+msgstr ""
+
+#: src/std/hash.md:43
+msgid "\"164-6743\""
+msgstr ""
+
+#: src/std/hash.md:46
+msgid "\"Calling Ashley: {}\""
+msgstr ""
+
+#: src/std/hash.md:47
+msgid "\"Don't have Ashley's number.\""
+msgstr ""
+
+#: src/std/hash.md:52
+msgid ""
+"// `HashMap::iter()` returns an iterator that yields \n"
+"    // (&'a key, &'a value) pairs in arbitrary order.\n"
+msgstr ""
+
+#: src/std/hash.md:55
+msgid "\"Calling {}: {}\""
+msgstr ""
+
+#: src/std/hash.md:60
+msgid ""
+"For more information on how hashing and hash maps (sometimes called hash "
+"tables) work, have a look at [Hash Table Wikipedia](https://en.wikipedia.org/"
+"wiki/Hash_table)"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:3
+msgid ""
+"Any type that implements the `Eq` and `Hash` traits can be a key in "
+"`HashMap`. This includes:"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:6
+msgid "`bool` (though not very useful since there are only two possible keys)"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:7
+msgid "`int`, `uint`, and all variations thereof"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:8
+msgid ""
+"`String` and `&str` (protip: you can have a `HashMap` keyed by `String` and "
+"call `.get()` with an `&str`)"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:11
+msgid ""
+"Note that `f32` and `f64` do _not_ implement `Hash`, likely because [floating-"
+"point precision errors](https://en.wikipedia.org/wiki/"
+"Floating_point#Accuracy_problems) would make using them as hashmap keys "
+"horribly error-prone."
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:15
+msgid ""
+"All collection classes implement `Eq` and `Hash` if their contained type also "
+"respectively implements `Eq` and `Hash`. For example, `Vec<T>` will implement "
+"`Hash` if `T` implements `Hash`."
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:19
+msgid ""
+"You can easily implement `Eq` and `Hash` for a custom type with just one "
+"line: `#[derive(PartialEq, Eq, Hash)]`"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:22
+msgid ""
+"The compiler will do the rest. If you want more control over the details, you "
+"can implement `Eq` and/or `Hash` yourself. This guide will not cover the "
+"specifics of implementing `Hash`."
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:26
+msgid ""
+"To play around with using a `struct` in `HashMap`, let's try making a very "
+"simple user logon system:"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:31
+msgid "// Eq requires that you derive PartialEq on the type.\n"
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:48
+msgid "\"Username: {}\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:49
+msgid "\"Password: {}\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:50
+msgid "\"Attempting logon...\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:59
+msgid "\"Successful logon!\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:60
+msgid "\"Name: {}\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:61
+msgid "\"Email: {}\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:63
+msgid "\"Login failed!\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:71 src/std/hash/alt_key_types.md:82
+#: src/std/hash/alt_key_types.md:84
+msgid "\"j.everyman\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:72 src/std/hash/alt_key_types.md:84
+msgid "\"password123\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:76
+msgid "\"John Everyman\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:77
+msgid "\"j.everyman@email.com\""
+msgstr ""
+
+#: src/std/hash/alt_key_types.md:82
+msgid "\"psasword123\""
+msgstr ""
+
+#: src/std/hash/hashset.md:3
+msgid ""
+"Consider a `HashSet` as a `HashMap` where we just care about the keys "
+"( `HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`)."
+msgstr ""
+
+#: src/std/hash/hashset.md:6
+msgid ""
+"\"What's the point of that?\" you ask. \"I could just store the keys in a "
+"`Vec`.\""
+msgstr ""
+
+#: src/std/hash/hashset.md:8
+msgid ""
+"A `HashSet`'s unique feature is that it is guaranteed to not have duplicate "
+"elements. That's the contract that any set collection fulfills. `HashSet` is "
+"just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/"
+"std/collections/struct.BTreeSet.html))"
+msgstr ""
+
+#: src/std/hash/hashset.md:13
+msgid ""
+"If you insert a value that is already present in the `HashSet`, (i.e. the new "
+"value is equal to the existing and they both have the same hash), then the "
+"new value will replace the old."
+msgstr ""
+
+#: src/std/hash/hashset.md:17
+msgid ""
+"This is great for when you never want more than one of something, or when you "
+"want to know if you've already got something."
+msgstr ""
+
+#: src/std/hash/hashset.md:20
+msgid "But sets can do more than that."
+msgstr ""
+
+#: src/std/hash/hashset.md:22
+msgid ""
+"Sets have 4 primary operations (all of the following calls return an "
+"iterator):"
+msgstr ""
+
+#: src/std/hash/hashset.md:24
+msgid "`union`: get all the unique elements in both sets."
+msgstr ""
+
+#: src/std/hash/hashset.md:26
+msgid ""
+"`difference`: get all the elements that are in the first set but not the "
+"second."
+msgstr ""
+
+#: src/std/hash/hashset.md:28
+msgid "`intersection`: get all the elements that are only in _both_ sets."
+msgstr ""
+
+#: src/std/hash/hashset.md:30
+msgid ""
+"`symmetric_difference`: get all the elements that are in one set or the "
+"other, but _not_ both."
+msgstr ""
+
+#: src/std/hash/hashset.md:33
+msgid "Try all of these in the following example:"
+msgstr ""
+
+#: src/std/hash/hashset.md:45
+msgid ""
+"// `HashSet::insert()` returns false if\n"
+"    // there was a value already present.\n"
+msgstr ""
+
+#: src/std/hash/hashset.md:47
+msgid "\"Value 4 is already in set B!\""
+msgstr ""
+
+#: src/std/hash/hashset.md:52
+msgid ""
+"// If a collection's element type implements `Debug`,\n"
+"    // then the collection implements `Debug`.\n"
+"    // It usually prints its elements in the format `[elem1, elem2, ...]`\n"
+msgstr ""
+
+#: src/std/hash/hashset.md:55
+msgid "\"A: {:?}\""
+msgstr ""
+
+#: src/std/hash/hashset.md:56
+msgid "\"B: {:?}\""
+msgstr ""
+
+#: src/std/hash/hashset.md:58
+msgid "// Print [1, 2, 3, 4, 5] in arbitrary order\n"
+msgstr ""
+
+#: src/std/hash/hashset.md:59
+msgid "\"Union: {:?}\""
+msgstr ""
+
+#: src/std/hash/hashset.md:61
+msgid "// This should print [1]\n"
+msgstr ""
+
+#: src/std/hash/hashset.md:62
+msgid "\"Difference: {:?}\""
+msgstr ""
+
+#: src/std/hash/hashset.md:64
+msgid "// Print [2, 3, 4] in arbitrary order.\n"
+msgstr ""
+
+#: src/std/hash/hashset.md:65
+msgid "\"Intersection: {:?}\""
+msgstr ""
+
+#: src/std/hash/hashset.md:67
+msgid "// Print [1, 5]\n"
+msgstr ""
+
+#: src/std/hash/hashset.md:68
+msgid "\"Symmetric Difference: {:?}\""
+msgstr ""
+
+#: src/std/hash/hashset.md:73
+msgid ""
+"(Examples are adapted from the [documentation.](https://doc.rust-lang.org/std/"
+"collections/struct.HashSet.html#method.difference))"
+msgstr ""
+
+#: src/std/rc.md:3
+msgid ""
+"When multiple ownership is needed, `Rc`(Reference Counting) can be used. `Rc` "
+"keeps track of the number of the references which means the number of owners "
+"of the value wrapped inside an `Rc`."
+msgstr ""
+
+#: src/std/rc.md:5
+msgid ""
+"Reference count of an `Rc` increases by 1 whenever an `Rc` is cloned, and "
+"decreases by 1 whenever one cloned `Rc` is dropped out of the scope. When an "
+"`Rc`'s reference count becomes zero (which means there are no remaining "
+"owners), both the `Rc` and the value are all dropped."
+msgstr ""
+
+#: src/std/rc.md:7
+msgid ""
+"Cloning an `Rc` never performs a deep copy. Cloning creates just another "
+"pointer to the wrapped value, and increments the count."
+msgstr ""
+
+#: src/std/rc.md:13
+msgid "\"Rc examples\""
+msgstr ""
+
+#: src/std/rc.md:15
+msgid "\"--- rc_a is created ---\""
+msgstr ""
+
+#: src/std/rc.md:18 src/std/rc.md:25 src/std/rc.md:37
+msgid "\"Reference Count of rc_a: {}\""
+msgstr ""
+
+#: src/std/rc.md:21
+msgid "\"--- rc_a is cloned to rc_b ---\""
+msgstr ""
+
+#: src/std/rc.md:24
+msgid "\"Reference Count of rc_b: {}\""
+msgstr ""
+
+#: src/std/rc.md:27
+msgid "// Two `Rc`s are equal if their inner values are equal\n"
+msgstr ""
+
+#: src/std/rc.md:28
+msgid "\"rc_a and rc_b are equal: {}\""
+msgstr ""
+
+#: src/std/rc.md:30
+msgid "// We can use methods of a value directly\n"
+msgstr ""
+
+#: src/std/rc.md:31
+msgid "\"Length of the value inside rc_a: {}\""
+msgstr ""
+
+#: src/std/rc.md:32
+msgid "\"Value of rc_b: {}\""
+msgstr ""
+
+#: src/std/rc.md:34
+msgid "\"--- rc_b is dropped out of scope ---\""
+msgstr ""
+
+#: src/std/rc.md:39
+msgid "\"--- rc_a is dropped out of scope ---\""
+msgstr ""
+
+#: src/std/rc.md:42
+msgid ""
+"// Error! `rc_examples` already moved into `rc_a`\n"
+"    // And when `rc_a` is dropped, `rc_examples` is dropped together\n"
+"    // println!(\"rc_examples: {}\", rc_examples);\n"
+"    // TODO ^ Try uncommenting this line\n"
+msgstr ""
+
+#: src/std/rc.md:51
+msgid ""
+"[std::rc](https://doc.rust-lang.org/std/rc/index.html) and [std::sync::arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html)."
+msgstr ""
+
+#: src/std/arc.md:1
+msgid "Arc"
+msgstr ""
+
+#: src/std/arc.md:3
+msgid ""
+"When shared ownership between threads is needed, `Arc`(Atomically Reference "
+"Counted) can be used. This struct, via the `Clone` implementation can create "
+"a reference pointer for the location of a value in the memory heap while "
+"increasing the reference counter. As it shares ownership between threads, "
+"when the last reference pointer to a value is out of scope, the variable is "
+"dropped."
+msgstr ""
+
+#: src/std/arc.md:15
+msgid "// This variable declaration is where its value is specified.\n"
+msgstr ""
+
+#: src/std/arc.md:16
+msgid "\"the same apple\""
+msgstr ""
+
+#: src/std/arc.md:19
+msgid ""
+"// Here there is no value specification as it is a pointer to a\n"
+"        // reference in the memory heap.\n"
+msgstr ""
+
+#: src/std/arc.md:24
+msgid ""
+"// As Arc was used, threads can be spawned using the value allocated\n"
+"            // in the Arc variable pointer's location.\n"
+msgstr ""
+
+#: src/std/arc.md:30
+msgid "// Make sure all Arc instances are printed from spawned threads.\n"
+msgstr ""
+
+#: src/std_misc.md:3
+msgid ""
+"Many other types are provided by the std library to support things such as:"
+msgstr ""
+
+#: src/std_misc.md:10
+msgid "These expand beyond what the [primitives](primitives.md) provide."
+msgstr ""
+
+#: src/std_misc/threads.md:3
+msgid ""
+"Rust provides a mechanism for spawning native OS threads via the `spawn` "
+"function, the argument of this function is a moving closure."
+msgstr ""
+
+#: src/std_misc/threads.md:10 src/std_misc/threads/testcase_mapreduce.md:28
+msgid "// This is the `main` thread\n"
+msgstr ""
+
+#: src/std_misc/threads.md:13
+msgid "// Make a vector to hold the children which are spawned.\n"
+msgstr ""
+
+#: src/std_misc/threads.md:17
+msgid "// Spin up another thread\n"
+msgstr ""
+
+#: src/std_misc/threads.md:19
+msgid "\"this is thread number {}\""
+msgstr ""
+
+#: src/std_misc/threads.md:24
+msgid "// Wait for the thread to finish. Returns a result.\n"
+msgstr ""
+
+#: src/std_misc/threads.md:30
+msgid "These threads will be scheduled by the OS."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:3
+msgid ""
+"Rust makes it very easy to parallelise data processing, without many of the "
+"headaches traditionally associated with such an attempt."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:5
+msgid ""
+"The standard library provides great threading primitives out of the box. "
+"These, combined with Rust's concept of Ownership and aliasing rules, "
+"automatically prevent data races."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:9
+msgid ""
+"The aliasing rules (one writable reference XOR many readable references) "
+"automatically prevent you from manipulating state that is visible to other "
+"threads. (Where synchronisation is needed, there are synchronisation "
+"primitives like `Mutex`es or `Channel`s.)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:14
+msgid ""
+"In this example, we will calculate the sum of all digits in a block of "
+"numbers. We will do this by parcelling out chunks of the block into different "
+"threads. Each thread will sum its tiny block of digits, and subsequently we "
+"will sum the intermediate sums produced by each thread."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:19
+msgid ""
+"Note that, although we're passing references across thread boundaries, Rust "
+"understands that we're only passing read-only references, and that thus no "
+"unsafety or data races can occur. Also because the references we're passing "
+"have `'static` lifetimes, Rust understands that our data won't be destroyed "
+"while these threads are still running. (When you need to share non-`static` "
+"data between threads, you can use a smart pointer like `Arc` to keep the data "
+"alive and avoid non-`static` lifetimes.)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:32
+msgid ""
+"// This is our data to process.\n"
+"    // We will calculate the sum of all digits via a threaded map-reduce "
+"algorithm.\n"
+"    // Each whitespace separated chunk will be handled in a different "
+"thread.\n"
+"    //\n"
+"    // TODO: see what happens to the output if you insert spaces!\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:37
+msgid ""
+"\"86967897737416471853297327050364959\n"
+"11861322575564723963297542624962850\n"
+"70856234701860851907960690014725639\n"
+"38397966707106094172783238747669219\n"
+"52380795257888236525459303330302837\n"
+"58495327135744041048897885734297812\n"
+"69920216438980873548808413720956532\n"
+"16278424637452589860345374828574668\""
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:46
+msgid "// Make a vector to hold the child-threads which we will spawn.\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:49
+msgid ""
+"/*************************************************************************\n"
+"     * \"Map\" phase\n"
+"     *\n"
+"     * Divide our data into segments, and apply initial processing\n"
+"     ************************************************************************/"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:55
+msgid ""
+"// split our data into segments for individual calculation\n"
+"    // each chunk will be a reference (&str) into the actual data\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:59
+msgid ""
+"// Iterate over the data segments.\n"
+"    // .enumerate() adds the current loop index to whatever is iterated\n"
+"    // the resulting tuple \"(index, element)\" is then immediately\n"
+"    // \"destructured\" into two variables, \"i\" and \"data_segment\" with "
+"a\n"
+"    // \"destructuring assignment\"\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:65
+msgid "\"data segment {} is \\\"{}\\\"\""
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:67
+msgid ""
+"// Process each data segment in a separate thread\n"
+"        //\n"
+"        // spawn() returns a handle to the new thread,\n"
+"        // which we MUST keep to access the returned value\n"
+"        //\n"
+"        // 'move || -> u32' is syntax for a closure that:\n"
+"        // * takes no arguments ('||')\n"
+"        // * takes ownership of its captured variables ('move') and\n"
+"        // * returns an unsigned 32-bit integer ('-> u32')\n"
+"        //\n"
+"        // Rust is smart enough to infer the '-> u32' from\n"
+"        // the closure itself so we could have left that out.\n"
+"        //\n"
+"        // TODO: try removing the 'move' and see what happens\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:82
+msgid "// Calculate the intermediate sum of this segment:\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:84
+msgid "// iterate over the characters of our segment..\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:86
+msgid "// .. convert text-characters to their number value..\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:87
+msgid "\"should be a digit\""
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:88
+msgid "// .. and sum the resulting iterator of numbers\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:91
+msgid "// println! locks stdout, so no text-interleaving occurs\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:92
+msgid "\"processed segment {}, result={}\""
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:94
+msgid ""
+"// \"return\" not needed, because Rust is an \"expression language\", the\n"
+"            // last evaluated expression in each block is automatically its "
+"value.\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:102
+msgid ""
+"/*************************************************************************\n"
+"     * \"Reduce\" phase\n"
+"     *\n"
+"     * Collect our intermediate results, and combine them into a final "
+"result\n"
+"     ************************************************************************/"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:108
+msgid ""
+"// combine each thread's intermediate results into a single final sum.\n"
+"    //\n"
+"    // we use the \"turbofish\" ::<> to provide sum() with a type hint.\n"
+"    //\n"
+"    // TODO: try without the turbofish, by instead explicitly\n"
+"    // specifying the type of final_result\n"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:116
+msgid "\"Final sum result: {}\""
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:122
+msgid "Assignments"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:123
+msgid ""
+"It is not wise to let our number of threads depend on user inputted data. "
+"What if the user decides to insert a lot of spaces? Do we _really_ want to "
+"spawn 2,000 threads? Modify the program so that the data is always chunked "
+"into a limited number of chunks, defined by a static constant at the "
+"beginning of the program."
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:129
+msgid "[Threads](../threads.md)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:130
+msgid "[vectors](../../std/vec.md) and [iterators](../../trait/iter.md)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:131
+msgid ""
+"[closures](../../fn/closures.md), [move](../../scope/move.md) semantics and "
+"[`move` closures](https://doc.rust-lang.org/book/ch13-01-closures."
+"html#closures-can-capture-their-environment)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:132
+msgid ""
+"[destructuring](https://doc.rust-lang.org/book/ch18-03-pattern-syntax."
+"html#destructuring-to-break-apart-values) assignments"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:133
+msgid ""
+"[turbofish notation](https://doc.rust-lang.org/book/appendix-02-operators."
+"html?highlight=turbofish) to help type inference"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:134
+msgid "[unwrap vs. expect](../../error/option_unwrap.md)"
+msgstr ""
+
+#: src/std_misc/threads/testcase_mapreduce.md:135
+msgid "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
+msgstr ""
+
+#: src/std_misc/channels.md:3
+msgid ""
+"Rust provides asynchronous `channels` for communication between threads. "
+"Channels allow a unidirectional flow of information between two end-points: "
+"the `Sender` and the `Receiver`."
+msgstr ""
+
+#: src/std_misc/channels.md:15
+msgid ""
+"// Channels have two endpoints: the `Sender<T>` and the `Receiver<T>`,\n"
+"    // where `T` is the type of the message to be transferred\n"
+"    // (type annotation is superfluous)\n"
+msgstr ""
+
+#: src/std_misc/channels.md:22
+msgid "// The sender endpoint can be copied\n"
+msgstr ""
+
+#: src/std_misc/channels.md:25
+msgid "// Each thread will send its id via the channel\n"
+msgstr ""
+
+#: src/std_misc/channels.md:27
+msgid ""
+"// The thread takes ownership over `thread_tx`\n"
+"            // Each thread queues a message in the channel\n"
+msgstr ""
+
+#: src/std_misc/channels.md:31
+msgid ""
+"// Sending is a non-blocking operation, the thread will continue\n"
+"            // immediately after sending its message\n"
+msgstr ""
+
+#: src/std_misc/channels.md:33
+msgid "\"thread {} finished\""
+msgstr ""
+
+#: src/std_misc/channels.md:39
+msgid "// Here, all the messages are collected\n"
+msgstr ""
+
+#: src/std_misc/channels.md:42
+msgid ""
+"// The `recv` method picks a message from the channel\n"
+"        // `recv` will block the current thread if there are no messages "
+"available\n"
+msgstr ""
+
+#: src/std_misc/channels.md:47
+msgid "// Wait for the threads to complete any remaining work\n"
+msgstr ""
+
+#: src/std_misc/channels.md:49
+msgid "\"oops! the child thread panicked\""
+msgstr ""
+
+#: src/std_misc/channels.md:52
+msgid "// Show the order in which the messages were sent\n"
+msgstr ""
+
+#: src/std_misc/path.md:3
+msgid ""
+"The `Path` struct represents file paths in the underlying filesystem. There "
+"are two flavors of `Path`: `posix::Path`, for UNIX-like systems, and "
+"`windows::Path`, for Windows. The prelude exports the appropriate platform-"
+"specific `Path` variant."
+msgstr ""
+
+#: src/std_misc/path.md:8
+msgid ""
+"A `Path` can be created from an `OsStr`, and provides several methods to get "
+"information from the file/directory the path points to."
+msgstr ""
+
+#: src/std_misc/path.md:11
+msgid ""
+"A `Path` is immutable. The owned version of `Path` is `PathBuf`. The relation "
+"between `Path` and `PathBuf` is similar to that of `str` and `String`: a "
+"`PathBuf` can be mutated in-place, and can be dereferenced to a `Path`."
+msgstr ""
+
+#: src/std_misc/path.md:15
+msgid ""
+"Note that a `Path` is _not_ internally represented as an UTF-8 string, but "
+"instead is stored as an `OsString`. Therefore, converting a `Path` to a "
+"`&str` is _not_ free and may fail (an `Option` is returned). However, a "
+"`Path` can be freely converted to an `OsString` or `&OsStr` using "
+"`into_os_string` and `as_os_str`, respectively."
+msgstr ""
+
+#: src/std_misc/path.md:25
+msgid "// Create a `Path` from an `&'static str`\n"
+msgstr ""
+
+#: src/std_misc/path.md:26
+msgid "\".\""
+msgstr ""
+
+#: src/std_misc/path.md:28
+msgid "// The `display` method returns a `Display`able structure\n"
+msgstr ""
+
+#: src/std_misc/path.md:31
+msgid ""
+"// `join` merges a path with a byte container using the OS specific\n"
+"    // separator, and returns a `PathBuf`\n"
+msgstr ""
+
+#: src/std_misc/path.md:35
+msgid "// `push` extends the `PathBuf` with a `&Path`\n"
+msgstr ""
+
+#: src/std_misc/path.md:37
+msgid "\"myfile.tar.gz\""
+msgstr ""
+
+#: src/std_misc/path.md:39
+msgid "// `set_file_name` updates the file name of the `PathBuf`\n"
+msgstr ""
+
+#: src/std_misc/path.md:40
+msgid "\"package.tgz\""
+msgstr ""
+
+#: src/std_misc/path.md:42
+msgid "// Convert the `PathBuf` into a string slice\n"
+msgstr ""
+
+#: src/std_misc/path.md:44
+msgid "\"new path is not a valid UTF-8 sequence\""
+msgstr ""
+
+#: src/std_misc/path.md:45
+msgid "\"new path is {}\""
+msgstr ""
+
+#: src/std_misc/path.md:51
+msgid ""
+"Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) "
+"and the `Metadata` struct."
+msgstr ""
+
+#: src/std_misc/path.md:56
+msgid ""
+"[OsStr](https://doc.rust-lang.org/std/ffi/struct.OsStr.html) and [Metadata]"
+"(https://doc.rust-lang.org/std/fs/struct.Metadata.html)."
+msgstr ""
+
+#: src/std_misc/file.md:3
+msgid ""
+"The `File` struct represents a file that has been opened (it wraps a file "
+"descriptor), and gives read and/or write access to the underlying file."
+msgstr ""
+
+#: src/std_misc/file.md:6
+msgid ""
+"Since many things can go wrong when doing file I/O, all the `File` methods "
+"return the `io::Result<T>` type, which is an alias for `Result<T, io::Error>`."
+msgstr ""
+
+#: src/std_misc/file.md:9
+msgid ""
+"This makes the failure of all I/O operations _explicit_. Thanks to this, the "
+"programmer can see all the failure paths, and is encouraged to handle them in "
+"a proactive manner."
+msgstr ""
+
+#: src/std_misc/file/open.md:3
+msgid "The `open` function can be used to open a file in read-only mode."
+msgstr ""
+
+#: src/std_misc/file/open.md:5
+msgid ""
+"A `File` owns a resource, the file descriptor and takes care of closing the "
+"file when it is `drop`ed."
+msgstr ""
+
+#: src/std_misc/file/open.md:14
+msgid "// Create a path to the desired file\n"
+msgstr ""
+
+#: src/std_misc/file/open.md:15
+msgid "\"hello.txt\""
+msgstr ""
+
+#: src/std_misc/file/open.md:18
+msgid "// Open the path in read-only mode, returns `io::Result<File>`\n"
+msgstr ""
+
+#: src/std_misc/file/open.md:20
+msgid "\"couldn't open {}: {}\""
+msgstr ""
+
+#: src/std_misc/file/open.md:24
+msgid "// Read the file contents into a string, returns `io::Result<usize>`\n"
+msgstr ""
+
+#: src/std_misc/file/open.md:27
+msgid "\"couldn't read {}: {}\""
+msgstr ""
+
+#: src/std_misc/file/open.md:28
+msgid "\"{} contains:\\n{}\""
+msgstr ""
+
+#: src/std_misc/file/open.md:31
+msgid "// `file` goes out of scope, and the \"hello.txt\" file gets closed\n"
+msgstr ""
+
+#: src/std_misc/file/open.md:35 src/std_misc/file/create.md:39
+#: src/std_misc/fs.md:109
+msgid "Here's the expected successful output:"
+msgstr ""
+
+#: src/std_misc/file/open.md:37
+msgid ""
+"```shell\n"
+"$ echo \"Hello World!\" > hello.txt\n"
+"$ rustc open.rs && ./open\n"
+"hello.txt contains:\n"
+"Hello World!\n"
+"```"
+msgstr ""
+
+#: src/std_misc/file/open.md:44
+msgid ""
+"(You are encouraged to test the previous example under different failure "
+"conditions: `hello.txt` doesn't exist, or `hello.txt` is not readable, etc.)"
+msgstr ""
+
+#: src/std_misc/file/create.md:3
+msgid ""
+"The `create` function opens a file in write-only mode. If the file already "
+"existed, the old content is destroyed. Otherwise, a new file is created."
+msgstr ""
+
+#: src/std_misc/file/create.md:9
+msgid ""
+"\"Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod\n"
+"tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,\n"
+"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo\n"
+"consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+"cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat "
+"non\n"
+"proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+"\""
+msgstr ""
+
+#: src/std_misc/file/create.md:22
+msgid "\"lorem_ipsum.txt\""
+msgstr ""
+
+#: src/std_misc/file/create.md:25
+msgid "// Open a file in write-only mode, returns `io::Result<File>`\n"
+msgstr ""
+
+#: src/std_misc/file/create.md:27
+msgid "\"couldn't create {}: {}\""
+msgstr ""
+
+#: src/std_misc/file/create.md:31
+msgid "// Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`\n"
+msgstr ""
+
+#: src/std_misc/file/create.md:33
+msgid "\"couldn't write to {}: {}\""
+msgstr ""
+
+#: src/std_misc/file/create.md:34
+msgid "\"successfully wrote to {}\""
+msgstr ""
+
+#: src/std_misc/file/create.md:53
+msgid ""
+"(As in the previous example, you are encouraged to test this example under "
+"failure conditions.)"
+msgstr ""
+
+#: src/std_misc/file/create.md:56
+msgid ""
+"The [`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) "
+"struct can be used to configure how a file is opened."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:3
+msgid "A naive approach"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:5
+msgid ""
+"This might be a reasonable first attempt for a beginner's first "
+"implementation for reading lines from a file."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:22
+msgid ""
+"Since the method `lines()` returns an iterator over the lines in the file, we "
+"can also perform a map inline and collect the results, yielding a more "
+"concise and fluent expression."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:31
+msgid "// panic on possible file-reading errors\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:32
+msgid "// split the string into an iterator of string slices\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:33
+msgid "// make each slice into a string\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:34
+msgid "// gather them together into a vector\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:38
+msgid ""
+"Note that in both examples above, we must convert the `&str` reference "
+"returned from `lines()` to the owned type `String`, using `.to_string()` and "
+"`String::from` respectively."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:42
+msgid "A more efficient approach"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:44
+msgid ""
+"Here we pass ownership of the open `File` to a `BufReader` struct. "
+"`BufReader` uses an internal buffer to reduce intermediate allocations."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:47
+msgid ""
+"We also update `read_lines` to return an iterator instead of allocating new "
+"`String` objects in memory for each line."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:56
+msgid "// File hosts.txt must exist in the current path\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:57
+msgid "\"./hosts.txt\""
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:58
+msgid "// Consumes the iterator, returns an (Optional) String\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:64
+msgid ""
+"// The output is wrapped in a Result to allow matching on errors.\n"
+"// Returns an Iterator to the Reader of the lines of the file.\n"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:74
+msgid "Running this program simply prints the lines individually."
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:75
+msgid ""
+"```shell\n"
+"$ echo -e \"127.0.0.1\\n192.168.0.1\\n\" > hosts.txt\n"
+"$ rustc read_lines.rs && ./read_lines\n"
+"127.0.0.1\n"
+"192.168.0.1\n"
+"```"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:82
+msgid ""
+"(Note that since `File::open` expects a generic `AsRef<Path>` as argument, we "
+"define our generic `read_lines()` method with the same generic constraint, "
+"using the `where` keyword.)"
+msgstr ""
+
+#: src/std_misc/file/read_lines.md:85
+msgid ""
+"This process is more efficient than creating a `String` in memory with all of "
+"the file's contents. This can especially cause performance issues when "
+"working with larger files."
+msgstr ""
+
+#: src/std_misc/process.md:3
+msgid ""
+"The `process::Output` struct represents the output of a finished child "
+"process, and the `process::Command` struct is a process builder."
+msgstr ""
+
+#: src/std_misc/process.md:10
+msgid "\"rustc\""
+msgstr ""
+
+#: src/std_misc/process.md:11
+msgid "\"--version\""
+msgstr ""
+
+#: src/std_misc/process.md:13
+msgid "\"failed to execute process: {}\""
+msgstr ""
+
+#: src/std_misc/process.md:19
+msgid "\"rustc succeeded and stdout was:\\n{}\""
+msgstr ""
+
+#: src/std_misc/process.md:23
+msgid "\"rustc failed and stderr was:\\n{}\""
+msgstr ""
+
+#: src/std_misc/process.md:28
+msgid ""
+"(You are encouraged to try the previous example with an incorrect flag passed "
+"to `rustc`)"
+msgstr ""
+
+#: src/std_misc/process/pipe.md:3
+msgid ""
+"The `std::Child` struct represents a running child process, and exposes the "
+"`stdin`, `stdout` and `stderr` handles for interaction with the underlying "
+"process via pipes."
+msgstr ""
+
+#: src/std_misc/process/pipe.md:11
+msgid "\"the quick brown fox jumps over the lazy dog\\n\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:15
+msgid "// Spawn the `wc` command\n"
+msgstr ""
+
+#: src/std_misc/process/pipe.md:16 src/std_misc/fs.md:12 src/std_misc/fs.md:73
+#: src/std_misc/ffi.md:11
+msgid "\"windows\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:17
+msgid "\"powershell\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:18
+msgid "\"-Command\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:18
+msgid "\"$input | Measure-Object -Line -Word -Character\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:21
+msgid "\"wc\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:27
+msgid "\"couldn't spawn wc: {}\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:31
+msgid ""
+"// Write a string to the `stdin` of `wc`.\n"
+"    //\n"
+"    // `stdin` has type `Option<ChildStdin>`, but since we know this "
+"instance\n"
+"    // must have one, we can directly `unwrap` it.\n"
+msgstr ""
+
+#: src/std_misc/process/pipe.md:36
+msgid "\"couldn't write to wc stdin: {}\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:37
+msgid "\"sent pangram to wc\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:40
+msgid ""
+"// Because `stdin` does not live after the above calls, it is `drop`ed,\n"
+"    // and the pipe is closed.\n"
+"    //\n"
+"    // This is very important, otherwise `wc` wouldn't start processing the\n"
+"    // input we just sent.\n"
+msgstr ""
+
+#: src/std_misc/process/pipe.md:46
+msgid ""
+"// The `stdout` field also has type `Option<ChildStdout>` so must be "
+"unwrapped.\n"
+msgstr ""
+
+#: src/std_misc/process/pipe.md:49
+msgid "\"couldn't read wc stdout: {}\""
+msgstr ""
+
+#: src/std_misc/process/pipe.md:50
+msgid "\"wc responded with:\\n{}\""
+msgstr ""
+
+#: src/std_misc/process/wait.md:3
+msgid ""
+"If you'd like to wait for a `process::Child` to finish, you must call `Child::"
+"wait`, which will return a `process::ExitStatus`."
+msgstr ""
+
+#: src/std_misc/process/wait.md:10
+msgid "\"sleep\""
+msgstr ""
+
+#: src/std_misc/process/wait.md:13
+msgid "\"reached end of main\""
+msgstr ""
+
+#: src/std_misc/process/wait.md:18
+msgid ""
+"# `wait` keeps running for 5 seconds until the `sleep 5` command finishes\n"
+msgstr ""
+
+#: src/std_misc/fs.md:3
+msgid ""
+"The `std::fs` module contains several functions that deal with the filesystem."
+msgstr ""
+
+#: src/std_misc/fs.md:10 src/std_misc/fs.md:68 src/std_misc/ffi.md:20
+msgid "\"unix\""
+msgstr ""
+
+#: src/std_misc/fs.md:15
+msgid "// A simple implementation of `% cat path`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:25
+msgid "// A simple implementation of `% echo s > path`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:32
+msgid "// A simple implementation of `% touch path` (ignores existing files)\n"
+msgstr ""
+
+#: src/std_misc/fs.md:42
+msgid "\"`mkdir a`\""
+msgstr ""
+
+#: src/std_misc/fs.md:43
+msgid "// Create a directory, returns `io::Result<()>`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:45 src/std_misc/fs.md:52 src/std_misc/fs.md:58
+#: src/std_misc/fs.md:63 src/std_misc/fs.md:70 src/std_misc/fs.md:75
+#: src/std_misc/fs.md:81 src/std_misc/fs.md:88 src/std_misc/fs.md:97
+#: src/std_misc/fs.md:103
+msgid "\"! {:?}\""
+msgstr ""
+
+#: src/std_misc/fs.md:49
+msgid "\"`echo hello > a/b.txt`\""
+msgstr ""
+
+#: src/std_misc/fs.md:50
+msgid ""
+"// The previous match can be simplified using the `unwrap_or_else` method\n"
+msgstr ""
+
+#: src/std_misc/fs.md:51
+msgid "\"a/b.txt\""
+msgstr ""
+
+#: src/std_misc/fs.md:55
+msgid "\"`mkdir -p a/c/d`\""
+msgstr ""
+
+#: src/std_misc/fs.md:56
+msgid "// Recursively create a directory, returns `io::Result<()>`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:57 src/std_misc/fs.md:102
+msgid "\"a/c/d\""
+msgstr ""
+
+#: src/std_misc/fs.md:61
+msgid "\"`touch a/c/e.txt`\""
+msgstr ""
+
+#: src/std_misc/fs.md:62 src/std_misc/fs.md:96
+msgid "\"a/c/e.txt\""
+msgstr ""
+
+#: src/std_misc/fs.md:66
+msgid "\"`ln -s ../b.txt a/c/b.txt`\""
+msgstr ""
+
+#: src/std_misc/fs.md:67
+msgid "// Create a symbolic link, returns `io::Result<()>`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:69 src/std_misc/fs.md:74
+msgid "\"../b.txt\""
+msgstr ""
+
+#: src/std_misc/fs.md:69 src/std_misc/fs.md:74 src/std_misc/fs.md:80
+msgid "\"a/c/b.txt\""
+msgstr ""
+
+#: src/std_misc/fs.md:79
+msgid "\"`cat a/c/b.txt`\""
+msgstr ""
+
+#: src/std_misc/fs.md:85
+msgid "\"`ls a`\""
+msgstr ""
+
+#: src/std_misc/fs.md:86
+msgid "// Read the contents of a directory, returns `io::Result<Vec<Path>>`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:94
+msgid "\"`rm a/c/e.txt`\""
+msgstr ""
+
+#: src/std_misc/fs.md:95
+msgid "// Remove a file, returns `io::Result<()>`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:100
+msgid "\"`rmdir a/c/d`\""
+msgstr ""
+
+#: src/std_misc/fs.md:101
+msgid "// Remove an empty directory, returns `io::Result<()>`\n"
+msgstr ""
+
+#: src/std_misc/fs.md:111
+msgid ""
+"```shell\n"
+"$ rustc fs.rs && ./fs\n"
+"`mkdir a`\n"
+"`echo hello > a/b.txt`\n"
+"`mkdir -p a/c/d`\n"
+"`touch a/c/e.txt`\n"
+"`ln -s ../b.txt a/c/b.txt`\n"
+"`cat a/c/b.txt`\n"
+"> hello\n"
+"`ls a`\n"
+"> \"a/b.txt\"\n"
+"> \"a/c\"\n"
+"`rm a/c/e.txt`\n"
+"`rmdir a/c/d`\n"
+"```"
+msgstr ""
+
+#: src/std_misc/fs.md:127
+msgid "And the final state of the `a` directory is:"
+msgstr ""
+
+#: src/std_misc/fs.md:139
+msgid "An alternative way to define the function `cat` is with `?` notation:"
+msgstr ""
+
+#: src/std_misc/fs.md:152
+msgid "[`cfg!`](../attribute/cfg.md)"
+msgstr ""
+
+#: src/std_misc/arg.md:3
+msgid "Standard Library"
+msgstr ""
+
+#: src/std_misc/arg.md:5
+msgid ""
+"The command line arguments can be accessed using `std::env::args`, which "
+"returns an iterator that yields a `String` for each argument:"
+msgstr ""
+
+#: src/std_misc/arg.md:14
+msgid "// The first argument is the path that was used to call the program.\n"
+msgstr ""
+
+#: src/std_misc/arg.md:15
+msgid "\"My path is {}.\""
+msgstr ""
+
+#: src/std_misc/arg.md:17
+msgid ""
+"// The rest of the arguments are the passed command line parameters.\n"
+"    // Call the program like this:\n"
+"    //   $ ./args arg1 arg2\n"
+msgstr ""
+
+#: src/std_misc/arg.md:20
+msgid "\"I got {:?} arguments: {:?}.\""
+msgstr ""
+
+#: src/std_misc/arg.md:24
+msgid ""
+"```shell\n"
+"$ ./args 1 2 3\n"
+"My path is ./args.\n"
+"I got 3 arguments: [\"1\", \"2\", \"3\"].\n"
+"```"
+msgstr ""
+
+#: src/std_misc/arg.md:32
+msgid ""
+"Alternatively, there are numerous crates that can provide extra functionality "
+"when creating command-line applications. One of the more popular command line "
+"argument crates being [`clap`](https://rust-cli.github.io/book/tutorial/cli-"
+"args.html#parsing-cli-arguments-with-clap)."
+msgstr ""
+
+#: src/std_misc/arg/matching.md:3
+msgid "Matching can be used to parse simple arguments:"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:17
+msgid ""
+"\"usage:\n"
+"match_args <string>\n"
+"    Check whether given string is the answer.\n"
+"match_args {{increase|decrease}} <integer>\n"
+"    Increase or decrease given integer by one.\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:28
+msgid "// no arguments passed\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:30
+msgid "\"My name is 'match_args'. Try passing some arguments!\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:32
+msgid "// one argument passed\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:35
+msgid "\"This is the answer!\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:36
+msgid "\"This is not the answer.\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:39
+msgid "// one command and one argument passed\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:43
+msgid "// parse the number\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:49
+msgid "\"error: second argument not an integer\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:54
+msgid "// parse the command\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:56
+msgid "\"increase\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:57
+msgid "\"decrease\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:59
+msgid "\"error: invalid command\""
+msgstr ""
+
+#: src/std_misc/arg/matching.md:64
+msgid "// all the other cases\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:66
+msgid "// show a help message\n"
+msgstr ""
+
+#: src/std_misc/arg/matching.md:73
+msgid ""
+"If you named your program `match_args.rs` and compile it like this `rustc "
+"match_args.rs`, you can execute it as follows:"
+msgstr ""
+
+#: src/std_misc/ffi.md:3
+msgid ""
+"Rust provides a Foreign Function Interface (FFI) to C libraries. Foreign "
+"functions must be declared inside an `extern` block annotated with a "
+"`#[link]` attribute containing the name of the foreign library."
+msgstr ""
+
+#: src/std_misc/ffi.md:9
+msgid "// this extern block links to the libm library\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:12
+msgid "\"msvcrt\""
+msgstr ""
+
+#: src/std_misc/ffi.md:14 src/std_misc/ffi.md:23
+msgid ""
+"// this is a foreign function\n"
+"    // that computes the square root of a single precision complex number\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:21
+msgid "\"m\""
+msgstr ""
+
+#: src/std_misc/ffi.md:29
+msgid ""
+"// Since calling foreign functions is considered unsafe,\n"
+"// it's common to write safe wrappers around them.\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:37
+msgid "// z = -1 + 0i\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:40
+msgid "// calling a foreign function is an unsafe operation\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:43
+msgid "\"the square root of {:?} is {:?}\""
+msgstr ""
+
+#: src/std_misc/ffi.md:45
+msgid "// calling safe API wrapped around unsafe operation\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:46
+msgid "\"cos({:?}) = {:?}\""
+msgstr ""
+
+#: src/std_misc/ffi.md:48
+msgid "// Minimal implementation of single precision complex numbers\n"
+msgstr ""
+
+#: src/std_misc/ffi.md:60
+msgid "\"{}-{}i\""
+msgstr ""
+
+#: src/std_misc/ffi.md:62
+msgid "\"{}+{}i\""
+msgstr ""
+
+#: src/testing.md:3
+msgid ""
+"Rust is a programming language that cares a lot about correctness and it "
+"includes support for writing software tests within the language itself."
+msgstr ""
+
+#: src/testing.md:6
+msgid "Testing comes in three styles:"
+msgstr ""
+
+#: src/testing.md:8
+msgid "[Unit](testing/unit_testing.md) testing."
+msgstr ""
+
+#: src/testing.md:9
+msgid "[Doc](testing/doc_testing.md) testing."
+msgstr ""
+
+#: src/testing.md:10
+msgid "[Integration](testing/integration_testing.md) testing."
+msgstr ""
+
+#: src/testing.md:12
+msgid "Also Rust has support for specifying additional dependencies for tests:"
+msgstr ""
+
+#: src/testing.md:14
+msgid "[Dev-dependencies](testing/dev_dependencies.md)"
+msgstr ""
+
+#: src/testing.md:18
+msgid ""
+"[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) chapter on "
+"testing"
+msgstr ""
+
+#: src/testing.md:19
+msgid ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) on doc-testing"
+msgstr ""
+
+#: src/testing/unit_testing.md:3
+msgid ""
+"Tests are Rust functions that verify that the non-test code is functioning in "
+"the expected manner. The bodies of test functions typically perform some "
+"setup, run the code we want to test, then assert whether the results are what "
+"we expect."
+msgstr ""
+
+#: src/testing/unit_testing.md:8
+msgid ""
+"Most unit tests go into a `tests` [mod](../mod.md) with the `#[cfg(test)]` "
+"[attribute](../attribute.md). Test functions are marked with the `#[test]` "
+"attribute."
+msgstr ""
+
+#: src/testing/unit_testing.md:11
+msgid ""
+"Tests fail when something in the test function [panics](../std/panic.md). "
+"There are some helper [macros](../macros.md):"
+msgstr ""
+
+#: src/testing/unit_testing.md:14
+msgid "`assert!(expression)` - panics if expression evaluates to `false`."
+msgstr ""
+
+#: src/testing/unit_testing.md:15
+msgid ""
+"`assert_eq!(left, right)` and `assert_ne!(left, right)` - testing left and "
+"right expressions for equality and inequality respectively."
+msgstr ""
+
+#: src/testing/unit_testing.md:22
+msgid ""
+"// This is a really bad adding function, its purpose is to fail in this\n"
+"// example.\n"
+msgstr ""
+
+#: src/testing/unit_testing.md:32
+msgid ""
+"// Note this useful idiom: importing names from outer (for mod tests) scope.\n"
+msgstr ""
+
+#: src/testing/unit_testing.md:42
+msgid ""
+"// This assert would fire and test will fail.\n"
+"        // Please note, that private functions can be tested too!\n"
+msgstr ""
+
+#: src/testing/unit_testing.md:49
+msgid "Tests can be run with `cargo test`."
+msgstr ""
+
+#: src/testing/unit_testing.md:73
+msgid "Tests and `?`"
+msgstr ""
+
+#: src/testing/unit_testing.md:74
+msgid ""
+"None of the previous unit test examples had a return type. But in Rust 2018, "
+"your unit tests can return `Result<()>`, which lets you use `?` in them! This "
+"can make them much more concise."
+msgstr ""
+
+#: src/testing/unit_testing.md:83
+msgid "\"negative floats don't have square roots\""
+msgstr ""
+
+#: src/testing/unit_testing.md:100
+msgid ""
+"See [\"The Edition Guide\"](https://doc.rust-lang.org/edition-guide/rust-2018/"
+"error-handling-and-panics/question-mark-in-main-and-tests.html) for more "
+"details."
+msgstr ""
+
+#: src/testing/unit_testing.md:102
+msgid "Testing panics"
+msgstr ""
+
+#: src/testing/unit_testing.md:104
+msgid ""
+"To check functions that should panic under certain circumstances, use "
+"attribute `#[should_panic]`. This attribute accepts optional parameter "
+"`expected = ` with the text of the panic message. If your function can panic "
+"in multiple ways, it helps make sure your test is testing the correct panic."
+msgstr ""
+
+#: src/testing/unit_testing.md:112 src/testing/doc_testing.md:45
+msgid "\"Divide-by-zero error\""
+msgstr ""
+
+#: src/testing/unit_testing.md:114 src/testing/unit_testing.md:135
+msgid "\"Divide result is zero\""
+msgstr ""
+
+#: src/testing/unit_testing.md:142
+msgid "Running these tests gives us:"
+msgstr ""
+
+#: src/testing/unit_testing.md:161
+msgid "Running specific tests"
+msgstr ""
+
+#: src/testing/unit_testing.md:163
+msgid ""
+"To run specific tests one may specify the test name to `cargo test` command."
+msgstr ""
+
+#: src/testing/unit_testing.md:179
+msgid ""
+"To run multiple tests one may specify part of a test name that matches all "
+"the tests that should be run."
+msgstr ""
+
+#: src/testing/unit_testing.md:197
+msgid "Ignoring tests"
+msgstr ""
+
+#: src/testing/unit_testing.md:199
+msgid ""
+"Tests can be marked with the `#[ignore]` attribute to exclude some tests. Or "
+"to run them with command `cargo test -- --ignored`"
+msgstr ""
+
+#: src/testing/doc_testing.md:3
+msgid ""
+"The primary way of documenting a Rust project is through annotating the "
+"source code. Documentation comments are written in [CommonMark Markdown "
+"specification](https://commonmark.org/) and support code blocks in them. Rust "
+"takes care about correctness, so these code blocks are compiled and used as "
+"documentation tests."
+msgstr ""
+
+#: src/testing/doc_testing.md:10
+msgid ""
+"/// First line is a short summary describing function.\n"
+"///\n"
+"/// The next lines present detailed documentation. Code blocks start with\n"
+"/// triple backquotes and have implicit `fn main()` inside\n"
+"/// and `extern crate <cratename>`. Assume we're testing `doccomments` "
+"crate:\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::add(2, 3);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+msgstr ""
+
+#: src/testing/doc_testing.md:23
+msgid ""
+"/// Usually doc comments may include sections \"Examples\", \"Panics\" and "
+"\"Failures\".\n"
+"///\n"
+"/// The next function divides two numbers.\n"
+"///\n"
+"/// # Examples\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::div(10, 2);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+"///\n"
+"/// # Panics\n"
+"///\n"
+"/// The function panics if the second argument is zero.\n"
+"///\n"
+"/// ```rust,should_panic\n"
+"/// // panics on division by zero\n"
+"/// doccomments::div(10, 0);\n"
+"/// ```\n"
+msgstr ""
+
+#: src/testing/doc_testing.md:52
+msgid ""
+"Code blocks in documentation are automatically tested when running the "
+"regular `cargo test` command:"
+msgstr ""
+
+#: src/testing/doc_testing.md:71
+msgid "Motivation behind documentation tests"
+msgstr ""
+
+#: src/testing/doc_testing.md:73
+msgid ""
+"The main purpose of documentation tests is to serve as examples that exercise "
+"the functionality, which is one of the most important [guidelines](https://"
+"rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--"
+"not-try-not-unwrap-c-question-mark). It allows using examples from docs as "
+"complete code snippets. But using `?` makes compilation fail since `main` "
+"returns `unit`. The ability to hide some source lines from documentation "
+"comes to the rescue: one may write `fn try_main() -> Result<(), ErrorType>`, "
+"hide it and `unwrap` it in hidden `main`. Sounds complicated? Here's an "
+"example:"
+msgstr ""
+
+#: src/testing/doc_testing.md:82
+msgid ""
+"/// Using hidden `try_main` in doc tests.\n"
+"///\n"
+"/// ```\n"
+"/// # // hidden lines start with `#` symbol, but they're still compilable!\n"
+"/// # fn try_main() -> Result<(), String> { // line that wraps the body shown "
+"in doc\n"
+"/// let res = doccomments::try_div(10, 2)?;\n"
+"/// # Ok(()) // returning from try_main\n"
+"/// # }\n"
+"/// # fn main() { // starting main that'll unwrap()\n"
+"/// #    try_main().unwrap(); // calling try_main and unwrapping\n"
+"/// #                         // so that test will panic in case of error\n"
+"/// # }\n"
+"/// ```\n"
+msgstr ""
+
+#: src/testing/doc_testing.md:97
+msgid "\"Divide-by-zero\""
+msgstr ""
+
+#: src/testing/doc_testing.md:106
+msgid ""
+"[RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-"
+"conventions.md) on documentation style"
+msgstr ""
+
+#: src/testing/doc_testing.md:107
+msgid ""
+"[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
+"documentation.html) on documentation guidelines"
+msgstr ""
+
+#: src/testing/integration_testing.md:3
+msgid ""
+"[Unit tests](unit_testing.md) are testing one module in isolation at a time: "
+"they're small and can test private code. Integration tests are external to "
+"your crate and use only its public interface in the same way any other code "
+"would. Their purpose is to test that many parts of your library work "
+"correctly together."
+msgstr ""
+
+#: src/testing/integration_testing.md:8
+msgid "Cargo looks for integration tests in `tests` directory next to `src`."
+msgstr ""
+
+#: src/testing/integration_testing.md:10 src/testing/dev_dependencies.md:17
+msgid "File `src/lib.rs`:"
+msgstr ""
+
+#: src/testing/integration_testing.md:13
+msgid "// Define this in a crate called `adder`.\n"
+msgstr ""
+
+#: src/testing/integration_testing.md:19
+msgid "File with test: `tests/integration_test.rs`:"
+msgstr ""
+
+#: src/testing/integration_testing.md:28
+msgid "Running tests with `cargo test` command:"
+msgstr ""
+
+#: src/testing/integration_testing.md:50
+msgid ""
+"Each Rust source file in the `tests` directory is compiled as a separate "
+"crate. In order to share some code between integration tests we can make a "
+"module with public functions, importing and using it within tests."
+msgstr ""
+
+#: src/testing/integration_testing.md:54
+msgid "File `tests/common/mod.rs`:"
+msgstr ""
+
+#: src/testing/integration_testing.md:58
+msgid ""
+"// some setup code, like creating required files/directories, starting\n"
+"    // servers, etc.\n"
+msgstr ""
+
+#: src/testing/integration_testing.md:63
+msgid "File with test: `tests/integration_test.rs`"
+msgstr ""
+
+#: src/testing/integration_testing.md:66
+msgid "// importing common module.\n"
+msgstr ""
+
+#: src/testing/integration_testing.md:71
+msgid "// using common code.\n"
+msgstr ""
+
+#: src/testing/integration_testing.md:77
+msgid ""
+"Creating the module as `tests/common.rs` also works, but is not recommended "
+"because the test runner will treat the file as a test crate and try to run "
+"tests inside it."
+msgstr ""
+
+#: src/testing/dev_dependencies.md:1
+msgid "Development dependencies"
+msgstr ""
+
+#: src/testing/dev_dependencies.md:3
+msgid ""
+"Sometimes there is a need to have dependencies for tests (or examples, or "
+"benchmarks) only. Such dependencies are added to `Cargo.toml` in the `[dev-"
+"dependencies]` section. These dependencies are not propagated to other "
+"packages which depend on this package."
+msgstr ""
+
+#: src/testing/dev_dependencies.md:8
+msgid ""
+"One such example is [`pretty_assertions`](https://docs.rs/"
+"pretty_assertions/1.0.0/pretty_assertions/index.html), which extends standard "
+"`assert_eq!` and `assert_ne!` macros, to provide colorful diff.  \n"
+"File `Cargo.toml`:"
+msgstr ""
+
+#: src/testing/dev_dependencies.md:11
+msgid ""
+"```toml\n"
+"# standard crate data is left out\n"
+"[dev-dependencies]\n"
+"pretty_assertions = \"1\"\n"
+"```"
+msgstr ""
+
+#: src/testing/dev_dependencies.md:27
+msgid "// crate for test-only use. Cannot be used in non-test code.\n"
+msgstr ""
+
+#: src/testing/dev_dependencies.md:37
+msgid ""
+"[Cargo](http://doc.crates.io/specifying-dependencies.html) docs on specifying "
+"dependencies."
+msgstr ""
+
+#: src/unsafe.md:3
+msgid ""
+"As an introduction to this section, to borrow from [the official docs]"
+"(https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html), \"one should try "
+"to minimize the amount of unsafe code in a code base.\" With that in mind, "
+"let's get started! Unsafe annotations in Rust are used to bypass protections "
+"put in place by the compiler; specifically, there are four primary things "
+"that unsafe is used for:"
+msgstr ""
+
+#: src/unsafe.md:9
+msgid "dereferencing raw pointers"
+msgstr ""
+
+#: src/unsafe.md:10
+msgid ""
+"calling functions or methods which are `unsafe` (including calling a function "
+"over FFI, see [a previous chapter](std_misc/ffi.md) of the book)"
+msgstr ""
+
+#: src/unsafe.md:12
+msgid "accessing or modifying static mutable variables"
+msgstr ""
+
+#: src/unsafe.md:13
+msgid "implementing unsafe traits"
+msgstr ""
+
+#: src/unsafe.md:15
+msgid "Raw Pointers"
+msgstr ""
+
+#: src/unsafe.md:16
+msgid ""
+"Raw pointers `*` and references `&T` function similarly, but references are "
+"always safe because they are guaranteed to point to valid data due to the "
+"borrow checker. Dereferencing a raw pointer can only be done through an "
+"unsafe block."
+msgstr ""
+
+#: src/unsafe.md:31
+msgid "Calling Unsafe Functions"
+msgstr ""
+
+#: src/unsafe.md:32
+msgid ""
+"Some functions can be declared as `unsafe`, meaning it is the programmer's "
+"responsibility to ensure correctness instead of the compiler's. One example "
+"of this is [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/slice/"
+"fn.from_raw_parts.html) which will create a slice given a pointer to the "
+"first element and a length."
+msgstr ""
+
+#: src/unsafe.md:54
+msgid ""
+"For `slice::from_raw_parts`, one of the assumptions which _must_ be upheld is "
+"that the pointer passed in points to valid memory and that the memory pointed "
+"to is of the correct type. If these invariants aren't upheld then the "
+"program's behaviour is undefined and there is no knowing what will happen."
+msgstr ""
+
+#: src/unsafe/asm.md:3
+msgid ""
+"Rust provides support for inline assembly via the `asm!` macro. It can be "
+"used to embed handwritten assembly in the assembly output generated by the "
+"compiler. Generally this should not be necessary, but might be where the "
+"required performance or timing cannot be otherwise achieved. Accessing low "
+"level hardware primitives, e.g. in kernel code, may also demand this "
+"functionality."
+msgstr ""
+
+#: src/unsafe/asm.md:8
+msgid ""
+"**Note**: the examples here are given in x86/x86-64 assembly, but other "
+"architectures are also supported."
+msgstr ""
+
+#: src/unsafe/asm.md:10
+msgid "Inline assembly is currently supported on the following architectures:"
+msgstr ""
+
+#: src/unsafe/asm.md:11
+msgid "x86 and x86-64"
+msgstr ""
+
+#: src/unsafe/asm.md:12
+msgid "ARM"
+msgstr ""
+
+#: src/unsafe/asm.md:13
+msgid "AArch64"
+msgstr ""
+
+#: src/unsafe/asm.md:14
+msgid "RISC-V"
+msgstr ""
+
+#: src/unsafe/asm.md:16
+msgid "Basic usage"
+msgstr ""
+
+#: src/unsafe/asm.md:18
+msgid "Let us start with the simplest possible example:"
+msgstr ""
+
+#: src/unsafe/asm.md:21 src/unsafe/asm.md:41 src/unsafe/asm.md:68
+#: src/unsafe/asm.md:106 src/unsafe/asm.md:123 src/unsafe/asm.md:148
+#: src/unsafe/asm.md:174 src/unsafe/asm.md:195 src/unsafe/asm.md:212
+#: src/unsafe/asm.md:251 src/unsafe/asm.md:287 src/unsafe/asm.md:303
+#: src/unsafe/asm.md:329 src/unsafe/asm.md:367 src/unsafe/asm.md:394
+#: src/unsafe/asm.md:418 src/unsafe/asm.md:456
+msgid "\"x86_64\""
+msgstr ""
+
+#: src/unsafe/asm.md:25
+msgid "\"nop\""
+msgstr ""
+
+#: src/unsafe/asm.md:30
+msgid ""
+"This will insert a NOP (no operation) instruction into the assembly generated "
+"by the compiler. Note that all `asm!` invocations have to be inside an "
+"`unsafe` block, as they could insert arbitrary instructions and break various "
+"invariants. The instructions to be inserted are listed in the first argument "
+"of the `asm!` macro as a string literal."
+msgstr ""
+
+#: src/unsafe/asm.md:35
+msgid "Inputs and outputs"
+msgstr ""
+
+#: src/unsafe/asm.md:37
+msgid ""
+"Now inserting an instruction that does nothing is rather boring. Let us do "
+"something that actually acts on data:"
+msgstr ""
+
+#: src/unsafe/asm.md:46
+msgid "\"mov {}, 5\""
+msgstr ""
+
+#: src/unsafe/asm.md:52
+msgid ""
+"This will write the value `5` into the `u64` variable `x`. You can see that "
+"the string literal we use to specify instructions is actually a template "
+"string. It is governed by the same rules as Rust [format strings](https://doc."
+"rust-lang.org/std/fmt/#syntax). The arguments that are inserted into the "
+"template however look a bit different than you may be familiar with. First we "
+"need to specify if the variable is an input or an output of the inline "
+"assembly. In this case it is an output. We declared this by writing `out`. We "
+"also need to specify in what kind of register the assembly expects the "
+"variable. In this case we put it in an arbitrary general purpose register by "
+"specifying `reg`. The compiler will choose an appropriate register to insert "
+"into the template and will read the variable from there after the inline "
+"assembly finishes executing."
+msgstr ""
+
+#: src/unsafe/asm.md:65
+msgid "Let us see another example that also uses an input:"
+msgstr ""
+
+#: src/unsafe/asm.md:75
+msgid "\"mov {0}, {1}\""
+msgstr ""
+
+#: src/unsafe/asm.md:76 src/unsafe/asm.md:111 src/unsafe/asm.md:129
+msgid "\"add {0}, 5\""
+msgstr ""
+
+#: src/unsafe/asm.md:85
+msgid ""
+"This will add `5` to the input in variable `i` and write the result to "
+"variable `o`. The particular way this assembly does this is first copying the "
+"value from `i` to the output, and then adding `5` to it."
+msgstr ""
+
+#: src/unsafe/asm.md:89
+msgid "The example shows a few things:"
+msgstr ""
+
+#: src/unsafe/asm.md:91
+msgid ""
+"First, we can see that `asm!` allows multiple template string arguments; each "
+"one is treated as a separate line of assembly code, as if they were all "
+"joined together with newlines between them. This makes it easy to format "
+"assembly code."
+msgstr ""
+
+#: src/unsafe/asm.md:96
+msgid ""
+"Second, we can see that inputs are declared by writing `in` instead of `out`."
+msgstr ""
+
+#: src/unsafe/asm.md:98
+msgid ""
+"Third, we can see that we can specify an argument number, or name as in any "
+"format string. For inline assembly templates this is particularly useful as "
+"arguments are often used more than once. For more complex inline assembly "
+"using this facility is generally recommended, as it improves readability, and "
+"allows reordering instructions without changing the argument order."
+msgstr ""
+
+#: src/unsafe/asm.md:103
+msgid "We can further refine the above example to avoid the `mov` instruction:"
+msgstr ""
+
+#: src/unsafe/asm.md:117
+msgid ""
+"We can see that `inout` is used to specify an argument that is both input and "
+"output. This is different from specifying an input and output separately in "
+"that it is guaranteed to assign both to the same register."
+msgstr ""
+
+#: src/unsafe/asm.md:120
+msgid ""
+"It is also possible to specify different variables for the input and output "
+"parts of an `inout` operand:"
+msgstr ""
+
+#: src/unsafe/asm.md:135
+msgid "Late output operands"
+msgstr ""
+
+#: src/unsafe/asm.md:137
+msgid ""
+"The Rust compiler is conservative with its allocation of operands. It is "
+"assumed that an `out` can be written at any time, and can therefore not share "
+"its location with any other argument. However, to guarantee optimal "
+"performance it is important to use as few registers as possible, so they "
+"won't have to be saved and reloaded around the inline assembly block. To "
+"achieve this Rust provides a `lateout` specifier. This can be used on any "
+"output that is written only after all inputs have been consumed. There is "
+"also an `inlateout` variant of this specifier."
+msgstr ""
+
+#: src/unsafe/asm.md:145
+msgid ""
+"Here is an example where `inlateout` _cannot_ be used in `release` mode or "
+"other optimized cases:"
+msgstr ""
+
+#: src/unsafe/asm.md:156 src/unsafe/asm.md:180 src/unsafe/asm.md:463
+msgid "\"add {0}, {1}\""
+msgstr ""
+
+#: src/unsafe/asm.md:157
+msgid "\"add {0}, {2}\""
+msgstr ""
+
+#: src/unsafe/asm.md:167
+msgid ""
+"In unoptimized cases (e.g. `Debug` mode), replacing `inout(reg) a` with "
+"`inlateout(reg) a` in the above example can continue to give the expected "
+"result. However, with `release` mode or other optimized cases, using "
+"`inlateout(reg) a` can instead lead to the final value `a = 16`, causing the "
+"assertion to fail."
+msgstr ""
+
+#: src/unsafe/asm.md:169
+msgid ""
+"This is because in optimized cases, the compiler is free to allocate the same "
+"register for inputs `b` and `c` since it knows that they have the same value. "
+"Furthermore, when `inlateout` is used, `a` and `c` could be allocated to the "
+"same register, in which case the first `add` instruction would overwrite the "
+"initial load from variable `c`. This is in contrast to how using `inout(reg) "
+"a` ensures a separate register is allocated for `a`."
+msgstr ""
+
+#: src/unsafe/asm.md:171
+msgid ""
+"However, the following example can use `inlateout` since the output is only "
+"modified after all input registers have been read:"
+msgstr ""
+
+#: src/unsafe/asm.md:186
+msgid ""
+"As you can see, this assembly fragment will still work correctly if `a` and "
+"`b` are assigned to the same register."
+msgstr ""
+
+#: src/unsafe/asm.md:188
+msgid "Explicit register operands"
+msgstr ""
+
+#: src/unsafe/asm.md:190
+msgid ""
+"Some instructions require that the operands be in a specific register. "
+"Therefore, Rust inline assembly provides some more specific constraint "
+"specifiers. While `reg` is generally available on any architecture, explicit "
+"registers are highly architecture specific. E.g. for x86 the general purpose "
+"registers `eax`, `ebx`, `ecx`, `edx`, `ebp`, `esi`, and `edi` among others "
+"can be addressed by their name."
+msgstr ""
+
+#: src/unsafe/asm.md:200
+msgid "\"out 0x64, eax\""
+msgstr ""
+
+#: src/unsafe/asm.md:200 src/unsafe/asm.md:276
+msgid "\"eax\""
+msgstr ""
+
+#: src/unsafe/asm.md:205
+msgid ""
+"In this example we call the `out` instruction to output the content of the "
+"`cmd` variable to port `0x64`. Since the `out` instruction only accepts `eax` "
+"(and its sub registers) as operand we had to use the `eax` constraint "
+"specifier."
+msgstr ""
+
+#: src/unsafe/asm.md:207
+msgid ""
+"**Note**: unlike other operand types, explicit register operands cannot be "
+"used in the template string: you can't use `{}` and should write the register "
+"name directly instead. Also, they must appear at the end of the operand list "
+"after all other operand types."
+msgstr ""
+
+#: src/unsafe/asm.md:209
+msgid "Consider this example which uses the x86 `mul` instruction:"
+msgstr ""
+
+#: src/unsafe/asm.md:221
+msgid ""
+"// The x86 mul instruction takes rax as an implicit input and writes\n"
+"            // the 128-bit result of the multiplication to rax:rdx.\n"
+"            \"mul {}\""
+msgstr ""
+
+#: src/unsafe/asm.md:225 src/unsafe/asm.md:347
+msgid "\"rax\""
+msgstr ""
+
+#: src/unsafe/asm.md:226
+msgid "\"rdx\""
+msgstr ""
+
+#: src/unsafe/asm.md:235
+msgid ""
+"This uses the `mul` instruction to multiply two 64-bit inputs with a 128-bit "
+"result. The only explicit operand is a register, that we fill from the "
+"variable `a`. The second operand is implicit, and must be the `rax` register, "
+"which we fill from the variable `b`. The lower 64 bits of the result are "
+"stored in `rax` from which we fill the variable `lo`. The higher 64 bits are "
+"stored in `rdx` from which we fill the variable `hi`."
+msgstr ""
+
+#: src/unsafe/asm.md:241
+msgid "Clobbered registers"
+msgstr ""
+
+#: src/unsafe/asm.md:243
+msgid ""
+"In many cases inline assembly will modify state that is not needed as an "
+"output. Usually this is either because we have to use a scratch register in "
+"the assembly or because instructions modify state that we don't need to "
+"further examine. This state is generally referred to as being \"clobbered\". "
+"We need to tell the compiler about this since it may need to save and restore "
+"this state around the inline assembly block."
+msgstr ""
+
+#: src/unsafe/asm.md:253
+msgid "// three entries of four bytes each\n"
+msgstr ""
+
+#: src/unsafe/asm.md:255
+msgid ""
+"// String is stored as ascii in ebx, edx, ecx in order\n"
+"    // Because ebx is reserved, the asm needs to preserve the value of it.\n"
+"    // So we push and pop it around the main asm.\n"
+"    // 64 bit mode on 64 bit processors does not allow pushing/popping of\n"
+"    // 32 bit registers (like ebx), so we have to use the extended rbx "
+"register instead.\n"
+msgstr ""
+
+#: src/unsafe/asm.md:263
+msgid "\"push rbx\""
+msgstr ""
+
+#: src/unsafe/asm.md:264
+msgid "\"cpuid\""
+msgstr ""
+
+#: src/unsafe/asm.md:265
+msgid "\"mov [rdi], ebx\""
+msgstr ""
+
+#: src/unsafe/asm.md:266
+msgid "\"mov [rdi + 4], edx\""
+msgstr ""
+
+#: src/unsafe/asm.md:267
+msgid "\"mov [rdi + 8], ecx\""
+msgstr ""
+
+#: src/unsafe/asm.md:268
+msgid "\"pop rbx\""
+msgstr ""
+
+#: src/unsafe/asm.md:269
+msgid ""
+"// We use a pointer to an array for storing the values to simplify\n"
+"            // the Rust code at the cost of a couple more asm instructions\n"
+"            // This is more explicit with how the asm works however, as "
+"opposed\n"
+"            // to explicit register outputs such as `out(\"ecx\") val`\n"
+"            // The *pointer itself* is only an input even though it's written "
+"behind\n"
+msgstr ""
+
+#: src/unsafe/asm.md:274 src/unsafe/asm.md:345
+msgid "\"rdi\""
+msgstr ""
+
+#: src/unsafe/asm.md:275
+msgid "// select cpuid 0, also specify eax as clobbered\n"
+msgstr ""
+
+#: src/unsafe/asm.md:277
+msgid "// cpuid clobbers these registers too\n"
+msgstr ""
+
+#: src/unsafe/asm.md:278
+msgid "\"ecx\""
+msgstr ""
+
+#: src/unsafe/asm.md:279
+msgid "\"edx\""
+msgstr ""
+
+#: src/unsafe/asm.md:284
+msgid "\"CPU Manufacturer ID: {}\""
+msgstr ""
+
+#: src/unsafe/asm.md:291
+msgid ""
+"In the example above we use the `cpuid` instruction to read the CPU "
+"manufacturer ID. This instruction writes to `eax` with the maximum supported "
+"`cpuid` argument and `ebx`, `edx`, and `ecx` with the CPU manufacturer ID as "
+"ASCII bytes in that order."
+msgstr ""
+
+#: src/unsafe/asm.md:294
+msgid ""
+"Even though `eax` is never read we still need to tell the compiler that the "
+"register has been modified so that the compiler can save any values that were "
+"in these registers before the asm. This is done by declaring it as an output "
+"but with `_` instead of a variable name, which indicates that the output "
+"value is to be discarded."
+msgstr ""
+
+#: src/unsafe/asm.md:296
+msgid ""
+"This code also works around the limitation that `ebx` is a reserved register "
+"by LLVM. That means that LLVM assumes that it has full control over the "
+"register and it must be restored to its original state before exiting the asm "
+"block, so it cannot be used as an input or output **except** if the compiler "
+"uses it to fulfill a general register class (e.g. `in(reg)`). This makes "
+"`reg` operands dangerous when using reserved registers as we could "
+"unknowingly corrupt our input or output because they share the same register."
+msgstr ""
+
+#: src/unsafe/asm.md:298
+msgid ""
+"To work around this we use `rdi` to store the pointer to the output array, "
+"save `ebx` via `push`, read from `ebx` inside the asm block into the array "
+"and then restore `ebx` to its original state via `pop`. The `push` and `pop` "
+"use the full 64-bit `rbx` version of the register to ensure that the entire "
+"register is saved. On 32 bit targets the code would instead use `ebx` in the "
+"`push`/`pop`."
+msgstr ""
+
+#: src/unsafe/asm.md:300
+msgid ""
+"This can also be used with a general register class to obtain a scratch "
+"register for use inside the asm code:"
+msgstr ""
+
+#: src/unsafe/asm.md:305
+msgid "// Multiply x by 6 using shifts and adds\n"
+msgstr ""
+
+#: src/unsafe/asm.md:310
+msgid "\"mov {tmp}, {x}\""
+msgstr ""
+
+#: src/unsafe/asm.md:311
+msgid "\"shl {tmp}, 1\""
+msgstr ""
+
+#: src/unsafe/asm.md:312
+msgid "\"shl {x}, 2\""
+msgstr ""
+
+#: src/unsafe/asm.md:313
+msgid "\"add {x}, {tmp}\""
+msgstr ""
+
+#: src/unsafe/asm.md:322
+msgid "Symbol operands and ABI clobbers"
+msgstr ""
+
+#: src/unsafe/asm.md:324
+msgid ""
+"By default, `asm!` assumes that any register not specified as an output will "
+"have its contents preserved by the assembly code. The [`clobber_abi`](https://"
+"doc.rust-lang.org/stable/reference/inline-assembly.html#abi-clobbers) "
+"argument to `asm!` tells the compiler to automatically insert the necessary "
+"clobber operands according to the given calling convention ABI: any register "
+"which is not fully preserved in that ABI will be treated as clobbered.  "
+"Multiple `clobber_abi` arguments may be provided and all clobbers from all "
+"specified ABIs will be inserted."
+msgstr ""
+
+#: src/unsafe/asm.md:332 src/unsafe/asm.md:350
+msgid "\"C\""
+msgstr ""
+
+#: src/unsafe/asm.md:333
+msgid "\"arg = {}\""
+msgstr ""
+
+#: src/unsafe/asm.md:341
+msgid "\"call {}\""
+msgstr ""
+
+#: src/unsafe/asm.md:342
+msgid "// Function pointer to call\n"
+msgstr ""
+
+#: src/unsafe/asm.md:344
+msgid "// 1st argument in rdi\n"
+msgstr ""
+
+#: src/unsafe/asm.md:346
+msgid "// Return value in rax\n"
+msgstr ""
+
+#: src/unsafe/asm.md:348
+msgid ""
+"// Mark all registers which are not preserved by the \"C\" calling\n"
+"            // convention as clobbered.\n"
+msgstr ""
+
+#: src/unsafe/asm.md:358
+msgid "Register template modifiers"
+msgstr ""
+
+#: src/unsafe/asm.md:360
+msgid ""
+"In some cases, fine control is needed over the way a register name is "
+"formatted when inserted into the template string. This is needed when an "
+"architecture's assembly language has several names for the same register, "
+"each typically being a \"view\" over a subset of the register (e.g. the low "
+"32 bits of a 64-bit register)."
+msgstr ""
+
+#: src/unsafe/asm.md:362
+msgid ""
+"By default the compiler will always choose the name that refers to the full "
+"register size (e.g. `rax` on x86-64, `eax` on x86, etc)."
+msgstr ""
+
+#: src/unsafe/asm.md:364
+msgid ""
+"This default can be overridden by using modifiers on the template string "
+"operands, just like you would with format strings:"
+msgstr ""
+
+#: src/unsafe/asm.md:373
+msgid "\"mov {0:h}, {0:l}\""
+msgstr ""
+
+#: src/unsafe/asm.md:380
+msgid ""
+"In this example, we use the `reg_abcd` register class to restrict the "
+"register allocator to the 4 legacy x86 registers (`ax`, `bx`, `cx`, `dx`) of "
+"which the first two bytes can be addressed independently."
+msgstr ""
+
+#: src/unsafe/asm.md:382
+msgid ""
+"Let us assume that the register allocator has chosen to allocate `x` in the "
+"`ax` register. The `h` modifier will emit the register name for the high byte "
+"of that register and the `l` modifier will emit the register name for the low "
+"byte. The asm code will therefore be expanded as `mov ah, al` which copies "
+"the low byte of the value into the high byte."
+msgstr ""
+
+#: src/unsafe/asm.md:385
+msgid ""
+"If you use a smaller data type (e.g. `u16`) with an operand and forget to use "
+"template modifiers, the compiler will emit a warning and suggest the correct "
+"modifier to use."
+msgstr ""
+
+#: src/unsafe/asm.md:387
+msgid "Memory address operands"
+msgstr ""
+
+#: src/unsafe/asm.md:389
+msgid ""
+"Sometimes assembly instructions require operands passed via memory addresses/"
+"memory locations. You have to manually use the memory address syntax "
+"specified by the target architecture. For example, on x86/x86_64 using Intel "
+"assembly syntax, you should wrap inputs/outputs in `[]` to indicate they are "
+"memory operands:"
+msgstr ""
+
+#: src/unsafe/asm.md:399
+msgid "\"fldcw [{}]\""
+msgstr ""
+
+#: src/unsafe/asm.md:405
+msgid "Labels"
+msgstr ""
+
+#: src/unsafe/asm.md:407
+msgid ""
+"Any reuse of a named label, local or otherwise, can result in an assembler or "
+"linker error or may cause other strange behavior. Reuse of a named label can "
+"happen in a variety of ways including:"
+msgstr ""
+
+#: src/unsafe/asm.md:409
+msgid ""
+"explicitly: using a label more than once in one `asm!` block, or multiple "
+"times across blocks."
+msgstr ""
+
+#: src/unsafe/asm.md:410
+msgid ""
+"implicitly via inlining: the compiler is allowed to instantiate multiple "
+"copies of an `asm!` block, for example when the function containing it is "
+"inlined in multiple places."
+msgstr ""
+
+#: src/unsafe/asm.md:411
+msgid ""
+"implicitly via LTO: LTO can cause code from _other crates_ to be placed in "
+"the same codegen unit, and so could bring in arbitrary labels."
+msgstr ""
+
+#: src/unsafe/asm.md:413
+msgid ""
+"As a consequence, you should only use GNU assembler **numeric** [local labels]"
+"(https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-Labels) "
+"inside inline assembly code. Defining symbols in assembly code may lead to "
+"assembler and/or linker errors due to duplicate symbol definitions."
+msgstr ""
+
+#: src/unsafe/asm.md:415
+msgid ""
+"Moreover, on x86 when using the default Intel syntax, due to [an LLVM bug]"
+"(https://bugs.llvm.org/show_bug.cgi?id=36144), you shouldn't use labels "
+"exclusively made of `0` and `1` digits, e.g. `0`, `11` or `101010`, as they "
+"may end up being interpreted as binary values. Using `options(att_syntax)` "
+"will avoid any ambiguity, but that affects the syntax of the _entire_ `asm!` "
+"block. (See [Options](#options), below, for more on `options`.)"
+msgstr ""
+
+#: src/unsafe/asm.md:424
+msgid "\"mov {0}, 10\""
+msgstr ""
+
+#: src/unsafe/asm.md:425 src/unsafe/asm.md:430
+msgid "\"2:\""
+msgstr ""
+
+#: src/unsafe/asm.md:426
+msgid "\"sub {0}, 1\""
+msgstr ""
+
+#: src/unsafe/asm.md:427
+msgid "\"cmp {0}, 3\""
+msgstr ""
+
+#: src/unsafe/asm.md:428
+msgid "\"jle 2f\""
+msgstr ""
+
+#: src/unsafe/asm.md:429
+msgid "\"jmp 2b\""
+msgstr ""
+
+#: src/unsafe/asm.md:431
+msgid "\"add {0}, 2\""
+msgstr ""
+
+#: src/unsafe/asm.md:439
+msgid ""
+"This will decrement the `{0}` register value from 10 to 3, then add 2 and "
+"store it in `a`."
+msgstr ""
+
+#: src/unsafe/asm.md:441
+msgid "This example shows a few things:"
+msgstr ""
+
+#: src/unsafe/asm.md:443
+msgid ""
+"First, that the same number can be used as a label multiple times in the same "
+"inline block."
+msgstr ""
+
+#: src/unsafe/asm.md:444
+msgid ""
+"Second, that when a numeric label is used as a reference (as an instruction "
+"operand, for example), the suffixes “b” (“backward”) or ”f” (“forward”) "
+"should be added to the numeric label. It will then refer to the nearest label "
+"defined by this number in this direction."
+msgstr ""
+
+#: src/unsafe/asm.md:449
+msgid "Options"
+msgstr ""
+
+#: src/unsafe/asm.md:451
+msgid ""
+"By default, an inline assembly block is treated the same way as an external "
+"FFI function call with a custom calling convention: it may read/write memory, "
+"have observable side effects, etc. However, in many cases it is desirable to "
+"give the compiler more information about what the assembly code is actually "
+"doing so that it can optimize better."
+msgstr ""
+
+#: src/unsafe/asm.md:453
+msgid "Let's take our previous example of an `add` instruction:"
+msgstr ""
+
+#: src/unsafe/asm.md:472
+msgid ""
+"Options can be provided as an optional final argument to the `asm!` macro. We "
+"specified three options here:"
+msgstr ""
+
+#: src/unsafe/asm.md:473
+msgid ""
+"`pure` means that the asm code has no observable side effects and that its "
+"output depends only on its inputs. This allows the compiler optimizer to call "
+"the inline asm fewer times or even eliminate it entirely."
+msgstr ""
+
+#: src/unsafe/asm.md:474
+msgid ""
+"`nomem` means that the asm code does not read or write to memory. By default "
+"the compiler will assume that inline assembly can read or write any memory "
+"address that is accessible to it (e.g. through a pointer passed as an "
+"operand, or a global)."
+msgstr ""
+
+#: src/unsafe/asm.md:475
+msgid ""
+"`nostack` means that the asm code does not push any data onto the stack. This "
+"allows the compiler to use optimizations such as the stack red zone on x86-64 "
+"to avoid stack pointer adjustments."
+msgstr ""
+
+#: src/unsafe/asm.md:477
+msgid ""
+"These allow the compiler to better optimize code using `asm!`, for example by "
+"eliminating pure `asm!` blocks whose outputs are not needed."
+msgstr ""
+
+#: src/unsafe/asm.md:479
+msgid ""
+"See the [reference](https://doc.rust-lang.org/stable/reference/inline-"
+"assembly.html) for the full list of available options and their effects."
+msgstr ""
+
+#: src/compatibility.md:3
+msgid ""
+"The Rust language is fastly evolving, and because of this certain "
+"compatibility issues can arise, despite efforts to ensure forwards-"
+"compatibility wherever possible."
+msgstr ""
+
+#: src/compatibility.md:7
+msgid "[Raw identifiers](compatibility/raw_identifiers.md)"
+msgstr ""
+
+#: src/compatibility/raw_identifiers.md:3
+msgid ""
+"Rust, like many programming languages, has the concept of \"keywords\". These "
+"identifiers mean something to the language, and so you cannot use them in "
+"places like variable names, function names, and other places. Raw identifiers "
+"let you use keywords where they would not normally be allowed. This is "
+"particularly useful when Rust introduces new keywords, and a library using an "
+"older edition of Rust has a variable or function with the same name as a "
+"keyword introduced in a newer edition."
+msgstr ""
+
+#: src/compatibility/raw_identifiers.md:11
+msgid ""
+"For example, consider a crate `foo` compiled with the 2015 edition of Rust "
+"that exports a function named `try`. This keyword is reserved for a new "
+"feature in the 2018 edition, so without raw identifiers, we would have no way "
+"to name the function."
+msgstr ""
+
+#: src/compatibility/raw_identifiers.md:24
+msgid "You'll get this error:"
+msgstr ""
+
+#: src/compatibility/raw_identifiers.md:34
+msgid "You can write this with a raw identifier:"
+msgstr ""
+
+#: src/meta.md:3
+msgid ""
+"Some topics aren't exactly relevant to how you program runs but provide you "
+"tooling or infrastructure support which just makes things better for "
+"everyone. These topics include:"
+msgstr ""
+
+#: src/meta.md:7
+msgid ""
+"[Documentation](meta/doc.md): Generate library documentation for users via "
+"the included `rustdoc`."
+msgstr ""
+
+#: src/meta.md:9
+msgid ""
+"[Playground](meta/playground.md): Integrate the Rust Playground in your "
+"documentation."
+msgstr ""
+
+#: src/meta/doc.md:3
+msgid ""
+"Use `cargo doc` to build documentation in `target/doc`, `cargo doc --open` "
+"will automatically open it in your web browser."
+msgstr ""
+
+#: src/meta/doc.md:6
+msgid ""
+"Use `cargo test` to run all tests (including documentation tests), and `cargo "
+"test --doc` to only run documentation tests."
+msgstr ""
+
+#: src/meta/doc.md:9
+msgid ""
+"These commands will appropriately invoke `rustdoc` (and `rustc`) as required."
+msgstr ""
+
+#: src/meta/doc.md:11
+msgid "Doc comments"
+msgstr ""
+
+#: src/meta/doc.md:13
+msgid ""
+"Doc comments are very useful for big projects that require documentation. "
+"When running `rustdoc`, these are the comments that get compiled into "
+"documentation. They are denoted by a `///`, and support [Markdown](https://en."
+"wikipedia.org/wiki/Markdown)."
+msgstr ""
+
+#: src/meta/doc.md:18
+msgid "\"doc\""
+msgstr ""
+
+#: src/meta/doc.md:19
+msgid "/// A human being is represented here\n"
+msgstr ""
+
+#: src/meta/doc.md:22
+msgid "/// A person must have a name, no matter how much Juliet may hate it\n"
+msgstr ""
+
+#: src/meta/doc.md:27
+msgid ""
+"/// Creates a person with the given name.\n"
+"    ///\n"
+"    /// # Examples\n"
+"    ///\n"
+"    /// ```\n"
+"    /// // You can have rust code between fences inside the comments\n"
+"    /// // If you pass --test to `rustdoc`, it will even test it for you!\n"
+"    /// use doc::Person;\n"
+"    /// let person = Person::new(\"name\");\n"
+"    /// ```\n"
+msgstr ""
+
+#: src/meta/doc.md:43
+msgid ""
+"/// Gives a friendly hello!\n"
+"    ///\n"
+"    /// Says \"Hello, [name](Person::name)\" to the `Person` it is called "
+"on.\n"
+msgstr ""
+
+#: src/meta/doc.md:47
+msgid "\"Hello, {}!\""
+msgstr ""
+
+#: src/meta/doc.md:52
+msgid "\"John\""
+msgstr ""
+
+#: src/meta/doc.md:58
+msgid ""
+"To run the tests, first build the code as a library, then tell `rustdoc` "
+"where to find the library so it can link it into each doctest program:"
+msgstr ""
+
+#: src/meta/doc.md:61
+msgid ""
+"```shell\n"
+"$ rustc doc.rs --crate-type lib\n"
+"$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
+"```"
+msgstr ""
+
+#: src/meta/doc.md:66
+msgid "Doc attributes"
+msgstr ""
+
+#: src/meta/doc.md:68
+msgid ""
+"Below are a few examples of the most common `#[doc]` attributes used with "
+"`rustdoc`."
+msgstr ""
+
+#: src/meta/doc.md:71
+msgid "`inline`"
+msgstr ""
+
+#: src/meta/doc.md:73
+msgid "Used to inline docs, instead of linking out to separate page."
+msgstr ""
+
+#: src/meta/doc.md:78
+msgid "/// bar docs\n"
+msgstr ""
+
+#: src/meta/doc.md:81
+msgid "/// the docs for Bar\n"
+msgstr ""
+
+#: src/meta/doc.md:86
+msgid "`no_inline`"
+msgstr ""
+
+#: src/meta/doc.md:88
+msgid "Used to prevent linking out to separate page or anywhere."
+msgstr ""
+
+#: src/meta/doc.md:91
+msgid "// Example from libcore/prelude\n"
+msgstr ""
+
+#: src/meta/doc.md:96
+msgid "`hidden`"
+msgstr ""
+
+#: src/meta/doc.md:98
+msgid "Using this tells `rustdoc` not to include this in documentation:"
+msgstr ""
+
+#: src/meta/doc.md:101
+msgid "// Example from the futures-rs library\n"
+msgstr ""
+
+#: src/meta/doc.md:106
+msgid ""
+"For documentation, `rustdoc` is widely used by the community. It's what is "
+"used to generate the [std library docs](https://doc.rust-lang.org/std/)."
+msgstr ""
+
+#: src/meta/doc.md:111
+msgid ""
+"[The Rust Book: Making Useful Documentation Comments](https://doc.rust-lang."
+"org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-"
+"comments)"
+msgstr ""
+
+#: src/meta/doc.md:112
+msgid "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/index.html)"
+msgstr ""
+
+#: src/meta/doc.md:113
+msgid ""
+"[The Reference: Doc comments](https://doc.rust-lang.org/stable/reference/"
+"comments.html#doc-comments)"
+msgstr ""
+
+#: src/meta/doc.md:114
+msgid ""
+"[RFC 1574: API Documentation Conventions](https://rust-lang.github.io/"
+"rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-"
+"text)"
+msgstr ""
+
+#: src/meta/doc.md:115
+msgid ""
+"[RFC 1946: Relative links to other items from doc comments (intra-rustdoc "
+"links)](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
+msgstr ""
+
+#: src/meta/doc.md:116
+msgid ""
+"[Is there any documentation style guide for comments? (reddit)](https://www."
+"reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
+msgstr ""
+
+#: src/meta/playground.md:3
+msgid ""
+"The [Rust Playground](https://play.rust-lang.org/) is a way to experiment "
+"with Rust code through a web interface."
+msgstr ""
+
+#: src/meta/playground.md:6
+msgid "Using it with `mdbook`"
+msgstr ""
+
+#: src/meta/playground.md:8
+msgid ""
+"In [`mdbook`](https://github.com/rust-lang/mdBook), you can make code "
+"examples playable and editable."
+msgstr ""
+
+#: src/meta/playground.md:16
+msgid ""
+"This allows the reader to both run your code sample, but also modify and "
+"tweak it. The key here is the adding of the word `editable` to your codefence "
+"block separated by a comma."
+msgstr ""
+
+#: src/meta/playground.md:26
+msgid ""
+"Additionally, you can add `ignore` if you want `mdbook` to skip your code "
+"when it builds and tests."
+msgstr ""
+
+#: src/meta/playground.md:35
+msgid "Using it with docs"
+msgstr ""
+
+#: src/meta/playground.md:37
+msgid ""
+"You may have noticed in some of the [official Rust docs](https://doc.rust-"
+"lang.org/core/) a button that says \"Run\", which opens the code sample up in "
+"a new tab in Rust Playground. This feature is enabled if you use the `#[doc]` "
+"attribute called [`html_playground_url`](https://doc.rust-lang.org/rustdoc/"
+"write-documentation/the-doc-attribute.html#html_playground_url)."
+msgstr ""
+
+#: src/meta/playground.md:42
+msgid ""
+"````\n"
+"#![doc(html_playground_url = \"https://play.rust-lang.org/\")]\n"
+"//! ```\n"
+"//! println!(\"Hello World\");\n"
+"//! ```\n"
+"````"
+msgstr ""
+
+#: src/meta/playground.md:51
+msgid "[The Rust Playground](https://play.rust-lang.org/)"
+msgstr ""
+
+#: src/meta/playground.md:52
+msgid ""
+"[The Rust Playground On Github](https://github.com/integer32llc/rust-"
+"playground/)"
+msgstr ""
+
+#: src/meta/playground.md:53
+msgid ""
+"[The rustdoc Book](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)"
+msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2916,16 +2916,16 @@ msgstr "[类型转换](../../types/cast.md)"
 
 #: src/custom_types/enum/testcase_linked_list.md:3
 msgid "A common way to implement a linked-list is via `enums`:"
-msgstr "使用 `enum` 实现链表是一种常见的方法："
+msgstr "使用 `enum` 是实现链表的常见方法："
 
 #: src/custom_types/enum/testcase_linked_list.md:9
 msgid ""
 "// Cons: Tuple struct that wraps an element and a pointer to the next node\n"
-msgstr "// Cons：元组结构体包含一个元素和一个指向下一节点的指针\n"
+msgstr "// Cons：包含一个元素和指向下一节点指针的元组结构体\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:11
 msgid "// Nil: A node that signifies the end of the linked list\n"
-msgstr "// Nil：表示链表结束的节点\n"
+msgstr "// Nil：表示链表末尾的节点\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:14
 msgid "// Methods can be attached to an enum\n"
@@ -2933,24 +2933,24 @@ msgstr "// 可以为枚举实现方法\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:17
 msgid "// Create an empty list\n"
-msgstr "// 创建一个空链表\n"
+msgstr "// 创建空链表\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:19
 msgid "// `Nil` has type `List`\n"
-msgstr "// `Nil` 属于 `List` 类型\n"
+msgstr "// `Nil` 的类型是 `List`\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:23
 msgid ""
 "// Consume a list, and return the same list with a new element at its front\n"
-msgstr "// 处理一个链表，并返回在其头部插入新元素后的同一链表\n"
+msgstr "// 消耗一个链表，并返回在其头部添加新元素后的链表\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:25
 msgid "// `Cons` also has type List\n"
-msgstr "// `Cons` 也是 List 类型\n"
+msgstr "// `Cons` 的类型也是 List\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:29
 msgid "// Return the length of the list\n"
-msgstr "// 返回链表的长度\n"
+msgstr "// 返回链表长度\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:31
 msgid ""
@@ -2962,11 +2962,11 @@ msgid ""
 "        // rust will infer &s and ref tail. \n"
 "        // See https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/default-match-bindings.html\n"
 msgstr ""
-"// 必须对 `self` 进行匹配，因为这个方法的行为取决于 `self` 的成员\n"
-"        // `self` 的类型是 `&List`，而 `*self` 的类型是 `List`，匹配一个具体的\n"
-"        // 类型 `T` 要优于匹配一个引用 `&T`\n"
-"        // 在 Rust 2018 之后，你也可以在这里使用 self，在下面使用 tail（不带 ref），\n"
-"        // Rust 会推断出 &s 和 ref tail。\n"
+"// 需要对 `self` 进行匹配，因为方法的行为取决于 `self` 的变体\n"
+"        // `self` 的类型是 `&List`，而 `*self` 的类型是 `List`\n"
+"        // 匹配具体类型 `T` 优于匹配引用 `&T`\n"
+"        // 在 Rust 2018 版本后，这里可以直接使用 self，下面可以使用 tail（无需 ref）\n"
+"        // Rust 会自动推断为 &s 和 ref tail\n"
 "        // 参见 https://doc.rust-lang.org/edition-guide/rust-2018/ownership-and-lifetimes/default-match-bindings.html\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:39
@@ -2974,12 +2974,12 @@ msgid ""
 "// Can't take ownership of the tail, because `self` is borrowed;\n"
 "            // instead take a reference to the tail\n"
 msgstr ""
-"// 不能获取 tail 的所有权，因为 `self` 是借用的；\n"
-"            // 相反，我们获取 tail 的引用\n"
+"// 无法获取 tail 的所有权，因为 `self` 是借用的；\n"
+"            // 所以取 tail 的引用\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:42
 msgid "// Base Case: An empty list has zero length\n"
-msgstr "// 基本情况：空链表的长度为零\n"
+msgstr "// 基本情况：空链表长度为零\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:47
 msgid "// Return representation of the list as a (heap allocated) string\n"
@@ -2990,7 +2990,7 @@ msgid ""
 "// `format!` is similar to `print!`, but returns a heap\n"
 "                // allocated string instead of printing to the console\n"
 msgstr ""
-"// `format!` 类似于 `print!`，但返回一个堆分配的字符串，\n"
+"// `format!` 类似于 `print!`，但返回堆分配的字符串，\n"
 "                // 而不是打印到控制台\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:53 src/generics/impl.md:44
@@ -3003,7 +3003,7 @@ msgstr "\"Nil\""
 
 #: src/custom_types/enum/testcase_linked_list.md:63
 msgid "// Create an empty linked list\n"
-msgstr "// 创建一个空链表\n"
+msgstr "// 创建空链表\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:66
 msgid "// Prepend some elements\n"
@@ -3015,21 +3015,21 @@ msgstr "// 显示链表的最终状态\n"
 
 #: src/custom_types/enum/testcase_linked_list.md:72
 msgid "\"linked list has length: {}\""
-msgstr "\"链表的长度为：{}\""
+msgstr "\"链表长度为：{}\""
 
 #: src/custom_types/enum/testcase_linked_list.md:79
 msgid "[`Box`](../../std/box.md) and [methods](../../fn/methods.md)"
-msgstr "[`Box`](../../std/box.md) 和 [方法](../../fn/methods.md)"
+msgstr "[`Box`](../../std/box.md) 和[方法](../../fn/methods.md)"
 
 #: src/custom_types/constants.md:3
 msgid ""
 "Rust has two different types of constants which can be declared in any scope "
 "including global. Both require explicit type annotation:"
-msgstr "Rust 有两种不同类型的常量，可以在包括全局作用域在内的任何作用域中声明。两者都需要显式的类型标注："
+msgstr "Rust 有两种常量类型，可以在任何作用域（包括全局作用域）中声明。两者都需要显式类型标注："
 
 #: src/custom_types/constants.md:6
 msgid "`const`: An unchangeable value (the common case)."
-msgstr "`const`：不可改变的值（常见用法）。"
+msgstr "`const`：不可变值（常见用法）。"
 
 #: src/custom_types/constants.md:7
 msgid ""
@@ -3038,8 +3038,8 @@ msgid ""
 "have to be specified. Accessing or modifying a mutable static variable is "
 "[`unsafe`](../unsafe.md)."
 msgstr ""
-"`static`：具有 [`'static`](../scope/lifetime/static_lifetime.md) 生命周期的可能可变的变量。"
-"静态生命周期是自动推断的，不需要明确指定。访问或修改可变静态变量是 [`unsafe`](../unsafe.md) 的。"
+"`static`：具有 [`'static`](../scope/lifetime/static_lifetime.md) 生命周期的可能可变变量。"
+"静态生命周期会被自动推断，无需明确指定。访问或修改可变静态变量是 [`unsafe`](../unsafe.md) 的。"
 
 #: src/custom_types/constants.md:12
 msgid "// Globals are declared outside all other scopes.\n"
@@ -3051,7 +3051,7 @@ msgstr "\"Rust\""
 
 #: src/custom_types/constants.md:17
 msgid "// Access constant in some function\n"
-msgstr "// 在某个函数中访问常量\n"
+msgstr "// 在函数中访问常量\n"
 
 #: src/custom_types/constants.md:24
 msgid "// Access constant in the main thread\n"
@@ -3063,7 +3063,7 @@ msgstr "\"这是 {}\""
 
 #: src/custom_types/constants.md:26
 msgid "\"The threshold is {}\""
-msgstr "\"阈值是 {}\""
+msgstr "\"阈值为 {}\""
 
 #: src/custom_types/constants.md:27
 msgid "\"{} is {}\""
@@ -3079,7 +3079,7 @@ msgstr "\"小的\""
 
 #: src/custom_types/constants.md:29
 msgid "// Error! Cannot modify a `const`.\n"
-msgstr "// 报错！不能修改 `const`。\n"
+msgstr "// 错误！不能修改 `const`。\n"
 
 #: src/custom_types/constants.md:31 src/variable_bindings/scope.md:21
 #: src/variable_bindings/declare.md:25 src/variable_bindings/freeze.md:16
@@ -3087,7 +3087,7 @@ msgstr "// 报错！不能修改 `const`。\n"
 #: src/scope/borrow.md:41 src/scope/borrow/mut.md:52 src/std/vec.md:31
 #: src/std/vec.md:44 src/std/hash/hashset.md:48
 msgid "// FIXME ^ Comment out this line\n"
-msgstr "// 修复 ^ 注释掉这一行\n"
+msgstr "// 修复：^ 注释掉此行\n"
 
 #: src/custom_types/constants.md:37
 msgid ""
@@ -3106,13 +3106,14 @@ msgid ""
 "infer the type of the variable from the context, heavily reducing the "
 "annotation burden."
 msgstr ""
-"Rust 通过静态类型提供类型安全。变量绑定在声明时可以进行类型标注。然而，在大多数情况下，编译器能够从上下文中推断出变量的类型，大大减少了注解的负担。"
+"Rust 通过静态类型提供类型安全。变量绑定在声明时可以添加类型注解。然而，在大多数情况下，"
+"编译器能够从上下文推断出变量类型，大大减少了类型注解的负担。"
 
 #: src/variable_bindings.md:8
 msgid ""
 "Values (like literals) can be bound to variables, using the `let` binding."
 msgstr ""
-"值（如字面量）可以使用 `let` 绑定到变量。"
+"可以使用 `let` 关键字将值（如字面量）绑定到变量。"
 
 #: src/variable_bindings.md:16
 msgid "// copy `an_integer` into `copied_integer`\n"
@@ -3120,38 +3121,38 @@ msgstr "// 将 `an_integer` 复制到 `copied_integer`\n"
 
 #: src/variable_bindings.md:19
 msgid "\"An integer: {:?}\""
-msgstr "\"一个整数：{:?}\""
+msgstr "\"整数：{:?}\""
 
 #: src/variable_bindings.md:20
 msgid "\"A boolean: {:?}\""
-msgstr "\"一个布尔值：{:?}\""
+msgstr "\"布尔值：{:?}\""
 
 #: src/variable_bindings.md:21
 msgid "\"Meet the unit value: {:?}\""
-msgstr "\"遇见单元值：{:?}\""
+msgstr "\"单元值：{:?}\""
 
 #: src/variable_bindings.md:23
 msgid ""
 "// The compiler warns about unused variable bindings; these warnings can\n"
 "    // be silenced by prefixing the variable name with an underscore\n"
 msgstr ""
-"// 编译器会对未使用的变量绑定发出警告；这些警告可以\n"
-"    // 通过在变量名前加上下划线来消除\n"
+"// 编译器会对未使用的变量绑定发出警告\n"
+"    // 可以通过在变量名前加下划线来消除这些警告\n"
 
 #: src/variable_bindings.md:28
 msgid ""
 "// FIXME ^ Prefix with an underscore to suppress the warning\n"
 "    // Please note that warnings may not be shown in a browser\n"
 msgstr ""
-"// 修复 ^ 在变量名前加上下划线以消除警告\n"
-"    // 请注意，在浏览器中可能不会显示警告\n"
+"// 修复：^ 在变量名前加下划线以消除警告\n"
+"    // 注意：在浏览器中可能不会显示警告\n"
 
 #: src/variable_bindings/mut.md:3
 msgid ""
 "Variable bindings are immutable by default, but this can be overridden using "
 "the `mut` modifier."
 msgstr ""
-"变量绑定默认是不可变的，但可以使用 `mut` 修饰符来覆盖这一行为。"
+"变量绑定默认是不可变的，但可以使用 `mut` 修饰符来改变这一行为。"
 
 #: src/variable_bindings/mut.md:11
 msgid "\"Before mutation: {}\""
@@ -3167,7 +3168,7 @@ msgstr "\"修改后：{}\""
 
 #: src/variable_bindings/mut.md:18
 msgid "// Error! Cannot assign a new value to an immutable variable\n"
-msgstr "// 报错！不能对不可变变量赋新值\n"
+msgstr "// 错误！不能给不可变变量赋新值\n"
 
 #: src/variable_bindings/mut.md:23
 msgid "The compiler will throw a detailed diagnostic about mutability errors."
@@ -3178,7 +3179,7 @@ msgid ""
 "Variable bindings have a scope, and are constrained to live in a _block_. A "
 "block is a collection of statements enclosed by braces `{}`."
 msgstr ""
-"变量绑定有作用域，它们被限制在一个**代码块**中存在。代码块是由花括号 `{}` 包围的一系列语句。"
+"变量绑定有作用域，它们被限制在一个**代码块**中生存。代码块是由花括号 `{}` 包围的一系列语句。"
 
 #: src/variable_bindings/scope.md:7
 msgid "// This binding lives in the main function\n"
@@ -3190,11 +3191,11 @@ msgstr "// 这是一个代码块，它的作用域比 main 函数小\n"
 
 #: src/variable_bindings/scope.md:12
 msgid "// This binding only exists in this block\n"
-msgstr "// 这个绑定只存在于这个代码块中\n"
+msgstr "// 这个绑定只存在于此代码块中\n"
 
 #: src/variable_bindings/scope.md:15
 msgid "\"inner short: {}\""
-msgstr "\"内部的 short：{}\""
+msgstr "\"内部 short：{}\""
 
 #: src/variable_bindings/scope.md:17
 msgid "// End of the block\n"
@@ -3202,26 +3203,26 @@ msgstr "// 代码块结束\n"
 
 #: src/variable_bindings/scope.md:19
 msgid "// Error! `short_lived_binding` doesn't exist in this scope\n"
-msgstr "// 报错！`short_lived_binding` 在这个作用域中不存在\n"
+msgstr "// 错误！`short_lived_binding` 在此作用域中不存在\n"
 
 #: src/variable_bindings/scope.md:20
 msgid "\"outer short: {}\""
-msgstr "\"外部的 short：{}\""
+msgstr "\"外部 short：{}\""
 
 #: src/variable_bindings/scope.md:23
 msgid "\"outer long: {}\""
-msgstr "\"外部的 long：{}\""
+msgstr "\"外部 long：{}\""
 
 #: src/variable_bindings/scope.md:26
 msgid ""
 "Also, [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing) "
 "is allowed."
 msgstr ""
-"此外，允许[变量遮蔽](https://en.wikipedia.org/wiki/Variable_shadowing)。"
+"此外，Rust 允许[变量遮蔽](https://en.wikipedia.org/wiki/Variable_shadowing)。"
 
 #: src/variable_bindings/scope.md:32
 msgid "\"before being shadowed: {}\""
-msgstr "\"被遮蔽之前：{}\""
+msgstr "\"被遮蔽前：{}\""
 
 #: src/variable_bindings/scope.md:34
 msgid "// This binding *shadows* the outer one\n"
@@ -3233,11 +3234,11 @@ msgstr "\"abc\""
 
 #: src/variable_bindings/scope.md:37
 msgid "\"shadowed in inner block: {}\""
-msgstr "\"在内部代码块中被遮蔽：{}\""
+msgstr "\"内部代码块中被遮蔽：{}\""
 
 #: src/variable_bindings/scope.md:39
 msgid "\"outside inner block: {}\""
-msgstr "\"在内部代码块外：{}\""
+msgstr "\"内部代码块外：{}\""
 
 #: src/variable_bindings/scope.md:41
 msgid "// This binding *shadows* the previous binding\n"
@@ -3245,7 +3246,7 @@ msgstr "// 这个绑定*遮蔽*了之前的绑定\n"
 
 #: src/variable_bindings/scope.md:43
 msgid "\"shadowed in outer block: {}\""
-msgstr "\"在外部代码块中被遮蔽：{}\""
+msgstr "\"外部代码块中被遮蔽：{}\""
 
 #: src/variable_bindings/declare.md:3
 msgid ""
@@ -3253,7 +3254,7 @@ msgid ""
 "However, this form is seldom used, as it may lead to the use of uninitialized "
 "variables."
 msgstr ""
-"可以先声明变量绑定，然后再初始化它们。然而，这种形式很少使用，因为它可能导致使用未初始化的变量。"
+"可以先声明变量绑定，然后再初始化。但这种形式很少使用，因为它可能导致使用未初始化的变量。"
 
 #: src/variable_bindings/declare.md:9
 msgid "// Declare a variable binding\n"
@@ -3265,11 +3266,11 @@ msgstr "// 初始化绑定\n"
 
 #: src/variable_bindings/declare.md:19
 msgid "\"a binding: {}\""
-msgstr "\"一个绑定：{}\""
+msgstr "\"绑定：{}\""
 
 #: src/variable_bindings/declare.md:23
 msgid "// Error! Use of uninitialized binding\n"
-msgstr "// 报错！使用未初始化的绑定\n"
+msgstr "// 错误！使用未初始化的绑定\n"
 
 #: src/variable_bindings/declare.md:24 src/variable_bindings/declare.md:29
 msgid "\"another binding: {}\""
@@ -3287,7 +3288,7 @@ msgid ""
 "When data is bound by the same name immutably, it also _freezes_. _Frozen_ "
 "data can't be modified until the immutable binding goes out of scope:"
 msgstr ""
-"当数据以相同的名称被不可变地绑定时，它也会**冻结**。被冻结的数据在不可变绑定离开作用域之前不能被修改："
+"当数据以相同名称被不可变地绑定时，它也会**冻结**。被冻结的数据在不可变绑定离开作用域之前不能被修改："
 
 #: src/variable_bindings/freeze.md:11
 msgid "// Shadowing by immutable `_mutable_integer`\n"
@@ -3295,7 +3296,7 @@ msgstr "// 通过不可变的 `_mutable_integer` 进行遮蔽\n"
 
 #: src/variable_bindings/freeze.md:14
 msgid "// Error! `_mutable_integer` is frozen in this scope\n"
-msgstr "// 报错！`_mutable_integer` 在这个作用域中被冻结\n"
+msgstr "// 错误！`_mutable_integer` 在此作用域中被冻结\n"
 
 #: src/variable_bindings/freeze.md:18
 msgid "// `_mutable_integer` goes out of scope\n"
@@ -3303,22 +3304,22 @@ msgstr "// `_mutable_integer` 离开作用域\n"
 
 #: src/variable_bindings/freeze.md:21
 msgid "// Ok! `_mutable_integer` is not frozen in this scope\n"
-msgstr "// 正确！`_mutable_integer` 在这个作用域中没有被冻结\n"
+msgstr "// 正确！`_mutable_integer` 在此作用域中未被冻结\n"
 
 #: src/types.md:3
 msgid ""
 "Rust provides several mechanisms to change or define the type of primitive "
 "and user defined types. The following sections cover:"
 msgstr ""
-"Rust 提供了几种机制来更改或定义原生类型和用户定义类型。以下部分涵盖了："
+"Rust 提供了几种机制来更改或定义原生类型和用户定义类型。以下部分将介绍："
 
 #: src/types.md:5
 msgid "[Casting](types/cast.md) between primitive types"
-msgstr "原生类型之间的[转换](types/cast.md)"
+msgstr "原生类型之间的[类型转换](types/cast.md)"
 
 #: src/types.md:6
 msgid "Specifying the desired type of [literals](types/literals.md)"
-msgstr "指定[字面值](types/literals.md)的所需类型"
+msgstr "指定[字面量](types/literals.md)的类型"
 
 #: src/types.md:7
 msgid "Using [type inference](types/inference.md)"
@@ -3326,7 +3327,7 @@ msgstr "使用[类型推断](types/inference.md)"
 
 #: src/types.md:8
 msgid "[Aliasing](types/alias.md) types"
-msgstr "[别名化](types/alias.md)类型"
+msgstr "类型[别名](types/alias.md)"
 
 #: src/types/cast.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -6735,11 +6735,11 @@ msgid ""
 "Modules can be mapped to a file/directory hierarchy. Let's break down the "
 "[visibility example](visibility.md) in files:"
 msgstr ""
-"模块可以映射到文件/目录层次结构。让我们将[可见性示例](visibility.md)拆分到多个文件中："
+"模块可以映射到文件/目录层次结构。让我们将[可见性示例](visibility.md)拆分成多个文件："
 
 #: src/mod/split.md:16
 msgid "In `split.rs`:"
-msgstr "在 `split.rs` 中："
+msgstr "在 `split.rs` 文件中："
 
 #: src/mod/split.md:19
 msgid ""
@@ -6747,11 +6747,11 @@ msgid ""
 "// insert its contents inside a module named `my` under this scope\n"
 msgstr ""
 "// 这个声明会查找名为 `my.rs` 的文件，并将其内容\n"
-"// 插入到这个作用域下名为 `my` 的模块中\n"
+"// 插入到当前作用域下名为 `my` 的模块中\n"
 
 #: src/mod/split.md:39
 msgid "In `my.rs`:"
-msgstr "在 `my.rs` 中："
+msgstr "在 `my.rs` 文件中："
 
 #: src/mod/split.md:42
 msgid ""
@@ -6759,40 +6759,41 @@ msgid ""
 "// and `inaccessible.rs` files and insert them here under their respective\n"
 "// modules\n"
 msgstr ""
-"// 类似地，`mod inaccessible` 和 `mod nested` 将定位 `nested.rs` \n"
-"// 和 `inaccessible.rs` 文件，并将它们插入到这里各自的模块下\n"
+"// 同样，`mod inaccessible` 和 `mod nested` 会分别定位到\n"
+"// `nested.rs` 和 `inaccessible.rs` 文件，\n"
+"// 并将它们的内容插入到这里对应的模块中\n"
 
 #: src/mod/split.md:53
 msgid "\"called `my::private_function()`\""
-msgstr "\"调用 `my::private_function()`\""
+msgstr "\"调用了 `my::private_function()`\""
 
 #: src/mod/split.md:57
 msgid "\"called `my::indirect_access()`, that\\n> \""
-msgstr "\"调用 `my::indirect_access()`，它\\n> \""
+msgstr "\"调用了 `my::indirect_access()`，它\\n> \""
 
 #: src/mod/split.md:63
 msgid "In `my/nested.rs`:"
-msgstr "在 `my/nested.rs` 中："
+msgstr "在 `my/nested.rs` 文件中："
 
 #: src/mod/split.md:67
 msgid "\"called `my::nested::function()`\""
-msgstr "\"调用 `my::nested::function()`\""
+msgstr "\"调用了 `my::nested::function()`\""
 
 #: src/mod/split.md:72
 msgid "\"called `my::nested::private_function()`\""
-msgstr "\"调用 `my::nested::private_function()`\""
+msgstr "\"调用了 `my::nested::private_function()`\""
 
 #: src/mod/split.md:76
 msgid "In `my/inaccessible.rs`:"
-msgstr "在 `my/inaccessible.rs` 中："
+msgstr "在 `my/inaccessible.rs` 文件中："
 
 #: src/mod/split.md:81
 msgid "\"called `my::inaccessible::public_function()`\""
-msgstr "\"调用 `my::inaccessible::public_function()`\""
+msgstr "\"调用了 `my::inaccessible::public_function()`\""
 
 #: src/mod/split.md:85
 msgid "Let's check that things still work as before:"
-msgstr "让我们检查一下是否一切仍然像之前一样工作："
+msgstr "让我们检查一下是否一切仍然如之前一样正常运行："
 
 #: src/crates.md:3
 msgid ""
@@ -6803,7 +6804,7 @@ msgid ""
 "_before_ running the compiler over it. In other words, modules do _not_ get "
 "compiled individually, only crates get compiled."
 msgstr ""
-"crate 是 Rust 中的编译单元。每当调用 `rustc some_file.rs` 时，`some_file.rs` 就被视为**crate 文件**。如果 `some_file.rs` 中有 `mod` 声明，那么模块文件的内容会在编译器运行之前被插入到 crate 文件中 `mod` 声明的位置。换句话说，模块**不会**被单独编译，只有 crate 才会被编译。"
+"在 Rust 中，crate 是一个编译单元。每当执行 `rustc some_file.rs` 时，`some_file.rs` 就被视为**crate 文件**。如果 `some_file.rs` 中包含 `mod` 声明，那么模块文件的内容会在编译器处理之前被插入到 crate 文件中 `mod` 声明的位置。换句话说，模块**不会**被单独编译，只有 crate 才会被编译。"
 
 #: src/crates.md:10
 msgid ""
@@ -6811,7 +6812,7 @@ msgid ""
 "will produce a binary from a crate. This behavior can be overridden by "
 "passing the `--crate-type` flag to `lib`."
 msgstr ""
-"一个 crate 可以被编译成二进制文件或库。默认情况下，`rustc` 会从 crate 生成二进制文件。这个行为可以通过向 `lib` 传递 `--crate-type` 标志来改变。"
+"一个 crate 可以被编译成二进制文件或库。默认情况下，`rustc` 会将 crate 编译成二进制文件。通过向 `rustc` 传递 `--crate-type` 标志并指定 `lib`，可以改变这一默认行为。"
 
 #: src/crates/lib.md:3
 msgid "Let's create a library, and then see how to link it to another crate."
@@ -6819,7 +6820,7 @@ msgstr "让我们创建一个库，然后看看如何将它链接到另一个 cr
 
 #: src/crates/lib.md:5
 msgid "In `rary.rs`:"
-msgstr "在 `rary.rs` 中："
+msgstr "在 `rary.rs` 文件中："
 
 #: src/crates/lib.md:9 src/attribute/crate.md:19
 msgid "\"called rary's `public_function()`\""
@@ -6840,7 +6841,7 @@ msgid ""
 "crate-name` option to `rustc` or by using the [`crate_name` attribute](../"
 "attribute/crate.md)."
 msgstr ""
-"库的名称前缀为 \"lib\"，默认情况下它们以 crate 文件命名，但这个默认名称可以通过向 `rustc` 传递 `--crate-name` 选项或使用 [`crate_name` 属性](../attribute/crate.md) 来覆盖。"
+"库文件名会自动添加 \"lib\" 前缀，默认使用 crate 文件的名称。但可以通过向 `rustc` 传递 `--crate-name` 选项或使用 [`crate_name` 属性](../attribute/crate.md) 来覆盖这个默认名称。"
 
 #: src/crates/using_lib.md:3
 msgid ""
@@ -6848,20 +6849,20 @@ msgid ""
 "All of its items will then be imported under a module named the same as the "
 "library. This module generally behaves the same way as any other module."
 msgstr ""
-"要将一个 crate 链接到这个新库，你可以使用 `rustc` 的 `--extern` 标志。然后，它的所有项目都会被导入到一个与库同名的模块下。这个模块通常的行为与任何其他模块相同。"
+"要将 crate 链接到这个新库，可以使用 `rustc` 的 `--extern` 标志。库中的所有项目都会被导入到一个与库同名的模块下。这个模块的行为通常与其他模块相同。"
 
 #: src/crates/using_lib.md:8
 msgid ""
 "// extern crate rary; // May be required for Rust 2015 edition or earlier\n"
 msgstr ""
-"// extern crate rary; // 可能在 Rust 2015 版本或更早版本中需要\n"
+"// extern crate rary; // Rust 2015 版本或更早版本可能需要此声明\n"
 
 #: src/crates/using_lib.md:13
 msgid ""
 "// Error! `private_function` is private\n"
 "    //rary::private_function();\n"
 msgstr ""
-"// 报错！`private_function` 是私有的\n"
+"// 错误！`private_function` 是私有的\n"
 "    //rary::private_function();\n"
 
 #: src/cargo.md:3
@@ -6869,14 +6870,14 @@ msgid ""
 "`cargo` is the official Rust package management tool. It has lots of really "
 "useful features to improve code quality and developer velocity! These include"
 msgstr ""
-"`cargo` 是 Rust 的官方包管理工具。它有许多非常有用的功能来提高代码质量和开发效率！这些功能包括"
+"`cargo` 是 Rust 的官方包管理工具。它提供了许多非常有用的功能，可以提高代码质量和开发效率！这些功能包括："
 
 #: src/cargo.md:6
 msgid ""
 "Dependency management and integration with [crates.io](https://crates.io) "
 "(the official Rust package registry)"
 msgstr ""
-"依赖管理和与 [crates.io](https://crates.io)（官方 Rust 包注册中心）的集成"
+"依赖管理和与 [crates.io](https://crates.io)（Rust 官方包注册中心）的集成"
 
 #: src/cargo.md:8
 msgid "Awareness of unit tests"
@@ -6891,7 +6892,7 @@ msgid ""
 "This chapter will go through some quick basics, but you can find the "
 "comprehensive docs in [The Cargo Book](https://doc.rust-lang.org/cargo/)."
 msgstr ""
-"本章将快速介绍一些基础知识，不过你可以在 [Cargo 手册](https://doc.rust-lang.org/cargo/) 中找到更全面的文档。"
+"本章将快速介绍一些基础知识，更全面的文档可以在 [Cargo 手册](https://doc.rust-lang.org/cargo/) 中找到。"
 
 #: src/cargo/deps.md:3
 msgid ""
@@ -6900,30 +6901,30 @@ msgid ""
 "Rust ecosystem comes standard with `cargo`! `cargo` can manage dependencies "
 "for a project."
 msgstr ""
-"大多数程序都依赖于一些库。如果你曾经手动管理过依赖，你就知道这有多痛苦。幸运的是，Rust 生态系统标配了 `cargo` 工具！`cargo` 可以为项目管理依赖。"
+"大多数程序都依赖于一些库。如果你曾经手动管理过依赖，你就知道这有多么痛苦。幸运的是，Rust 生态系统标配了 `cargo`！`cargo` 可以为项目管理依赖。"
 
 #: src/cargo/deps.md:8
 msgid "To create a new Rust project,"
-msgstr "创建一个新的 Rust 项目，"
+msgstr "要创建一个新的 Rust 项目，可以使用以下命令："
 
 #: src/cargo/deps.md:11
 msgid "# A binary\n"
-msgstr "# 二进制程序\n"
+msgstr "# 创建二进制项目\n"
 
 #: src/cargo/deps.md:13
 msgid "# A library\n"
-msgstr "# 库\n"
+msgstr "# 创建库项目\n"
 
 #: src/cargo/deps.md:18
 msgid ""
 "For the rest of this chapter, let's assume we are making a binary, rather "
 "than a library, but all of the concepts are the same."
 msgstr ""
-"在本章的剩余部分，我们假设我们正在创建一个二进制程序，而不是一个库，但所有的概念都是相同的。"
+"在本章的剩余部分，我们假设我们正在创建一个二进制项目，而不是一个库项目，但所有的概念都是相同的。"
 
 #: src/cargo/deps.md:21
 msgid "After the above commands, you should see a file hierarchy like this:"
-msgstr "执行上述命令后，应该会得到这样的文件层次结构："
+msgstr "执行上述命令后，你应该会看到如下的文件结构："
 
 #: src/cargo/deps.md:35
 msgid ""
@@ -6931,7 +6932,7 @@ msgid ""
 "new there. The `Cargo.toml` is the config file for `cargo` for this project. "
 "If you look inside it, you should see something like this:"
 msgstr ""
-"`main.rs` 是新的 `foo` 项目的入口源文件 —— 这没什么新鲜的。`Cargo.toml` 是这个项目的 `cargo` 配置文件。如果你查看它的内容，你应该看到类似这样的内容："
+"`main.rs` 是你新建的 `foo` 项目的主源文件 —— 这一点没什么新鲜的。`Cargo.toml` 则是这个项目的 `cargo` 配置文件。如果你查看它的内容，应该会看到类似这样的内容："
 
 #: src/cargo/deps.md:39
 msgid ""
@@ -6959,14 +6960,14 @@ msgid ""
 "is used by `crates.io` if you publish the crate (more later). It is also the "
 "name of the output binary when you compile."
 msgstr ""
-"`[package]` 下的 `name` 字段决定了项目的名称。如果你发布 crate（稍后会详细介绍），这个名称将被 `crates.io` 使用。这也是编译时输出的二进制文件的名称。"
+"`[package]` 下的 `name` 字段决定了项目的名称。如果你将 crate 发布到 `crates.io`（稍后会详细介绍），这个名称将被使用。同时，它也是编译时生成的二进制文件的名称。"
 
 #: src/cargo/deps.md:52
 msgid ""
 "The `version` field is a crate version number using [Semantic Versioning]"
 "(http://semver.org/)."
 msgstr ""
-"`version` 字段是使用 [语义化版本控制](http://semver.org/) 的 crate 版本号。"
+"`version` 字段是使用[语义化版本控制](http://semver.org/)的 crate 版本号。"
 
 #: src/cargo/deps.md:55
 msgid "The `authors` field is a list of authors used when publishing the crate."
@@ -6974,7 +6975,7 @@ msgstr "`authors` 字段是发布 crate 时使用的作者列表。"
 
 #: src/cargo/deps.md:57
 msgid "The `[dependencies]` section lets you add dependencies for your project."
-msgstr "`[dependencies]` 部分用来为项目添加依赖。"
+msgstr "`[dependencies]` 部分允许你为项目添加依赖。"
 
 #: src/cargo/deps.md:59
 msgid ""
@@ -6986,14 +6987,14 @@ msgid ""
 "to our `Cargo.toml` under `[dependencies]`: `clap = \"2.27.1\"`. And that's "
 "it! You can start using `clap` in your program."
 msgstr ""
-"例如，假设我们希望我们的程序有一个出色的命令行界面（CLI）。你可以在 [crates.io](https://crates.io)（官方的 Rust 包注册中心）上找到许多优秀的包。一个受欢迎的选择是 [clap](https://crates.io/crates/clap)。在撰写本文时，`clap` 最新发布的版本是 `2.27.1`。要在我们的程序中添加依赖，我们只需在 `Cargo.toml` 的 `[dependencies]` 下添加以下内容：`clap = \"2.27.1\"`。就是这样！你现在可以在你的程序中开始使用 `clap` 了。"
+"举个例子，假设我们想让程序拥有一个出色的命令行界面（CLI）。你可以在 [crates.io](https://crates.io)（Rust 官方包注册中心）上找到许多优秀的包。其中，[clap](https://crates.io/crates/clap) 是一个广受欢迎的选择。在撰写本文时，`clap` 的最新发布版本是 `2.27.1`。要在我们的程序中添加这个依赖，只需在 `Cargo.toml` 的 `[dependencies]` 下添加：`clap = \"2.27.1\"`。就这么简单！现在你就可以在程序中使用 `clap` 了。"
 
 #: src/cargo/deps.md:67
 msgid ""
 "`cargo` also supports [other types of dependencies](https://doc.rust-lang.org/"
 "cargo/reference/specifying-dependencies.html). Here is just a small sampling:"
 msgstr ""
-"`cargo` 还支持 [其他类型的依赖](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)。这里只是一个小示例："
+"`cargo` 还支持[其他类型的依赖](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)。这里给出一个简单的示例："
 
 #: src/cargo/deps.md:70
 msgid ""
@@ -7019,7 +7020,7 @@ msgstr ""
 "[dependencies]\n"
 "clap = \"2.27.1\" # 来自 crates.io\n"
 "rand = { git = \"https://github.com/rust-lang-nursery/rand\" } # 来自在线仓库\n"
-"bar = { path = \"../bar\" } # 来自本地文件系统中的路径\n"
+"bar = { path = \"../bar\" } # 来自本地文件系统的路径\n"
 "```"
 
 #: src/cargo/deps.md:82
@@ -7028,7 +7029,7 @@ msgid ""
 "options are listed in the [format specification](https://doc.rust-lang.org/"
 "cargo/reference/manifest.html) of `Cargo.toml`."
 msgstr ""
-"`cargo` 不仅仅是一个依赖管理器。所有可用的配置选项都列在 `Cargo.toml` 的 [格式规范](https://doc.rust-lang.org/cargo/reference/manifest.html) 中。"
+"`cargo` 不仅仅是一个依赖管理器。`Cargo.toml` 的[格式规范](https://doc.rust-lang.org/cargo/reference/manifest.html)中列出了所有可用的配置选项。"
 
 #: src/cargo/deps.md:86
 msgid ""
@@ -7038,7 +7039,7 @@ msgid ""
 "crates if needed, and build everything, including your crate. (Note that it "
 "only rebuilds what it has not already built, similar to `make`)."
 msgstr ""
-"要构建我们的项目，我们可以在项目目录的任何位置（包括子目录！）执行 `cargo build`。我们也可以使用 `cargo run` 来构建并运行。注意，这些命令会解析所有依赖，如果需要的话下载 crate，并构建所有内容，包括你的 crate。（注意，它只会重新构建尚未构建的部分，类似于 `make`）。"
+"我们可以在项目目录的任何位置（包括子目录！）执行 `cargo build` 来构建项目。也可以使用 `cargo run` 来构建并运行。请注意，这些命令会解析所有依赖，必要时下载 crate，并构建所有内容，包括你的 crate。（值得一提的是，它只会重新构建尚未构建的部分，类似于 `make`）。"
 
 #: src/cargo/deps.md:92
 msgid "Voila! That's all there is to it!"
@@ -7046,14 +7047,13 @@ msgstr "瞧！就是这么简单！"
 
 #: src/cargo/conventions.md:3
 msgid "In the previous chapter, we saw the following directory hierarchy:"
-msgstr "在上一章中，我们看到了以下目录层次结构："
+msgstr "在上一章中，我们看到了如下目录结构："
 
 #: src/cargo/conventions.md:12
 msgid ""
 "Suppose that we wanted to have two binaries in the same project, though. What "
 "then?"
-msgstr ""
-"假设我们想在同一个项目中有两个二进制文件。那该怎么办呢？"
+msgstr "那么，如果我们想在同一个项目中包含两个二进制文件，该怎么办呢？"
 
 #: src/cargo/conventions.md:15
 msgid ""
@@ -7061,7 +7061,8 @@ msgid ""
 "as we saw before, but you can add additional binaries by placing them in a "
 "`bin/` directory:"
 msgstr ""
-"事实证明，`cargo` 支持这一点。默认的二进制文件名是 `main`，就像我们之前看到的那样，但你可以通过将额外的二进制文件放在 `bin/` 目录中来添加它们："
+"`cargo` 实际上支持这种需求。如我们之前所见，默认的二进制文件名是 `main`，"
+"但你可以通过在 `bin/` 目录中放置额外的文件来添加其他二进制文件："
 
 #: src/cargo/conventions.md:28
 msgid ""
@@ -7069,7 +7070,8 @@ msgid ""
 "`--bin my_other_bin` flag, where `my_other_bin` is the name of the binary we "
 "want to work with."
 msgstr ""
-"要告诉 `cargo` 只编译或运行这个二进制文件，我们只需要给 `cargo` 传递 `--bin my_other_bin` 标志，其中 `my_other_bin` 是我们想要处理的二进制文件的名称。"
+"如果要指示 `cargo` 只编译或运行特定的二进制文件，只需传递 `--bin my_other_bin` 标志，"
+"其中 `my_other_bin` 是我们想要处理的二进制文件的名称。"
 
 #: src/cargo/conventions.md:32
 msgid ""
@@ -7077,11 +7079,12 @@ msgid ""
 "rust-lang.org/cargo/guide/project-layout.html) such as benchmarks, tests, and "
 "examples."
 msgstr ""
-"除了额外的二进制文件，`cargo` 还支持 [更多功能](https://doc.rust-lang.org/cargo/guide/project-layout.html)，如基准测试、测试和示例。"
+"除了额外的二进制文件，`cargo` 还支持[更多功能](https://doc.rust-lang.org/cargo/guide/project-layout.html)，"
+"如基准测试、测试和示例。"
 
 #: src/cargo/conventions.md:35
 msgid "In the next chapter, we will look more closely at tests."
-msgstr "在下一章中，我们将更仔细地看看测试。"
+msgstr "在下一章中，我们将更详细地探讨测试。"
 
 #: src/cargo/test.md:3
 msgid ""
@@ -7089,7 +7092,8 @@ msgid ""
 "support for unit and integration testing ([see this chapter](https://doc.rust-"
 "lang.org/book/ch11-00-testing.html) in TRPL)."
 msgstr ""
-"我们知道测试对于任何软件都是不可或缺的！Rust 对单元测试和集成测试有一流的支持（参见《Rust 程序设计语言》中的[这一章](https://doc.rust-lang.org/book/ch11-00-testing.html)）。"
+"众所周知，测试是任何软件不可或缺的一部分！Rust 为单元测试和集成测试提供了一流的支持"
+"（参见《Rust 程序设计语言》中的[这一章](https://doc.rust-lang.org/book/ch11-00-testing.html)）。"
 
 #: src/cargo/test.md:8
 msgid ""
@@ -7097,7 +7101,8 @@ msgid ""
 "integration tests. Organizationally, we can place unit tests in the modules "
 "they test and integration tests in their own `tests/` directory:"
 msgstr ""
-"从上面链接的测试章节中，我们可以看到如何编写单元测试和集成测试。在组织上，我们可以将单元测试放在它们所测试的模块中，而将集成测试放在它们自己的 `tests/` 目录中："
+"从上面链接的测试章节中，我们了解了如何编写单元测试和集成测试。在组织结构上，"
+"我们可以将单元测试放在它们所测试的模块中，而将集成测试放在专门的 `tests/` 目录中："
 
 #: src/cargo/test.md:23
 msgid ""
@@ -7106,7 +7111,8 @@ msgid ""
 "is meant to test your library as if it were being called from a dependent "
 "crate."
 msgstr ""
-"`tests` 中的每个文件都是一个单独的[集成测试](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests)，即旨在测试你的库，就像它被依赖的 crate 调用一样。"
+"`tests` 目录中的每个文件都是一个独立的[集成测试](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests)，"
+"即旨在测试你的库，就像它被依赖的 crate 调用一样。"
 
 #: src/cargo/test.md:28
 msgid ""
@@ -7114,15 +7120,16 @@ msgid ""
 "testing styles: [Unit](../testing/unit_testing.md), [Doc](../testing/"
 "doc_testing.md), and [Integration](../testing/integration_testing.md)."
 msgstr ""
-"[测试](../testing.md)章节详细阐述了三种不同的测试风格：[单元](../testing/unit_testing.md)、[文档](../testing/doc_testing.md)和[集成](../testing/integration_testing.md)。"
+"[测试](../testing.md)章节详细阐述了三种不同的测试风格：[单元测试](../testing/unit_testing.md)、"
+"[文档测试](../testing/doc_testing.md)和[集成测试](../testing/integration_testing.md)。"
 
 #: src/cargo/test.md:31
 msgid "`cargo` naturally provides an easy way to run all of your tests!"
-msgstr "`cargo` 提供了一个简单的方式运行所有测试！"
+msgstr "`cargo` 自然提供了一种简便的方式来运行所有测试！"
 
 #: src/cargo/test.md:37
 msgid "You should see output like this:"
-msgstr "你应该会看到类似这样的输出："
+msgstr "你将看到类似这样的输出："
 
 #: src/cargo/test.md:39
 msgid ""
@@ -7158,7 +7165,7 @@ msgstr ""
 
 #: src/cargo/test.md:54
 msgid "You can also run tests whose name matches a pattern:"
-msgstr "你也可以运行名称匹配某个模式的测试："
+msgstr "你还可以运行名称匹配特定模式的测试："
 
 #: src/cargo/test.md:60
 msgid ""
@@ -7192,15 +7199,13 @@ msgstr ""
 msgid ""
 "One word of caution: Cargo may run multiple tests concurrently, so make sure "
 "that they don't race with each other."
-msgstr ""
-"需要注意的是：Cargo 可能会并发运行多个测试，所以要确保它们之间不会相互竞争。"
+msgstr "需要注意：Cargo 可能会并发运行多个测试，因此请确保它们之间不会产生竞态条件。"
 
 #: src/cargo/test.md:76
 msgid ""
 "One example of this concurrency causing issues is if two tests output to a "
 "file, such as below:"
-msgstr ""
-"这种并发可能导致问题的一个例子是，如果两个测试输出到同一个文件，比如下面这样："
+msgstr "并发可能导致问题的一个例子是，如果两个测试同时输出到同一个文件，如下所示："
 
 #: src/cargo/test.md:82
 msgid "// Import the necessary modules\n"
@@ -7208,11 +7213,11 @@ msgstr "// 导入必要的模块\n"
 
 #: src/cargo/test.md:86
 msgid "// This test writes to a file\n"
-msgstr "// 这个测试写入一个文件\n"
+msgstr "// 这个测试向文件写入内容\n"
 
 #: src/cargo/test.md:89 src/cargo/test.md:106
 msgid "// Opens the file ferris.txt or creates one if it doesn't exist.\n"
-msgstr "// 打开 ferris.txt 文件，如果不存在则创建一个。\n"
+msgstr "// 打开 ferris.txt 文件，如果不存在则创建一个\n"
 
 #: src/cargo/test.md:93 src/cargo/test.md:110
 msgid "\"ferris.txt\""
@@ -7220,11 +7225,11 @@ msgstr "\"ferris.txt\""
 
 #: src/cargo/test.md:94 src/cargo/test.md:111
 msgid "\"Failed to open ferris.txt\""
-msgstr "\"Failed to open ferris.txt\""
+msgstr "\"无法打开 ferris.txt\""
 
 #: src/cargo/test.md:96
 msgid "// Print \"Ferris\" 5 times.\n"
-msgstr "// 打印 \"Ferris\" 5 次。\n"
+msgstr "// 循环打印 \"Ferris\" 5 次\n"
 
 #: src/cargo/test.md:98
 msgid "\"Ferris\\n\""
@@ -7232,7 +7237,7 @@ msgstr "\"Ferris\\n\""
 
 #: src/cargo/test.md:99 src/cargo/test.md:116
 msgid "\"Could not write to ferris.txt\""
-msgstr "\"Could not write to ferris.txt\""
+msgstr "\"无法写入 ferris.txt\""
 
 #: src/cargo/test.md:103
 msgid "// This test tries to write to the same file\n"
@@ -7240,7 +7245,7 @@ msgstr "// 这个测试尝试写入同一个文件\n"
 
 #: src/cargo/test.md:113
 msgid "// Print \"Corro\" 5 times.\n"
-msgstr "// 打印 \"Corro\" 5 次。\n"
+msgstr "// 循环打印 \"Corro\" 5 次\n"
 
 #: src/cargo/test.md:115
 msgid "\"Corro\\n\""
@@ -7248,11 +7253,11 @@ msgstr "\"Corro\\n\""
 
 #: src/cargo/test.md:122
 msgid "Although the intent is to get the following:"
-msgstr "尽管预期的结果是得到以下内容："
+msgstr "尽管预期结果应该是："
 
 #: src/cargo/test.md:136
 msgid "What actually gets put into `ferris.txt` is this:"
-msgstr "实际上 `ferris.txt` 中的内容可能是这样的："
+msgstr "但实际写入 `ferris.txt` 的内容可能是这样的："
 
 #: src/cargo/build_scripts.md:3
 msgid ""
@@ -7261,7 +7266,7 @@ msgid ""
 "code generation, or some native code that needs to be compiled. To solve this "
 "problem we have build scripts that Cargo can run."
 msgstr ""
-"有时候常规的 `cargo` 构建是不够的。也许你的 crate 在 `cargo` 成功编译之前需要一些先决条件，比如代码生成，或者需要编译一些本地代码。为了解决这个问题，我们有 Cargo 可以运行的构建脚本。"
+"有时候，`cargo` 的常规构建可能不足以满足需求。你的 crate 可能在 `cargo` 成功编译之前需要一些先决条件，比如代码生成，或者需要编译一些本地代码。为了解决这个问题，我们可以使用 Cargo 能够运行的构建脚本。"
 
 #: src/cargo/build_scripts.md:8
 msgid ""
@@ -7289,7 +7294,7 @@ msgid ""
 "Otherwise Cargo will look for a `build.rs` file in the project directory by "
 "default."
 msgstr ""
-"否则，Cargo 默认会在项目目录中寻找 `build.rs` 文件。"
+"如果没有指定，Cargo 默认会在项目目录中查找 `build.rs` 文件。"
 
 #: src/cargo/build_scripts.md:20
 msgid "How to use a build script"
@@ -7309,7 +7314,7 @@ msgid ""
 "here](https://doc.rust-lang.org/cargo/reference/environment-variables."
 "html#environment-variables-cargo-sets-for-build-scripts) that can be used."
 msgstr ""
-"Cargo 通过环境变量为脚本提供输入，这些环境变量[在这里指定](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)，可以被使用。"
+"Cargo 通过环境变量为脚本提供输入，这些环境变量可以被使用。具体参见[这里的说明](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)。"
 
 #: src/cargo/build_scripts.md:29
 msgid ""
@@ -7318,21 +7323,22 @@ msgid ""
 "be interpreted by Cargo directly and hence can be used to define parameters "
 "for the package's compilation."
 msgstr ""
-"脚本通过标准输出提供输出。所有打印的行都被写入 `target/debug/build/<pkg>/output`。此外，以 `cargo:` 为前缀的行将被 Cargo 直接解释，因此可以用来为包的编译定义参数。"
+"脚本通过标准输出提供输出。所有打印的行都会被写入 `target/debug/build/<pkg>/output`。此外，以 `cargo:` 为前缀的行会被 Cargo 直接解释，因此可以用来为包的编译定义参数。"
 
 #: src/cargo/build_scripts.md:34
 msgid ""
 "For further specification and examples have a read of the [Cargo "
 "specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)."
 msgstr ""
-"有关更多规范和示例，请阅读 [Cargo 规范](https://doc.rust-lang.org/cargo/reference/build-scripts.html)。"
+"如需了解更多详细规范和示例，请参阅 [Cargo 构建脚本规范]"
+"(https://doc.rust-lang.org/cargo/reference/build-scripts.html)。"
 
 #: src/attribute.md:3
 msgid ""
 "An attribute is metadata applied to some module, crate or item. This metadata "
 "can be used to/for:"
 msgstr ""
-"属性是应用于某个模块、crate 或项的元数据。这些元数据可以用于以下目的："
+"属性是应用于模块、crate 或条目的元数据。这些元数据可用于以下目的："
 
 #: src/attribute.md:8
 msgid "[conditional compilation of code](attribute/cfg.md)"
@@ -7341,20 +7347,20 @@ msgstr "[代码的条件编译](attribute/cfg.md)"
 #: src/attribute.md:9
 msgid ""
 "[set crate name, version and type (binary or library)](attribute/crate.md)"
-msgstr "[设置 crate 名称、版本和类型（二进制或库）](attribute/crate.md)"
+msgstr "[设置 crate 的名称、版本和类型（二进制或库）](attribute/crate.md)"
 
 #: src/attribute.md:10
 msgid ""
 "disable [lints](https://en.wikipedia.org/wiki/Lint_%28software%29) (warnings)"
-msgstr "禁用 [lints](https://en.wikipedia.org/wiki/Lint_%28software%29)（警告）"
+msgstr "禁用 [代码检查](https://en.wikipedia.org/wiki/Lint_%28software%29)（警告）"
 
 #: src/attribute.md:11
 msgid "enable compiler features (macros, glob imports, etc.)"
-msgstr "启用编译器特性（宏、全局导入等）"
+msgstr "启用编译器特性（如宏、全局导入等）"
 
 #: src/attribute.md:12
 msgid "link to a foreign library"
-msgstr "链接到外部库"
+msgstr "链接外部库"
 
 #: src/attribute.md:13
 msgid "mark functions as unit tests"
@@ -7362,21 +7368,22 @@ msgstr "将函数标记为单元测试"
 
 #: src/attribute.md:14
 msgid "mark functions that will be part of a benchmark"
-msgstr "将函数标记成为基准测试的一部分"
+msgstr "将函数标记为基准测试的一部分"
 
 #: src/attribute.md:15
 msgid ""
 "[attribute like macros](https://doc.rust-lang.org/book/ch19-06-macros."
 "html#attribute-like-macros)"
 msgstr ""
-"[类似属性的宏](https://doc.rust-lang.org/book/ch19-06-macros.html#attribute-like-macros)"
+"[类属性宏](https://doc.rust-lang.org/book/ch19-06-macros.html#attribute-like-macros)"
 
 #: src/attribute.md:17
 msgid ""
 "Attributes look like `#[outer_attribute]` or `#![inner_attribute]`, with the "
 "difference between them being where they apply."
 msgstr ""
-"属性看起来像 `#[outer_attribute]` 或 `#![inner_attribute]`，它们之间的区别在于应用的位置。"
+"属性的形式为 `#[outer_attribute]`（外部属性）或 `#![inner_attribute]`（内部属性），"
+"它们的区别在于应用的位置。"
 
 #: src/attribute.md:20
 msgid ""
@@ -7385,7 +7392,9 @@ msgid ""
 "function, a module declaration, a constant, a structure, an enum. Here is an "
 "example where attribute `#[derive(Debug)]` applies to the struct `Rectangle`:"
 msgstr ""
-"`#[outer_attribute]` 应用于紧随其后的[项](https://doc.rust-lang.org/stable/reference/items.html)。项的一些例子包括：函数、模块声明、常量、结构体、枚举。这里是一个例子，其中属性 `#[derive(Debug)]` 应用于结构体 `Rectangle`："
+"`#[outer_attribute]` 应用于紧随其后的[条目](https://doc.rust-lang.org/stable/"
+"reference/items.html)。条目的例子包括：函数、模块声明、常量、结构体、枚举等。"
+"以下是一个示例，其中属性 `#[derive(Debug)]` 应用于结构体 `Rectangle`："
 
 #: src/attribute.md:33
 msgid ""
@@ -7395,7 +7404,10 @@ msgid ""
 "it's placed. Here is an example where `#![allow(unused_variables)]` applies "
 "to the whole crate (if placed in `main.rs`):"
 msgstr ""
-"`#![inner_attribute]` 应用于包围它的[项](https://doc.rust-lang.org/stable/reference/items.html)（通常是模块或 crate）。换句话说，这个属性被解释为应用于它所在的整个作用域。这里是一个例子，其中 `#![allow(unused_variables)]` 应用于整个 crate（如果放在 `main.rs` 中）："
+"`#![inner_attribute]` 应用于包含它的[条目](https://doc.rust-lang.org/stable/"
+"reference/items.html)（通常是模块或 crate）。换句话说，这种属性被解释为应用于"
+"它所在的整个作用域。以下是一个示例，其中 `#![allow(unused_variables)]` 应用于"
+"整个 crate（如果放置在 `main.rs` 中）："
 
 #: src/attribute.md:42
 msgid "// This would normally warn about an unused variable.\n"
@@ -7421,7 +7433,7 @@ msgstr "`#[attribute(value)]`"
 msgid ""
 "Attributes can have multiple values and can be separated over multiple lines, "
 "too:"
-msgstr "属性可以有多个值，也可以分成多行："
+msgstr "属性可以有多个值，也可以跨多行分隔："
 
 #: src/attribute/unused.md:3
 msgid ""
@@ -7429,16 +7441,19 @@ msgid ""
 "Lint_%28software%29) that will warn about unused functions. An _attribute_ "
 "can be used to disable the lint."
 msgstr ""
-"编译器提供了一个 `dead_code` [_lint_](https://en.wikipedia.org/wiki/Lint_%28software%29)，它会对未使用的函数发出警告。可以使用**属性**来禁用这个 lint。"
+"编译器提供了一个 `dead_code` [lint](https://en.wikipedia.org/wiki/"
+"Lint_%28software%29)，用于警告未使用的函数。可以使用**属性**来禁用这个 lint。"
 
 #: src/attribute/unused.md:9
 msgid ""
 "// `#[allow(dead_code)]` is an attribute that disables the `dead_code` lint\n"
-msgstr "// `#[allow(dead_code)]` 是一个禁用 `dead_code` lint 的属性\n"
+msgstr ""
+"// `#[allow(dead_code)]` 是一个用于禁用 `dead_code` lint 的属性\n"
 
 #: src/attribute/unused.md:14
 msgid "// FIXME ^ Add an attribute to suppress the warning\n"
-msgstr "// FIXME ^ 添加一个属性来消除警告\n"
+msgstr ""
+"// FIXME ^ 添加一个属性来抑制警告\n"
 
 #: src/attribute/unused.md:22
 msgid ""
@@ -7446,7 +7461,8 @@ msgid ""
 "we'll allow dead code in some places because of the interactive nature of the "
 "examples."
 msgstr ""
-"注意，在实际程序中，你应该消除死代码。在这些例子中，我们会在某些地方允许死代码，这是因为这些例子的交互性质。"
+"注意，在实际程序中，你应该消除无用代码。在这些示例中，我们会在某些地方允许存在"
+"无用代码，这是因为这些示例具有交互性质。"
 
 #: src/attribute/crate.md:3
 msgid ""
@@ -7454,7 +7470,8 @@ msgid ""
 "is a binary or a library (and even which type of library), and the "
 "`crate_name` attribute can be used to set the name of the crate."
 msgstr ""
-"`crate_type` 属性可以用来告诉编译器一个 crate 是二进制文件还是库（甚至是哪种类型的库），而 `crate_name` 属性可以用来设置 crate 的名称。"
+"`crate_type` 属性可用于告诉编译器一个 crate 是二进制文件还是库（甚至是哪种类型"
+"的库），而 `crate_name` 属性可用于设置 crate 的名称。"
 
 #: src/attribute/crate.md:7
 msgid ""
@@ -7463,11 +7480,14 @@ msgid ""
 "manager. Since Cargo is used for the majority of Rust projects, this means "
 "real-world uses of `crate_type` and `crate_name` are relatively limited."
 msgstr ""
-"然而，需要注意的是，当使用 Cargo（Rust 的包管理器）时，`crate_type` 和 `crate_name` 属性**完全没有**效果。由于大多数 Rust 项目都使用 Cargo，这意味着 `crate_type` 和 `crate_name` 在实际使用中相对有限。"
+"然而，需要注意的是，当使用 Rust 的包管理器 Cargo 时，`crate_type` 和 "
+"`crate_name` 属性**完全不起作用**。由于大多数 Rust 项目都使用 Cargo，这意味着 "
+"`crate_type` 和 `crate_name` 在实际使用中的应用相对有限。"
 
 #: src/attribute/crate.md:13
 msgid "// This crate is a library\n"
-msgstr "// 这个 crate 是一个库\n"
+msgstr ""
+"// 这个 crate 是一个库\n"
 
 #: src/attribute/crate.md:14
 msgid "\"lib\""
@@ -7475,7 +7495,8 @@ msgstr "\"lib\""
 
 #: src/attribute/crate.md:14
 msgid "// The library is named \"rary\"\n"
-msgstr "// 这个库的名称是 \"rary\"\n"
+msgstr ""
+"// 这个库的名称是 \"rary\"\n"
 
 #: src/attribute/crate.md:16
 msgid "\"rary\""
@@ -7486,12 +7507,13 @@ msgid ""
 "When the `crate_type` attribute is used, we no longer need to pass the `--"
 "crate-type` flag to `rustc`."
 msgstr ""
-"当使用 `crate_type` 属性时，我们不再需要向 `rustc` 传递 `--crate-type` 标志。"
+"当使用 `crate_type` 属性时，我们就不再需要向 `rustc` 传递 `--crate-type` 标志。"
 
 #: src/attribute/cfg.md:3
 msgid ""
 "Configuration conditional checks are possible through two different operators:"
-msgstr "配置条件检查可以通过两种不同的操作符实现："
+msgstr ""
+"配置条件检查可以通过两种不同的操作符实现："
 
 #: src/attribute/cfg.md:5
 msgid "the `cfg` attribute: `#[cfg(...)]` in attribute position"
@@ -7507,7 +7529,8 @@ msgid ""
 "evaluates to `true` or `false` literals allowing for checks at run-time. Both "
 "utilize identical argument syntax."
 msgstr ""
-"前者启用条件编译，后者在运行时条件性地求值为 `true` 或 `false` 字面量，允许在运行时进行检查。两者使用相同的参数语法。"
+"前者启用条件编译，后者在运行时条件性地求值为 `true` 或 `false` 字面量，允许在"
+"运行时进行检查。两者使用相同的参数语法。"
 
 #: src/attribute/cfg.md:12
 msgid ""
@@ -7516,11 +7539,14 @@ msgid ""
 "when `cfg!` is used for the condition, regardless of what `cfg!` is "
 "evaluating."
 msgstr ""
-"`cfg!` 与 `#[cfg]` 不同，它不会移除任何代码，只会求值为 true 或 false。例如，当 `cfg!` 用于条件时，if/else 表达式中的所有块都需要是有效的，无论 `cfg!` 正在评估什么。"
+"`cfg!` 与 `#[cfg]` 不同，它不会移除任何代码，只会求值为 true 或 false。例如，"
+"当 `cfg!` 用于条件时，if/else 表达式中的所有代码块都需要是有效的，无论 `cfg!` "
+"正在评估什么。"
 
 #: src/attribute/cfg.md:15
 msgid "// This function only gets compiled if the target OS is linux\n"
-msgstr "// 这个函数只有在目标操作系统是 linux 时才会被编译\n"
+msgstr ""
+"// 这个函数只有在目标操作系统是 linux 时才会被编译\n"
 
 #: src/attribute/cfg.md:16 src/attribute/cfg.md:22 src/attribute/cfg.md:31
 msgid "\"linux\""
@@ -7528,16 +7554,16 @@ msgstr "\"linux\""
 
 #: src/attribute/cfg.md:18
 msgid "\"You are running linux!\""
-msgstr "\"你正在运行 linux！\""
+msgstr "\"你正在运行 Linux！\""
 
 #: src/attribute/cfg.md:20
 msgid ""
 "// And this function only gets compiled if the target OS is *not* linux\n"
-msgstr "// 而这个函数只有在目标操作系统*不是* linux 时才会被编译\n"
+msgstr "// 而这个函数只有在目标操作系统**不是** Linux 时才会被编译\n"
 
 #: src/attribute/cfg.md:24
 msgid "\"You are *not* running linux!\""
-msgstr "\"你*不是*在运行 linux！\""
+msgstr "\"你**不是**在运行 Linux！\""
 
 #: src/attribute/cfg.md:30
 msgid "\"Are you sure?\""
@@ -7545,11 +7571,11 @@ msgstr "\"你确定吗？\""
 
 #: src/attribute/cfg.md:32
 msgid "\"Yes. It's definitely linux!\""
-msgstr "\"是的。这绝对是 linux！\""
+msgstr "\"是的，这绝对是 Linux！\""
 
 #: src/attribute/cfg.md:34
 msgid "\"Yes. It's definitely *not* linux!\""
-msgstr "\"是的。这绝对**不是** linux！\""
+msgstr "\"是的，这绝对**不是** Linux！\""
 
 #: src/attribute/cfg.md:41
 msgid ""
@@ -7557,14 +7583,14 @@ msgid ""
 "html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro."
 "cfg!.html), and [macros](../macros.md)."
 msgstr ""
-"[参考](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation)、[`cfg!`](https://doc.rust-lang.org/std/macro.cfg!.html) 和 [宏](../macros.md)。"
+"[参考文档](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation)、[`cfg!` 宏](https://doc.rust-lang.org/std/macro.cfg!.html)和[宏](../macros.md)。"
 
 #: src/attribute/cfg/custom.md:3
 msgid ""
 "Some conditionals like `target_os` are implicitly provided by `rustc`, but "
 "custom conditionals must be passed to `rustc` using the `--cfg` flag."
 msgstr ""
-"一些条件如 `target_os` 是由 `rustc` 隐式提供的，但自定义条件必须使用 `--cfg` 标志传递给 `rustc`。"
+"一些条件（如 `target_os`）是由 `rustc` 隐式提供的，但自定义条件必须通过 `--cfg` 标志传递给 `rustc`。"
 
 #: src/attribute/cfg/custom.md:9
 msgid "\"condition met!\""
@@ -7572,7 +7598,7 @@ msgstr "\"条件满足！\""
 
 #: src/attribute/cfg/custom.md:17
 msgid "Try to run this to see what happens without the custom `cfg` flag."
-msgstr "尝试运行这个，看看没有自定义 `cfg` 标志会发生什么。"
+msgstr "尝试运行这段代码，看看没有自定义 `cfg` 标志会发生什么。"
 
 #: src/attribute/cfg/custom.md:19
 msgid "With the custom `cfg` flag:"
@@ -7587,9 +7613,9 @@ msgid ""
 "considered valid. The simplest and most common use of generics is for type "
 "parameters."
 msgstr ""
-"**泛型** 是关于将类型和函数扩展使其更通用的主题。这对于减少代码重复非常有用，"
-"但需要相对复杂的语法。也就是说，使用泛型需要非常小心地指定泛型类型在什么类型上实际有效。"
-"泛型最简单和最常见的用法是类型参数。"
+"**泛型**是一个关于将类型和功能泛化以适用于更广泛情况的主题。这在多方面都非常有用，可以大大减少代码重复，"
+"但可能需要相对复杂的语法。具体来说，使用泛型需要非常谨慎地指定泛型类型在哪些类型上是有效的。"
+"泛型最简单和最常见的用途是类型参数。"
 
 #: src/generics.md:10
 msgid ""
@@ -7600,9 +7626,9 @@ msgid ""
 "parameters `<T>`. Any type specified as a generic type parameter is generic, "
 "and everything else is concrete (non-generic)."
 msgstr ""
-"类型参数通过使用尖括号和大写 [驼峰命名法](https://en.wikipedia.org/wiki/CamelCase) 指定为泛型：`<Aaa, Bbb, ...>`。"
-"“泛型类型参数”通常表示为 `<T>`。在 Rust 中，“泛型”也描述了任何接受一个或多个泛型类型参数 `<T>` 的任何内容。"
-"任何指定为泛型类型参数的类型都是泛型的，其他所有类型都是具体的（非泛型）。"
+"类型参数通过使用尖括号和大写[驼峰命名法](https://en.wikipedia.org/wiki/CamelCase)来指定为泛型：`<Aaa, Bbb, ...>`。"
+""泛型类型参数"通常表示为 `<T>`。在 Rust 中，"泛型"也用来描述任何接受一个或多个泛型类型参数 `<T>` 的东西。"
+"任何被指定为泛型类型参数的类型都是泛型的，而其他所有类型都是具体的（非泛型）。"
 
 #: src/generics.md:16
 msgid ""
@@ -7617,16 +7643,16 @@ msgid ""
 "considered generic when used here as `(arg: T)`. This is the case even if `T` "
 "has previously been defined as a `struct`."
 msgstr ""
-"因为 `T` 已经使用 `<T>` 指定为泛型类型参数，所以在这里用作 `(arg: T)` 时被认为是泛型的。"
-"即使 `T` 之前已被定义为 `struct`，也是如此。"
+"因为 `T` 已经使用 `<T>` 指定为泛型类型参数，所以在这里用作 `(arg: T)` 时被视为泛型。"
+"即使 `T` 之前已被定义为一个 `struct`，这种情况也成立。"
 
 #: src/generics.md:27
 msgid "This example shows some of the syntax in action:"
-msgstr "这个例子展示了泛型语法的使用："
+msgstr "下面的例子展示了一些泛型语法的实际应用："
 
 #: src/generics.md:30
 msgid "// A concrete type `A`.\n"
-msgstr "// 一个具体类型 `A`。\n"
+msgstr "// 具体类型 `A`\n"
 
 #: src/generics.md:32
 msgid ""
@@ -7634,12 +7660,12 @@ msgid ""
 "`<A>`.\n"
 "// Therefore, `Single` is a concrete type, and `A` is defined as above.\n"
 msgstr ""
-"// 在定义类型 `Single` 时，第一次使用 `A` 时没有前置 `<A>`。\n"
-"// 因此，`Single` 是一个具体类型，`A` 如上所述定义。\n"
+"// 定义 `Single` 类型时，首次使用 `A` 前没有 `<A>`\n"
+"// 因此，`Single` 是具体类型，`A` 即上面定义的类型\n"
 
 #: src/generics.md:35
 msgid "//            ^ Here is `Single`s first use of the type `A`.\n"
-msgstr "//            ^ 这里是 `Single` 第一次使用类型 `A`。\n"
+msgstr "//            ^ 这里是 `Single` 首次使用 `A` 类型\n"
 
 #: src/generics.md:37
 msgid ""
@@ -7649,13 +7675,13 @@ msgid ""
 "including\n"
 "// the concrete type `A` defined at the top.\n"
 msgstr ""
-"// 这里，`<T>` 在第一次使用 `T` 之前，因此 `SingleGen` 是一个泛型类型。\n"
-"// 因为类型参数 `T` 是泛型的，它可以是任何东西，包括\n"
-"// 上面定义的具体类型 `A`。\n"
+"// 这里 `<T>` 在首次使用 `T` 之前，所以 `SingleGen` 是泛型\n"
+"// 由于类型参数 `T` 是泛型，它可以是任何类型\n"
+"// 包括上面定义的具体类型 `A`\n"
 
 #: src/generics.md:44
 msgid "// `Single` is concrete and explicitly takes `A`.\n"
-msgstr "// `Single` 是具体的，并且明确地接受 `A`。\n"
+msgstr "// `Single` 是具体类型，明确接受 `A`\n"
 
 #: src/generics.md:47
 msgid ""
@@ -7663,25 +7689,25 @@ msgid ""
 "    // and give it the value `SingleGen('a')`.\n"
 "    // Here, `SingleGen` has a type parameter explicitly specified.\n"
 msgstr ""
-"// 创建一个类型为 `SingleGen<char>` 的变量 `_char`\n"
-"    // 并赋予它值 `SingleGen('a')`。\n"
-"    // 这里，`SingleGen` 有一个明确指定的类型参数。\n"
+"// 创建 `SingleGen<char>` 类型的变量 `_char`\n"
+"    // 并赋值为 `SingleGen('a')`\n"
+"    // 这里 `SingleGen` 明确指定了类型参数\n"
 
 #: src/generics.md:52
 msgid "// `SingleGen` can also have a type parameter implicitly specified:\n"
-msgstr "// `SingleGen` 也可以有一个隐式指定的类型参数：\n"
+msgstr "// `SingleGen` 也可以隐式指定类型参数：\n"
 
 #: src/generics.md:53
 msgid "// Uses `A` defined at the top.\n"
-msgstr "// 使用上面定义的 `A`。\n"
+msgstr "// 使用上面定义的 `A`\n"
 
 #: src/generics.md:54
 msgid "// Uses `i32`.\n"
-msgstr "// 使用 `i32`。\n"
+msgstr "// 使用 `i32`\n"
 
 #: src/generics.md:55
 msgid "// Uses `char`.\n"
-msgstr "// 使用 `char`。\n"
+msgstr "// 使用 `char`\n"
 
 #: src/generics.md:61
 msgid "[`structs`](custom_types/structs.md)"
@@ -7692,7 +7718,7 @@ msgid ""
 "The same set of rules can be applied to functions: a type `T` becomes generic "
 "when preceded by `<T>`."
 msgstr ""
-"同样的规则也适用于函数：当类型 `T` 前置 `<T>` 时，那么它就变成了泛型。"
+"同样的规则也适用于函数：当类型 `T` 前面加上 `<T>` 时，它就变成了泛型。"
 
 #: src/generics/gen_fn.md:6
 msgid ""
@@ -7701,42 +7727,43 @@ msgid ""
 "type is generic, or if the compiler doesn't have enough information to infer "
 "the necessary type parameters."
 msgstr ""
-"使用泛型函数有时需要明确指定类型参数。如果函数调用时返回类型是泛型，"
-"或者编译器没有足够的信息来推断必要的类型参数，可能会出现这种情况。"
+"使用泛型函数有时需要明确指定类型参数。这种情况可能出现在函数返回类型是泛型时，"
+"或者编译器没有足够信息推断必要的类型参数时。"
 
 #: src/generics/gen_fn.md:11
 msgid ""
 "A function call with explicitly specified type parameters looks like: `fun::"
 "<A, B, ...>()`."
 msgstr ""
-"一个明确指定类型参数的函数调用看起来像这样：`fun::<A, B, ...>()`。"
+"明确指定类型参数的函数调用看起来像这样：`fun::<A, B, ...>()`。"
 
 #: src/generics/gen_fn.md:15
 msgid "// Concrete type `A`.\n"
-msgstr "// 具体类型 `A`。\n"
+msgstr "// 具体类型 `A`\n"
 
 #: src/generics/gen_fn.md:16
 msgid "// Concrete type `S`.\n"
-msgstr "// 具体类型 `S`。\n"
+msgstr "// 具体类型 `S`\n"
 
 #: src/generics/gen_fn.md:17
 msgid "// Generic type `SGen`.\n"
-msgstr "// 泛型类型 `SGen`。\n"
+msgstr "// 泛型 `SGen`\n"
 
 #: src/generics/gen_fn.md:18
 msgid ""
 "// The following functions all take ownership of the variable passed into\n"
 "// them and immediately go out of scope, freeing the variable.\n"
 msgstr ""
-"// 以下函数都获取传入的变量的所有权，并立即超出作用域，释放变量。\n"
+"// 以下函数都获取传入变量的所有权\n"
+"// 并立即离开作用域，释放该变量\n"
 
 #: src/generics/gen_fn.md:21
 msgid ""
 "// Define a function `reg_fn` that takes an argument `_s` of type `S`.\n"
 "// This has no `<T>` so this is not a generic function.\n"
 msgstr ""
-"// 定义一个函数 `reg_fn`，它接受一个类型为 `S` 的参数 `_s`。\n"
-"// 这没有 `<T>`，所以这不是一个泛型函数。\n"
+"// 定义函数 `reg_fn`，接受一个 `S` 类型的参数 `_s`\n"
+"// 由于没有 `<T>`，所以这不是泛型函数\n"
 
 #: src/generics/gen_fn.md:25
 msgid ""
@@ -7747,9 +7774,9 @@ msgid ""
 "// been specified as a generic type parameter for `gen_spec_t`, it is not "
 "generic.\n"
 msgstr ""
-"// 定义一个函数 `gen_spec_t`，它接受一个类型为 `SGen<T>` 的参数 `_s`。\n"
-"// 它被明确地赋予了类型参数 `A`，但因为 `A` 没有\n"
-"// 被指定为 `gen_spec_t` 的泛型类型参数，所以它不是泛型的。\n"
+"// 定义函数 `gen_spec_t`，接受一个 `SGen<T>` 类型的参数 `_s`\n"
+"// 虽然明确给定了类型参数 `A`，但因为 `A` 并未被指定为\n"
+"// `gen_spec_t` 的泛型类型参数，所以这个函数不是泛型的\n"
 
 #: src/generics/gen_fn.md:30
 msgid ""
@@ -7759,9 +7786,9 @@ msgid ""
 "type.\n"
 "// Because `i32` is not a generic type, this function is also not generic.\n"
 msgstr ""
-"// 定义一个函数 `gen_spec_i32`，它接受一个类型为 `SGen<i32>` 的参数 `_s`。\n"
-"// 它被明确地赋予了类型参数 `i32`，这是一个具体类型。\n"
-"// 因为 `i32` 不是泛型类型，所以这个函数也不是泛型的。\n"
+"// 定义函数 `gen_spec_i32`，接受一个 `SGen<i32>` 类型的参数 `_s`\n"
+"// 明确指定了类型参数 `i32`，这是一个具体类型\n"
+"// 由于 `i32` 不是泛型类型，所以这个函数也不是泛型的\n"
 
 #: src/generics/gen_fn.md:35
 msgid ""
@@ -7770,8 +7797,8 @@ msgid ""
 "// Because `SGen<T>` is preceded by `<T>`, this function is generic over "
 "`T`.\n"
 msgstr ""
-"// 定义一个函数 `generic`，它接受一个类型为 `SGen<T>` 的参数 `_s`。\n"
-"// 因为 `SGen<T>` 前置 `<T>`，所以这个函数是泛型的。\n"
+"// 定义函数 `generic`，接受一个 `SGen<T>` 类型的参数 `_s`\n"
+"// 由于 `SGen<T>` 前面有 `<T>`，所以这个函数是关于 `T` 的泛型函数\n"
 
 #: src/generics/gen_fn.md:41
 msgid "// Using the non-generic functions\n"
@@ -7779,23 +7806,23 @@ msgstr "// 使用非泛型函数\n"
 
 #: src/generics/gen_fn.md:42
 msgid "// Concrete type.\n"
-msgstr "// 具体类型。\n"
+msgstr "// 具体类型\n"
 
 #: src/generics/gen_fn.md:43
 msgid "// Implicitly specified type parameter `A`.\n"
-msgstr "// 隐式指定的类型参数 `A`。\n"
+msgstr "// 隐式指定类型参数 `A`\n"
 
 #: src/generics/gen_fn.md:44
 msgid "// Implicitly specified type parameter `i32`.\n"
-msgstr "// 隐式指定的类型参数 `i32`。\n"
+msgstr "// 隐式指定类型参数 `i32`\n"
 
 #: src/generics/gen_fn.md:46
 msgid "// Explicitly specified type parameter `char` to `generic()`.\n"
-msgstr "// 明确指定的类型参数 `char` 给 `generic()`。\n"
+msgstr "// 为 `generic()` 显式指定类型参数 `char`\n"
 
 #: src/generics/gen_fn.md:49
 msgid "// Implicitly specified type parameter `char` to `generic()`.\n"
-msgstr "// 隐式指定的类型参数 `char` 给 `generic()`。\n"
+msgstr "// 为 `generic()` 隐式指定类型参数 `char`\n"
 
 #: src/generics/gen_fn.md:50
 msgid "'c'"
@@ -7803,11 +7830,11 @@ msgstr "'c'"
 
 #: src/generics/gen_fn.md:56
 msgid "[functions](../fn.md) and [`struct`s](../custom_types/structs.md)"
-msgstr "[函数](../fn.md) 和 [`结构体`](../custom_types/structs.md)"
+msgstr "[函数](../fn.md)和[`结构体`](../custom_types/structs.md)"
 
 #: src/generics/impl.md:3
 msgid "Similar to functions, implementations require care to remain generic."
-msgstr "与函数类似，`impl` 实现部分使用泛型，也需要很仔细。"
+msgstr "与函数类似，实现（`impl`）在涉及泛型时也需要谨慎处理。"
 
 #: src/generics/impl.md:6
 msgid "// Concrete type `S`\n"
@@ -7819,7 +7846,7 @@ msgstr "// 泛型类型 `GenericVal`\n"
 
 #: src/generics/impl.md:8
 msgid "// impl of GenericVal where we explicitly specify type parameters:\n"
-msgstr "// GenericVal 的实现，我们在这里显式指定类型参数：\n"
+msgstr "// GenericVal 的实现，这里我们显式指定类型参数：\n"
 
 #: src/generics/impl.md:10
 msgid "// Specify `f32`\n"
@@ -7831,7 +7858,7 @@ msgstr "// 指定上面定义的 `S`\n"
 
 #: src/generics/impl.md:12
 msgid "// `<T>` Must precede the type to remain generic\n"
-msgstr "// `<T>` 必须在类型之前以保持泛型\n"
+msgstr "// `<T>` 必须放在类型前面以保持泛型\n"
 
 #: src/generics/impl.md:25
 msgid "// impl of Val\n"
@@ -7846,14 +7873,15 @@ msgid ""
 "[functions returning references](../scope/lifetime/fn.md), [`impl`](../fn/"
 "methods.md), and [`struct`](../custom_types/structs.md)"
 msgstr ""
-"[返回引用的函数](../scope/lifetime/fn.md)、[`impl`](../fn/methods.md) 和 [`结构体`](../custom_types/structs.md)"
+"[返回引用的函数](../scope/lifetime/fn.md)、[`impl`](../fn/methods.md) 和[结构体](../custom_types/structs.md)"
 
 #: src/generics/gen_trait.md:3
 msgid ""
 "Of course `trait`s can also be generic. Here we define one which reimplements "
 "the `Drop` `trait` as a generic method to `drop` itself and an input."
 msgstr ""
-"当然 `trait` 也可以是泛型的。这里我们定义了一个重新实现 `Drop` `trait` 的泛型方法，用于 `drop` 自身和一个输入。"
+"当然，`trait` 也可以是泛型的。这里我们定义了一个泛型 trait，它重新实现了 `Drop` trait，"
+"用于释放自身和一个输入参数。"
 
 #: src/generics/gen_trait.md:7
 msgid "// Non-copyable types.\n"
@@ -7861,7 +7889,7 @@ msgstr "// 不可复制的类型。\n"
 
 #: src/generics/gen_trait.md:10
 msgid "// A trait generic over `T`.\n"
-msgstr "// 一个泛型 `T` 的 trait。\n"
+msgstr "// 一个泛型 trait，使用类型参数 `T`。\n"
 
 #: src/generics/gen_trait.md:13
 msgid ""
@@ -7869,14 +7897,14 @@ msgid ""
 "    // additional single parameter `T` and does nothing with it.\n"
 msgstr ""
 "// 在调用者类型上定义一个方法，该方法接受一个\n"
-"    // 额外的单一参数 `T`，并且不对其做任何操作。\n"
+"    // 额外的类型为 `T` 的参数，但不对其进行任何操作。\n"
 
 #: src/generics/gen_trait.md:17
 msgid ""
 "// Implement `DoubleDrop<T>` for any generic parameter `T` and\n"
 "// caller `U`.\n"
 msgstr ""
-"// 为任何泛型参数 `T` 和调用者 `U` 实现 `DoubleDrop<T>`。\n"
+"// 为任意泛型参数 `T` 和调用者 `U` 实现 `DoubleDrop<T>`。\n"
 
 #: src/generics/gen_trait.md:21
 msgid ""
@@ -7884,11 +7912,11 @@ msgid ""
 "    // deallocating both.\n"
 msgstr ""
 "// 此方法获取两个传入参数的所有权，\n"
-"    // 释放两者的内存。\n"
+"    // 并释放它们的内存。\n"
 
 #: src/generics/gen_trait.md:30
 msgid "// Deallocate `empty` and `null`.\n"
-msgstr "// 释放 `empty` 和 `null`。\n"
+msgstr "// 释放 `empty` 和 `null` 的内存。\n"
 
 #: src/generics/gen_trait.md:33
 msgid ""
@@ -7905,7 +7933,7 @@ msgid ""
 "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [`struct`](../"
 "custom_types/structs.md), and [`trait`](../trait.md)"
 msgstr ""
-"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)、[`结构体`](../custom_types/structs.md) 和 [`trait`](../trait.md)"
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)、[`struct`](../custom_types/structs.md) 和 [`trait`](../trait.md)"
 
 #: src/generics/bounds.md:3
 msgid ""
@@ -7914,7 +7942,9 @@ msgid ""
 "following example uses the trait `Display` to print and so it requires `T` to "
 "be bound by `Display`; that is, `T` _must_ implement `Display`."
 msgstr ""
-"在使用泛型时，类型参数常常必须使用 trait 作为**约束**来规定类型实现了什么功能。例如，下面的例子使用 trait `Display` 来打印，因此它要求 `T` 被 `Display` 约束；也就是说，`T` **必须**实现 `Display`。"
+"在使用泛型时，类型参数通常需要使用 trait 作为**约束**，以规定类型应实现哪些功能。"
+"例如，下面的示例使用 `Display` trait 来打印，因此它要求 `T` 必须受 `Display` 约束；"
+"换句话说，`T` **必须**实现 `Display`。"
 
 #: src/generics/bounds.md:9
 msgid ""
@@ -7927,14 +7957,15 @@ msgstr ""
 #: src/generics/bounds.md:16
 msgid ""
 "Bounding restricts the generic to types that conform to the bounds. That is:"
-msgstr "约束将泛型限制为符合约束的类型。也就是说："
+msgstr "约束将泛型限制为符合约束条件的类型。也就是说："
 
 #: src/generics/bounds.md:20
 msgid ""
 "// Error! `Vec<T>` does not implement `Display`. This\n"
 "// specialization will fail.\n"
 msgstr ""
-"// 错误！`Vec<T>` 没有实现 `Display`。泛型特化失败。\n"
+"// 错误！`Vec<T>` 没有实现 `Display`。\n"
+"// 这个特化将会失败。\n"
 
 #: src/generics/bounds.md:26
 msgid ""
@@ -7942,27 +7973,27 @@ msgid ""
 "the [methods](../fn/methods.md) of traits specified in the bounds. For "
 "example:"
 msgstr ""
-"约束的另一个作用是允许泛型实例访问在约束中指定的 trait 的[方法](../fn/methods.md)。例如："
+"约束的另一个作用是允许泛型实例访问约束中指定的 trait 的[方法](../fn/methods.md)。例如："
 
 #: src/generics/bounds.md:30
 msgid "// A trait which implements the print marker: `{:?}`.\n"
-msgstr "// 这个 trait 用来实现打印标记：`{:?}`。\n"
+msgstr "// 实现打印标记 `{:?}` 的 trait。\n"
 
 #: src/generics/bounds.md:45
 msgid ""
 "// The generic `T` must implement `Debug`. Regardless\n"
 "// of the type, this will work properly.\n"
 msgstr ""
-"// 泛型 `T` 必须实现 `Debug`。这样，无论是什么类型，\n"
-"// 都可以让下面函数正常工作。\n"
+"// 泛型 `T` 必须实现 `Debug`。无论 `T` 是什么类型，\n"
+"// 这个函数都能正常工作。\n"
 
 #: src/generics/bounds.md:51
 msgid ""
 "// `T` must implement `HasArea`. Any type which meets\n"
 "// the bound can access `HasArea`'s function `area`.\n"
 msgstr ""
-"// `T` 必须实现 `HasArea`。任何符合这个约束的类型\n"
-"// 都可以访问 `HasArea` 的函数 `area`。\n"
+"// `T` 必须实现 `HasArea`。任何满足这个约束的类型\n"
+"// 都可以访问 `HasArea` 的 `area` 方法。\n"
 
 #: src/generics/bounds.md:61
 msgid "\"Area: {}\""
@@ -7985,14 +8016,14 @@ msgid ""
 "As an additional note, [`where`](../generics/where.md) clauses can also be "
 "used to apply bounds in some cases to be more expressive."
 msgstr ""
-"另外需要注意的是，在某些情况下可以使用 [`where`](../generics/where.md) 子句来应用约束，以使表达更加清晰。"
+"另外值得注意的是，在某些情况下可以使用 [`where`](../generics/where.md) 子句来应用约束，以使表达更加清晰。"
 
 #: src/generics/bounds.md:75
 msgid ""
 "[`std::fmt`](../hello/print.md), [`struct`s](../custom_types/structs.md), and "
 "[`trait`s](../trait.md)"
 msgstr ""
-"[`std::fmt`](../hello/print.md)、[`结构体`](../custom_types/structs.md) 和 [`trait`](../trait.md)"
+"[`std::fmt`](../hello/print.md)、[`struct`](../custom_types/structs.md)和 [`trait`](../trait.md)"
 
 #: src/generics/bounds/testcase_empty.md:3
 msgid ""
@@ -8000,7 +8031,7 @@ msgid ""
 "any functionality, you can still use it as a bound. `Eq` and `Copy` are "
 "examples of such `trait`s from the `std` library."
 msgstr ""
-"约束的工作机制会产生这样的效果，即使一个 `trait` 不包含任何功能，你仍然可以将其用作约束。`Eq` 和 `Copy` 是 `std` 库中这类 `trait` 的例子。"
+"约束的工作机制导致即使一个 `trait` 不包含任何功能，你仍然可以将其用作约束。`std` 库中的 `Eq` 和 `Copy` 就是这种 `trait` 的例子。"
 
 #: src/generics/bounds/testcase_empty.md:17
 msgid ""
@@ -8008,7 +8039,7 @@ msgid ""
 "// traits. The fact that the traits are empty is irrelevant.\n"
 msgstr ""
 "// 这些函数只对实现了这些 trait 的类型有效。\n"
-"// 事实上这些 trait 内部是空的，但这没有关系。\n"
+"// 这些 trait 是否为空并不重要。\n"
 
 #: src/generics/bounds/testcase_empty.md:20
 msgid "\"red\""
@@ -8027,18 +8058,18 @@ msgstr ""
 
 #: src/generics/bounds/testcase_empty.md:30
 msgid "\"A cardinal is {}\""
-msgstr "\"红雀是 {}\""
+msgstr "\"红雀是{}\""
 
 #: src/generics/bounds/testcase_empty.md:31
 msgid "\"A blue jay is {}\""
-msgstr "\"蓝松鸟是 {}\""
+msgstr "\"蓝松鸟是{}\""
 
 #: src/generics/bounds/testcase_empty.md:32
 msgid ""
 "//println!(\"A turkey is {}\", red(&_turkey));\n"
 "    // ^ TODO: Try uncommenting this line.\n"
 msgstr ""
-"//println!(\"火鸡是 {}\", red(&_turkey));\n"
+"//println!(\"火鸡是{}\", red(&_turkey));\n"
 "    // ^ TODO：尝试取消这行的注释。\n"
 
 #: src/generics/bounds/testcase_empty.md:39
@@ -8054,23 +8085,23 @@ msgid ""
 "Multiple bounds for a single type can be applied with a `+`. Like normal, "
 "different types are separated with `,`."
 msgstr ""
-"可以使用 `+` 来为单个类型指定多个约束。依照惯例，不同的类型用 `,` 分隔。"
+"可以使用 `+` 为单个类型指定多个约束。按照惯例，不同的类型用 `,` 分隔。"
 
 #: src/generics/multi_bounds.md:10
 msgid "\"Debug: `{:?}`\""
-msgstr "\"Debug: `{:?}`\""
+msgstr "\"Debug：`{:?}`\""
 
 #: src/generics/multi_bounds.md:11
 msgid "\"Display: `{}`\""
-msgstr "\"Display: `{}`\""
+msgstr "\"Display：`{}`\""
 
 #: src/generics/multi_bounds.md:15
 msgid "\"t: `{:?}`\""
-msgstr "\"t: `{:?}`\""
+msgstr "\"t：`{:?}`\""
 
 #: src/generics/multi_bounds.md:16
 msgid "\"u: `{:?}`\""
-msgstr "\"u: `{:?}`\""
+msgstr "\"u：`{:?}`\""
 
 #: src/generics/multi_bounds.md:20
 msgid "\"words\""
@@ -8082,7 +8113,7 @@ msgid ""
 "    // TODO ^ Try uncommenting this.\n"
 msgstr ""
 "//compare_prints(&array);\n"
-"    // TODO ^ 尝试取消这行的注释。\n"
+"    // TODO：尝试取消此行注释。\n"
 
 #: src/generics/multi_bounds.md:34
 msgid "[`std::fmt`](../hello/print.md) and [`trait`s](../trait.md)"
@@ -8095,11 +8126,11 @@ msgid ""
 "clauses can apply bounds to arbitrary types, rather than just to type "
 "parameters."
 msgstr ""
-"约束也可以使用 `where` 分句来表达，它紧接在开括号 `{` 之前，而不是在类型首次提及时。此外，`where` 分句可以将约束应用于任意类型，而不仅限于类型参数。"
+"约束也可以使用 `where` 子句来表达，它位于开括号 `{` 之前，而不是在类型首次提及时。此外，`where` 子句可以将约束应用于任意类型，而不仅限于类型参数。"
 
 #: src/generics/where.md:8
 msgid "Some cases that a `where` clause is useful:"
-msgstr "`where` 分句在以下情况下很有用："
+msgstr "`where` 子句在以下情况下特别有用："
 
 #: src/generics/where.md:10
 msgid "When specifying generic types and bounds separately is clearer:"
@@ -8107,21 +8138,21 @@ msgstr "当单独指定泛型类型和约束更清晰时："
 
 #: src/generics/where.md:14
 msgid "// Expressing bounds with a `where` clause\n"
-msgstr "// 使用 `where` 分句表达约束\n"
+msgstr "// 使用 `where` 子句表达约束\n"
 
 #: src/generics/where.md:21
 msgid ""
 "When using a `where` clause is more expressive than using normal syntax. The "
 "`impl` in this example cannot be directly expressed without a `where` clause:"
 msgstr ""
-"当使用 `where` 分句比使用普通语法更具表现力时。这个例子中的 `impl` 如果不使用 `where` 分句就无法直接表达："
+"当使用 `where` 子句比使用普通语法更具表现力时。这个例子中的 `impl` 如果不使用 `where` 子句就无法直接表达："
 
 #: src/generics/where.md:30
 msgid ""
 "// Because we would otherwise have to express this as `T: Debug` or \n"
 "// use another method of indirect approach, this requires a `where` clause:\n"
 msgstr ""
-"// 这里需要一个 `where` 分句：否则就必须将其表达为 `T: Debug` 或\n"
+"// 这里需要一个 `where` 子句：否则就必须将其表达为 `T: Debug` 或\n"
 "// 使用另一种间接方法，\n"
 
 #: src/generics/where.md:35
@@ -8129,7 +8160,7 @@ msgid ""
 "// We want `Option<T>: Debug` as our bound because that is what's\n"
 "    // being printed. Doing otherwise would be using the wrong bound.\n"
 msgstr ""
-"// 我们想要 `Option<T>: Debug` 作为我们的约束，因为这是\n"
+"// 我们需要 `Option<T>: Debug` 作为我们的约束，因为这是\n"
 "    // 正在被打印的内容。否则就会使用错误的约束。\n"
 
 #: src/generics/where.md:51
@@ -8144,14 +8175,14 @@ msgid ""
 "The `newtype` idiom gives compile time guarantees that the right type of "
 "value is supplied to a program."
 msgstr ""
-"`newtype` 惯用法在编译时保证了向程序提供了正确类型的值。"
+"`newtype` 模式在编译时保证了程序接收到正确类型的值。"
 
 #: src/generics/new_types.md:6
 msgid ""
 "For example, an age verification function that checks age in years, _must_ be "
 "given a value of type `Years`."
 msgstr ""
-"例如，一个检查年龄（以年为单位）的年龄验证函数，**必须**给定 `Years` 类型的值。"
+"例如，一个检查年龄（以年为单位）的年龄验证函数，**必须**接收 `Years` 类型的值。"
 
 #: src/generics/new_types.md:22
 msgid "/// truncates partial years\n"
@@ -8159,33 +8190,33 @@ msgstr "/// 截断不足一年的部分\n"
 
 #: src/generics/new_types.md:35 src/generics/new_types.md:36
 msgid "\"Is an adult? {}\""
-msgstr "\"是成年人吗？{}\""
+msgstr "\"是否成年？{}\""
 
 #: src/generics/new_types.md:37
 msgid "// println!(\"Is an adult? {}\", is_adult(&age_days));\n"
-msgstr "// println!(\"是成年人吗？{}\", is_adult(&age_days));\n"
+msgstr "// println!(\"是否成年？{}\", is_adult(&age_days));\n"
 
 #: src/generics/new_types.md:41
 msgid ""
 "Uncomment the last print statement to observe that the type supplied must be "
 "`Years`."
 msgstr ""
-"取消最后一个 print 语句的注释，观察所提供的类型必须是 `Years`。"
+"取消最后一个 print 语句的注释，你会发现所提供的类型必须是 `Years`。"
 
 #: src/generics/new_types.md:43
 msgid ""
 "To obtain the `newtype`'s value as the base type, you may use the tuple or "
 "destructuring syntax like so:"
 msgstr ""
-"要获取 `newtype` 的值作为基本类型，你可以使用元组或解构语法，如下所示："
+"要获取 `newtype` 的基本类型值，你可以使用元组语法或解构语法，如下所示："
 
 #: src/generics/new_types.md:49
 msgid "// Tuple\n"
-msgstr "// 元组\n"
+msgstr "// 元组语法\n"
 
 #: src/generics/new_types.md:50
 msgid "// Destructuring\n"
-msgstr "// 解构\n"
+msgstr "// 解构语法\n"
 
 #: src/generics/new_types.md:56
 msgid "[`structs`](../custom_types/structs.md)"
@@ -8197,14 +8228,14 @@ msgid ""
 "doc.rust-lang.org/reference/items.html)s of various types. It is an extension "
 "to `trait` generics, and allows `trait`s to internally define new items."
 msgstr ""
-"\"关联项\"指的是与各种类型的 [`item`](https://doc.rust-lang.org/reference/items.html) 相关的一组规则。它是 `trait` 泛型的扩展，允许 `trait` 在内部定义新的项。"
+""关联项"是指与各种类型的[`项`](https://doc.rust-lang.org/reference/items.html)相关的一组规则。它是 `trait` 泛型的扩展，允许 `trait` 在内部定义新的项。"
 
 #: src/generics/assoc_items.md:7
 msgid ""
 "One such item is called an _associated type_, providing simpler usage "
 "patterns when the `trait` is generic over its container type."
 msgstr ""
-"其中一种项被称为**关联类型**，当 `trait` 对其容器类型是泛型时，它提供了更简单的使用模式。"
+"其中一种项被称为**关联类型**，当 `trait` 对其容器类型是泛型时，它提供了更简洁的使用模式。"
 
 #: src/generics/assoc_items.md:12
 msgid ""
@@ -8218,7 +8249,7 @@ msgid ""
 "A `trait` that is generic over its container type has type specification "
 "requirements - users of the `trait` _must_ specify all of its generic types."
 msgstr ""
-"对于容器类型是泛型的 `trait`，须遵守类型规范要求 - `trait` 的使用者**必须**指定所有泛型类型。"
+"对于容器类型是泛型的 `trait`，有类型规范要求 —— `trait` 的使用者**必须**指定所有的泛型类型。"
 
 #: src/generics/assoc_items/the_problem.md:6
 msgid ""
@@ -8227,7 +8258,7 @@ msgid ""
 "specifying `i32` for `A` and `B` so that it can be used with `fn "
 "difference()`."
 msgstr ""
-"在下面的例子中，`Contains` `trait` 允许使用泛型类型 `A` 和 `B`。然后为 `Container` 类型实现该 trait，为 `A` 和 `B` 指定 `i32`，以便可以与 `fn difference()` 一起使用。"
+"在下面的例子中，`Contains` trait 允许使用泛型类型 `A` 和 `B`。然后为 `Container` 类型实现该 trait，将 `A` 和 `B` 指定为 `i32`，以便与 `fn difference()` 一起使用。"
 
 #: src/generics/assoc_items/the_problem.md:10
 msgid ""
@@ -8236,7 +8267,7 @@ msgid ""
 "that `A` and `B` are determined by the _input_ `C`. As you will see in the "
 "next section, associated types provide exactly that capability."
 msgstr ""
-"因为 `Contains` 是泛型的，我们必须为 `fn difference()` 显式声明**所有**泛型类型。在实践中，我们希望有一种方法来表达 `A` 和 `B` 是由**输入** `C` 决定的。你将在下一节中看到，关联类型恰好提供了这种能力。"
+"由于 `Contains` 是泛型的，我们不得不为 `fn difference()` 显式声明**所有**泛型类型。实际上，我们希望有一种方法来表达 `A` 和 `B` 是由**输入** `C` 决定的。正如你将在下一节中看到的，关联类型恰好提供了这种能力。"
 
 #: src/generics/assoc_items/the_problem.md:17
 #: src/generics/assoc_items/types.md:36
@@ -8244,38 +8275,39 @@ msgid ""
 "// A trait which checks if 2 items are stored inside of container.\n"
 "// Also retrieves first or last value.\n"
 msgstr ""
-"// 一个检查容器内是否存储了 2 个项的 trait。\n"
-"// 还可以检索第一个或最后一个值。\n"
+"// 一个检查容器内是否存储了两个项的 trait。\n"
+"// 同时可以检索第一个或最后一个值。\n"
 
 #: src/generics/assoc_items/the_problem.md:21
 msgid "// Explicitly requires `A` and `B`.\n"
-msgstr "// 显式要求 `A` 和 `B`。\n"
+msgstr "// 显式要求 `A` 和 `B`\n"
 
 #: src/generics/assoc_items/the_problem.md:22
 #: src/generics/assoc_items/the_problem.md:23
 msgid "// Doesn't explicitly require `A` or `B`.\n"
-msgstr "// 不显式要求 `A` 或 `B`。\n"
+msgstr "// 不需要显式指定 `A` 或 `B`\n"
 
 #: src/generics/assoc_items/the_problem.md:27
 msgid "// True if the numbers stored are equal.\n"
-msgstr "// 如果存储的数字相等则为 true。\n"
+msgstr "// 如果存储的数字相等则返回 true\n"
 
 #: src/generics/assoc_items/the_problem.md:32
 #: src/generics/assoc_items/types.md:60
 msgid "// Grab the first number.\n"
-msgstr "// 获取第一个数字。\n"
+msgstr "// 获取第一个数字\n"
 
 #: src/generics/assoc_items/the_problem.md:35
 #: src/generics/assoc_items/types.md:63
 msgid "// Grab the last number.\n"
-msgstr "// 获取最后一个数字。\n"
+msgstr "// 获取最后一个数字\n"
 
 #: src/generics/assoc_items/the_problem.md:38
 msgid ""
 "// `C` contains `A` and `B`. In light of that, having to express `A` and\n"
 "// `B` again is a nuisance.\n"
 msgstr ""
-"// `C` 包含了 `A` 和 `B`。鉴于此，还要指定 `A` 和 `B` 就显得很麻烦。\n"
+"// `C` 已经包含了 `A` 和 `B`。考虑到这一点，\n"
+"// 再次指定 `A` 和 `B` 就显得多余且麻烦。\n"
 
 #: src/generics/assoc_items/the_problem.md:52
 #: src/generics/assoc_items/types.md:77
@@ -8295,7 +8327,7 @@ msgstr "\"最后一个数字：{}\""
 #: src/generics/assoc_items/the_problem.md:58
 #: src/generics/assoc_items/types.md:83
 msgid "\"The difference is: {}\""
-msgstr "\"差值是：{}\""
+msgstr "\"差值为：{}\""
 
 #: src/generics/assoc_items/the_problem.md:64
 msgid ""
@@ -8309,7 +8341,8 @@ msgid ""
 "moving inner types locally into a trait as _output_ types. Syntax for the "
 "`trait` definition is as follows:"
 msgstr ""
-"通过将内部类型移动到 trait 中作为**输出**类型，使用\"关联类型\"提高了代码的整体可读性。这种 `trait` 定义的语法如下："
+"使用"关联类型"通过将内部类型局部移动到 trait 中作为**输出**类型，提高了代码的整体可读性。"
+"trait 定义的语法如下："
 
 #: src/generics/assoc_items/types.md:8
 msgid ""
@@ -8318,17 +8351,18 @@ msgid ""
 "// aliases).\n"
 msgstr ""
 "// `A` 和 `B` 在 trait 中通过 `type` 关键字定义。\n"
-"// （注意：这里的 `type` 与用于别名的 `type` 不同）。\n"
+"// （注意：这里的 `type` 与用于类型别名的 `type` 不同）\n"
 
 #: src/generics/assoc_items/types.md:15
 msgid "// Updated syntax to refer to these new types generically.\n"
-msgstr "// 这种新语法，能够泛型地表示这些新类型。\n"
+msgstr "// 更新后的语法，用于泛型地引用这些新类型\n"
 
 #: src/generics/assoc_items/types.md:20
 msgid ""
 "Note that functions that use the `trait` `Contains` are no longer required to "
 "express `A` or `B` at all:"
-msgstr "注意，使用 `Contains` 这个 `trait` 的函数不再需要明确表示 `A` 或 `B`："
+msgstr ""
+"注意，使用 `Contains` trait 的函数不再需要显式指定 `A` 或 `B`："
 
 #: src/generics/assoc_items/types.md:24
 msgid "// Without using associated types\n"
@@ -8341,11 +8375,11 @@ msgstr "// 使用关联类型\n"
 #: src/generics/assoc_items/types.md:32
 msgid ""
 "Let's rewrite the example from the previous section using associated types:"
-msgstr "让我们使用关联类型重写上一节的例子："
+msgstr "让我们使用关联类型重写上一节的示例："
 
 #: src/generics/assoc_items/types.md:40
 msgid "// Define generic types here which methods will be able to utilize.\n"
-msgstr "// 在这里定义泛型类型，方法将能够使用这些类型。\n"
+msgstr "// 在此定义泛型类型，方法将能够使用这些类型\n"
 
 #: src/generics/assoc_items/types.md:50
 msgid ""
@@ -8353,49 +8387,54 @@ msgid ""
 "    // is `Container(i32, i32)`, the `output` types are determined\n"
 "    // as `i32` and `i32`.\n"
 msgstr ""
-"// 指定 `A` 和 `B` 的类型。如果 `input` 类型\n"
-"    // 是 `Container(i32, i32)`，那么 `output` 类型就被确定\n"
-"    // 为 `i32` 和 `i32`。\n"
+"// 指定 `A` 和 `B` 的具体类型。如果 `input` 类型\n"
+"    // 是 `Container(i32, i32)`，那么 `output` 类型\n"
+"    // 就被确定为 `i32` 和 `i32`\n"
 
 #: src/generics/assoc_items/types.md:56
 msgid "// `&Self::A` and `&Self::B` are also valid here.\n"
-msgstr "// 这里 `&Self::A` 和 `&Self::B` 也是有效的。\n"
+msgstr "// 在这里使用 `&Self::A` 和 `&Self::B` 也是有效的。\n"
 
 #: src/generics/phantom.md:3
 msgid ""
 "A phantom type parameter is one that doesn't show up at runtime, but is "
 "checked statically (and only) at compile time."
-msgstr "虚类型参数是一种在运行时不会出现，但在（且仅在）编译时会被静态检查编译时检查的类型参数。"
+msgstr ""
+"虚类型参数是一种在运行时不会出现，但在编译时会进行静态检查的类型参数。"
 
 #: src/generics/phantom.md:6
 msgid ""
 "Data types can use extra generic type parameters to act as markers or to "
 "perform type checking at compile time. These extra parameters hold no storage "
 "values, and have no runtime behavior."
-msgstr "数据类型可以使用额外的泛型类型参数作为标记，或在编译时执行类型检查。这些额外的参数不占用存储空间，也没有运行时行为。"
+msgstr ""
+"数据类型可以使用额外的泛型类型参数作为标记，或在编译时进行类型检查。这些额外的参数不占用存储空间，也没有运行时行为。"
 
 #: src/generics/phantom.md:10
 msgid ""
 "In the following example, we combine [std::marker::PhantomData](https://doc."
 "rust-lang.org/std/marker/struct.PhantomData.html) with the phantom type "
 "parameter concept to create tuples containing different data types."
-msgstr "在下面的例子中，我们将 [std::marker::PhantomData](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) 与虚类型参数的概念结合起来，创建包含不同数据类型的元组。"
+msgstr ""
+"在下面的示例中，我们将 [`std::marker::PhantomData`](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) 与虚类型参数的概念结合，创建包含不同数据类型的元组。"
 
 #: src/generics/phantom.md:16
 msgid ""
 "// A phantom tuple struct which is generic over `A` with hidden parameter "
 "`B`.\n"
-msgstr "// 一个虚元组结构体，它在 `A` 上是泛型的，带有隐藏参数 `B`。\n"
+msgstr ""
+"// 一个虚元组结构体，它在 `A` 上是泛型的，带有隐藏参数 `B`。\n"
 
 #: src/generics/phantom.md:18 src/generics/phantom.md:22
 msgid "// Allow equality test for this type.\n"
-msgstr "// 允许对这个类型进行相等性测试。\n"
+msgstr "// 允许对此类型进行相等性测试。\n"
 
 #: src/generics/phantom.md:20
 msgid ""
 "// A phantom type struct which is generic over `A` with hidden parameter "
 "`B`.\n"
-msgstr "// 一个虚类型结构体，它在 `A` 上是泛型的，带有隐藏参数 `B`。\n"
+msgstr ""
+"// 一个虚类型结构体，它在 `A` 上是泛型的，带有隐藏参数 `B`。\n"
 
 #: src/generics/phantom.md:24
 msgid ""
@@ -8403,7 +8442,7 @@ msgid ""
 "//       Therefore, `B` cannot be used in computations.\n"
 msgstr ""
 "// 注意：为泛型类型 `A` 分配了存储空间，但没有为 `B` 分配。\n"
-"//       因此，`B` 不能参与运算。\n"
+"//       因此，`B` 不能用于计算。\n"
 
 #: src/generics/phantom.md:29
 msgid ""
@@ -8437,8 +8476,8 @@ msgid ""
 "    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
 "    //           _tuple1 == _tuple2);\n"
 msgstr ""
-"// 编译时错误！类型不匹配，所以这些不能比较：\n"
-"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"// 编译时错误！类型不匹配，无法比较：\n"
+"    // println!(\"_tuple1 == _tuple2 的结果是：{}\",\n"
 "    //           _tuple1 == _tuple2);\n"
 
 #: src/generics/phantom.md:50
@@ -8447,21 +8486,23 @@ msgid ""
 "    // println!(\"_struct1 == _struct2 yields: {}\",\n"
 "    //           _struct1 == _struct2);\n"
 msgstr ""
-"// 编译时错误！类型不匹配，所以这些不能比较：\n"
-"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"// 编译时错误！类型不匹配，无法比较：\n"
+"    // println!(\"_struct1 == _struct2 的结果是：{}\",\n"
 "    //           _struct1 == _struct2);\n"
 
 #: src/generics/phantom.md:58
 msgid ""
 "[Derive](../trait/derive.md), [struct](../custom_types/structs.md), and "
 "[TupleStructs](../custom_types/structs.md)"
-msgstr "[Derive](../trait/derive.md)、[struct](../custom_types/structs.md) 和 [TupleStructs](../custom_types/structs.md)"
+msgstr ""
+"[派生（Derive）](../trait/derive.md)、[结构体（struct）](../custom_types/structs.md)和[元组结构体（TupleStructs）](../custom_types/structs.md)"
 
 #: src/generics/phantom/testcase_units.md:3
 msgid ""
 "A useful method of unit conversions can be examined by implementing `Add` "
 "with a phantom type parameter. The `Add` `trait` is examined below:"
-msgstr "通过使用虚类型参数实现 `Add` 可以研究一种有用的单位转换方法。下面我们来看看 `Add` 这个 `trait`："
+msgstr ""
+"通过使用虚类型参数实现 `Add` trait，我们可以探索一种有用的单位转换方法。下面我们来看看 `Add` trait："
 
 #: src/generics/phantom/testcase_units.md:7
 msgid ""
@@ -8469,19 +8510,19 @@ msgid ""
 "// where RHS defaults to Self if not specified in the implementation.\n"
 msgstr ""
 "// 这个结构会强制要求：`Self + RHS = Output`\n"
-"// 其中如果在实现中没有指定 RHS，它会默认为 Self。\n"
+"// 其中，如果在实现中未指定 RHS，它将默认为 Self。\n"
 
 #: src/generics/phantom/testcase_units.md:14
 msgid "// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`.\n"
-msgstr "// `Output` 必须是 `T<U>`，这样 `T<U> + T<U> = T<U>`。\n"
+msgstr "// `Output` 必须是 `T<U>`，以确保 `T<U> + T<U> = T<U>`。\n"
 
 #: src/generics/phantom/testcase_units.md:22
 msgid "The whole implementation:"
-msgstr "完整的实现："
+msgstr "完整实现如下："
 
 #: src/generics/phantom/testcase_units.md:27
 msgid "/// Create void enumerations to define unit types.\n"
-msgstr "/// 创建空枚举来定义单位类型。\n"
+msgstr "/// 创建空枚举以定义单位类型。\n"
 
 #: src/generics/phantom/testcase_units.md:33
 msgid ""
@@ -8491,7 +8532,7 @@ msgid ""
 "/// `f64` already implements the `Clone` and `Copy` traits.\n"
 msgstr ""
 "/// `Length` 是一个带有虚类型参数 `Unit` 的类型，\n"
-"/// 它对长度类型（即 `f64`）并不是泛型的。\n"
+"/// 它不是长度类型（即 `f64`）的泛型。\n"
 "///\n"
 "/// `f64` 已经实现了 `Clone` 和 `Copy` trait。\n"
 
@@ -8529,7 +8570,7 @@ msgstr ""
 
 #: src/generics/phantom/testcase_units.md:65
 msgid "// Addition works.\n"
-msgstr "// 加法可以正常工作。\n"
+msgstr "// 加法运算正常工作。\n"
 
 #: src/generics/phantom/testcase_units.md:66
 msgid "\"one foot + one_foot = {:?} in\""
@@ -8545,7 +8586,7 @@ msgid ""
 "    // Compile-time Error: type mismatch.\n"
 "    //let one_feter = one_foot + one_meter;\n"
 msgstr ""
-"// 无意义的操作会如预期那样失败：\n"
+"// 无意义的操作会按预期失败：\n"
 "    // 编译时错误：类型不匹配。\n"
 "    //let one_feter = one_foot + one_meter;\n"
 
@@ -8556,7 +8597,8 @@ msgid ""
 "methods.md), [Overloading](../../trait/ops.md), [ref](../../scope/borrow/ref."
 "md), [Traits (`X for Y`)](../../trait.md), and [TupleStructs](../../"
 "custom_types/structs.md)."
-msgstr "[借用 (`&`)](../../scope/borrow.md)、[约束 (`X: Y`)](../../generics/bounds.md)、[enum](../../custom_types/enum.md)、[impl 和 self](../../fn/methods.md)、[重载](../../trait/ops.md)、[ref](../../scope/borrow/ref.md)、[Traits (`X for Y`)](../../trait.md) 和 [元组结构体](../../custom_types/structs.md)。"
+msgstr ""
+"[借用（`&`）](../../scope/borrow.md)、[约束（`X: Y`）](../../generics/bounds.md)、[枚举](../../custom_types/enum.md)、[impl 和 self](../../fn/methods.md)、[运算符重载](../../trait/ops.md)、[ref](../../scope/borrow/ref.md)、[trait（`X for Y`）](../../trait.md)以及[元组结构体](../../custom_types/structs.md)。"
 
 #: src/scope.md:3
 msgid ""
@@ -8564,7 +8606,7 @@ msgid ""
 "is, they indicate to the compiler when borrows are valid, when resources can "
 "be freed, and when variables are created or destroyed."
 msgstr ""
-"作用域在所有权、借用和生命周期中扮演着重要的角色。它们向编译器指示何时借用是有效的，何时资源可以被释放，以及何时变量被创建或销毁。"
+"作用域在所有权、借用和生命周期中扮演着重要角色。它们向编译器指示借用何时有效、资源何时可以被释放，以及变量何时被创建或销毁。"
 
 #: src/scope/raii.md:3
 msgid ""
@@ -8574,7 +8616,9 @@ msgid ""
 "(Resource Acquisition Is Initialization), so whenever an object goes out of "
 "scope, its destructor is called and its owned resources are freed."
 msgstr ""
-"Rust 中的变量不只是在栈上保存数据：它们还**持有**资源，例如 `Box<T>` 持有堆上的内存。Rust 强制执行 [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization)（资源获取即初始化），因此每当一个对象离开作用域时，它的析构函数就会被调用，它持有的资源就会被释放。"
+"Rust 中的变量不仅仅是在栈上保存数据：它们还**拥有**资源，例如 `Box<T>` 拥有堆上的内存。Rust 强制执行 [RAII]"
+"(https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization)（资源获取即初始化），因此每当一个对象离开作用域时，"
+"它的析构函数就会被调用，它拥有的资源也会被释放。"
 
 #: src/scope/raii.md:8
 msgid ""
@@ -8582,7 +8626,7 @@ msgid ""
 "manually free memory or worry about memory leaks again! Here's a quick "
 "showcase:"
 msgstr ""
-"这种行为可以防止**资源泄漏**的错误，所以你再也不用手动释放内存或担心内存泄漏了！这是一个简单示例："
+"这种行为可以防止**资源泄漏**错误，因此你再也不用手动释放内存或担心内存泄漏了！以下是一个简单示例："
 
 #: src/scope/raii.md:12
 msgid "// raii.rs\n"
@@ -8594,7 +8638,7 @@ msgstr "// 在堆上分配一个整数\n"
 
 #: src/scope/raii.md:17
 msgid "// `_box1` is destroyed here, and memory gets freed\n"
-msgstr "// `_box1` 在这里被销毁，内存被释放\n"
+msgstr "// `_box1` 在此处被销毁，内存被释放\n"
 
 #: src/scope/raii.md:24
 msgid "// A nested scope:\n"
@@ -8602,19 +8646,19 @@ msgstr "// 一个嵌套的作用域：\n"
 
 #: src/scope/raii.md:29
 msgid "// `_box3` is destroyed here, and memory gets freed\n"
-msgstr "// `_box3` 在这里被销毁，内存被释放\n"
+msgstr "// `_box3` 在此处被销毁，内存被释放\n"
 
 #: src/scope/raii.md:32
 msgid ""
 "// Creating lots of boxes just for fun\n"
 "    // There's no need to manually free memory!\n"
 msgstr ""
-"// 创建很多 box（只是为了好玩）\n"
-"    // 不需要手动释放内存！\n"
+"// 创建大量的 box（仅为演示）\n"
+"    // 无需手动释放内存！\n"
 
 #: src/scope/raii.md:38
 msgid "// `_box2` is destroyed here, and memory gets freed\n"
-msgstr "// `_box2` 在这里被销毁，内存被释放\n"
+msgstr "// `_box2` 在此处被销毁，内存被释放\n"
 
 #: src/scope/raii.md:42
 msgid ""
@@ -8625,7 +8669,7 @@ msgstr ""
 
 #: src/scope/raii.md:65
 msgid "No leaks here!"
-msgstr "没有泄漏！"
+msgstr "这里没有内存泄漏！"
 
 #: src/scope/raii.md:67
 msgid "Destructor"
@@ -8639,7 +8683,8 @@ msgid ""
 "implemented for every type, only implement it for your type if you require "
 "its own destructor logic."
 msgstr ""
-"Rust 中析构函数的概念是通过 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 提供的。当资源离开作用域时，析构函数被调用。并不是每种类型都需要实现这个 trait，只有当你需要为自己的类型实现析构函数逻辑时才需要实现它。"
+"Rust 中的析构函数概念是通过 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 提供的。"
+"当资源离开作用域时，析构函数会被调用。并非每种类型都需要实现这个 trait，只有当你需要为自己的类型实现特定的析构逻辑时才需要实现它。"
 
 #: src/scope/raii.md:74
 msgid ""
@@ -8647,11 +8692,12 @@ msgid ""
 "ops/trait.Drop.html) trait works. When the variable in the `main` function "
 "goes out of scope the custom destructor will be invoked."
 msgstr ""
-"运行下面的例子来看看 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 是如何工作的。当 `main` 函数中的变量离开作用域时，自定义的析构函数将被调用。"
+"运行下面的示例来了解 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 是如何工作的。"
+"当 `main` 函数中的变量离开作用域时，自定义的析构函数将被调用。"
 
 #: src/scope/raii.md:82
 msgid "\"ToDrop is being dropped\""
-msgstr "\"ToDrop 被丢弃了\""
+msgstr "\"ToDrop 正在被丢弃\""
 
 #: src/scope/raii.md:88
 msgid "\"Made a ToDrop!\""
@@ -8668,7 +8714,8 @@ msgid ""
 "once. Note that not all variables own resources (e.g. [references](../"
 "flow_control/match/destructuring/destructure_pointers.md))."
 msgstr ""
-"因为变量负责释放它们持有的资源，**资源只能有一个所有者**。这可以防止资源被多次释放。注意并不是所有的变量都持有资源（例如 [引用](../flow_control/match/destructuring/destructure_pointers.md)）。"
+"由于变量负责释放它们自己的资源，**资源只能有一个所有者**。这可以防止资源被多次释放。"
+"请注意，并非所有变量都拥有资源（例如[引用](../flow_control/match/destructuring/destructure_pointers.md)）。"
 
 #: src/scope/move.md:8
 msgid ""
@@ -8683,31 +8730,36 @@ msgid ""
 "After moving resources, the previous owner can no longer be used. This avoids "
 "creating dangling pointers."
 msgstr ""
-"在移动资源之后，之前的所有者就不能再被使用了。这避免了悬垂指针的产生。"
+"资源移动后，原所有者将无法再被使用。这避免了悬垂指针的产生。"
 
 #: src/scope/move.md:16
 msgid "// This function takes ownership of the heap allocated memory\n"
-msgstr "// 这个函数获取堆分配内存的所有权\n"
+msgstr ""
+"// 此函数获取堆分配内存的所有权\n"
 
 #: src/scope/move.md:18
 msgid "\"Destroying a box that contains {}\""
-msgstr "\"销毁一个包含 {} 的 box\""
+msgstr "\"正在销毁一个包含 {} 的 box\""
 
 #: src/scope/move.md:20
 msgid "// `c` is destroyed and the memory freed\n"
-msgstr "// `c` 被销毁并且内存被释放\n"
+msgstr ""
+"// `c` 被销毁，内存被释放\n"
 
 #: src/scope/move.md:24
 msgid "// _Stack_ allocated integer\n"
-msgstr "// 「栈」分配的整数\n"
+msgstr ""
+"// **栈**分配的整数\n"
 
 #: src/scope/move.md:27
 msgid "// *Copy* `x` into `y` - no resources are moved\n"
-msgstr "// 将 `x` *复制*到 `y` - 没有资源被移动\n"
+msgstr ""
+"// 将 `x` **复制**到 `y` - 没有资源被移动\n"
 
 #: src/scope/move.md:30
 msgid "// Both values can be independently used\n"
-msgstr "// 两个值可以独立使用\n"
+msgstr ""
+"// 两个值可以独立使用\n"
 
 #: src/scope/move.md:31
 msgid "\"x is {}, and y is {}\""
@@ -8715,7 +8767,8 @@ msgstr "\"x 是 {}，y 是 {}\""
 
 #: src/scope/move.md:33
 msgid "// `a` is a pointer to a _heap_ allocated integer\n"
-msgstr "// `a` 是一个指向「堆」分配的整数的指针\n"
+msgstr ""
+"// `a` 是指向**堆**分配整数的指针\n"
 
 #: src/scope/move.md:36
 msgid "\"a contains: {}\""
@@ -8723,7 +8776,8 @@ msgstr "\"a 包含：{}\""
 
 #: src/scope/move.md:38
 msgid "// *Move* `a` into `b`\n"
-msgstr "// 将 `a` *移动* 到 `b`\n"
+msgstr ""
+"// 将 `a` **移动**到 `b`\n"
 
 #: src/scope/move.md:40
 msgid ""
@@ -8731,9 +8785,9 @@ msgid ""
 "    // Both are now pointers to the same heap allocated data, but\n"
 "    // `b` now owns it.\n"
 msgstr ""
-"// 把 `a` 的指针地址（而不是数据）复制到 `b`。\n"
-"    // 现在两者都是指向同一个堆分配数据的指针，但是\n"
-"    // `b` 现在持有它。\n"
+"// `a` 的指针地址（而非数据）被复制到 `b`\n"
+"    // 现在两者都指向同一块堆分配的数据\n"
+"    // 但 `b` 现在拥有它\n"
 
 #: src/scope/move.md:44
 msgid ""
@@ -8742,13 +8796,14 @@ msgid ""
 "    //println!(\"a contains: {}\", a);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 错误！`a` 不能再访问数据，因为它不再持有堆内存\n"
-"    //println!(\"a contains: {}\", a);\n"
-"    // TODO ^ 试着取消注释这一行\n"
+"// 错误！`a` 不再拥有堆内存，因此无法访问数据\n"
+"    //println!(\"a 包含：{}\", a);\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/scope/move.md:49
 msgid "// This function takes ownership of the heap allocated memory from `b`\n"
-msgstr "// 这个函数从 `b` 获取堆分配内存的所有权\n"
+msgstr ""
+"// 此函数从 `b` 获取堆分配内存的所有权\n"
 
 #: src/scope/move.md:52
 msgid ""
@@ -8759,15 +8814,15 @@ msgid ""
 "    //println!(\"b contains: {}\", b);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 由于堆内存在这一点已经被释放，这个操作会导致解引用已释放的内存，\n"
-"    // 但这被编译器禁止\n"
+"// 此时堆内存已被释放，这个操作会导致解引用已释放的内存\n"
+"    // 但编译器禁止这样做\n"
 "    // 错误！原因与前面的错误相同\n"
-"    //println!(\"b contains: {}\", b);\n"
-"    // TODO ^ 试着取消注释这一行\n"
+"    //println!(\"b 包含：{}\", b);\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/scope/move/mut.md:3
 msgid "Mutability of data can be changed when ownership is transferred."
-msgstr "当所有权被转移时，数据的可变性可以被改变。"
+msgstr "当所有权转移时，数据的可变性可以改变。"
 
 #: src/scope/move/mut.md:9
 msgid "\"immutable_box contains {}\""

--- a/po/zh.po
+++ b/po/zh.po
@@ -5062,17 +5062,29 @@ msgid ""
 "        // explicitly handling the failing case.\n"
 msgstr ""
 
+#: src/flow_control/while_let.md:48
+msgid ""
+"// ^ Less rightward drift and doesn't require\n"
+"        // explicitly handling the failing case.\n"
+msgstr ""
+"// ^ 减少了向右偏移，并且不需要\n"
+"        // 显式处理失败的情况。\n"
+
 #: src/flow_control/while_let.md:51
 msgid ""
 "// ^ `if let` had additional optional `else`/`else if`\n"
 "    // clauses. `while let` does not have these.\n"
 msgstr ""
+"// ^ `if let` 有额外的可选 `else`/`else if`\n"
+"    // 子句。`while let` 没有这些。\n"
 
 #: src/flow_control/while_let.md:58
 msgid ""
 "[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the [RFC]"
 "(https://github.com/rust-lang/rfcs/pull/214)"
 msgstr ""
+"[`enum`](../custom_types/enum.md)、[`Option`](../std/option.md) 和 [RFC]"
+"(https://github.com/rust-lang/rfcs/pull/214)"
 
 #: src/fn.md:3
 msgid ""
@@ -5080,6 +5092,8 @@ msgid ""
 "annotated, just like variables, and, if the function returns a value, the "
 "return type must be specified after an arrow `->`."
 msgstr ""
+"函数使用 `fn` 关键字声明。它的参数需要标注类型，就像变量一样，如果函数返回一个值，"
+"返回类型必须在箭头 `->` 之后指定。"
 
 #: src/fn.md:7
 msgid ""
@@ -5087,47 +5101,52 @@ msgid ""
 "Alternatively, the `return` statement can be used to return a value earlier "
 "from within the function, even from inside loops or `if` statements."
 msgstr ""
+"函数中的最后一个表达式将被用作返回值。或者，可以使用 `return` 语句从函数内部提前返回一个值，"
+"甚至可以从循环或 `if` 语句内部返回。"
 
 #: src/fn.md:11
 msgid "Let's rewrite FizzBuzz using functions!"
-msgstr ""
+msgstr "让我们用函数重写 FizzBuzz！"
 
 #: src/fn.md:14
 msgid ""
 "// Unlike C/C++, there's no restriction on the order of function definitions\n"
 msgstr ""
+"// 与 C/C++ 不同，函数定义的顺序没有限制\n"
 
 #: src/fn.md:16
 msgid "// We can use this function here, and define it somewhere later\n"
-msgstr ""
+msgstr "// 我们可以在这里使用这个函数，并在稍后的某个地方定义它\n"
 
 #: src/fn.md:19
 msgid "// Function that returns a boolean value\n"
-msgstr ""
+msgstr "// 返回布尔值的函数\n"
 
 #: src/fn.md:22
 msgid "// Corner case, early return\n"
-msgstr ""
+msgstr "// 特殊情况，提前返回\n"
 
 #: src/fn.md:27
 msgid "// This is an expression, the `return` keyword is not necessary here\n"
-msgstr ""
+msgstr "// 这是一个表达式，这里不需要 `return` 关键字\n"
 
 #: src/fn.md:30
 msgid ""
 "// Functions that \"don't\" return a value, actually return the unit type "
 "`()`\n"
 msgstr ""
+"// \"不\"返回值的函数实际上返回单元类型 `()`\n"
 
 #: src/fn.md:43
 msgid ""
 "// When a function returns `()`, the return type can be omitted from the\n"
 "// signature\n"
 msgstr ""
+"// 当函数返回 `()` 时，可以在函数签名中省略返回类型\n"
 
 #: src/fn/methods.md:1
 msgid "Associated functions & Methods"
-msgstr ""
+msgstr "关联函数和方法"
 
 #: src/fn/methods.md:3
 msgid ""
@@ -5136,12 +5155,15 @@ msgid ""
 "are defined on a type generally, while methods are associated functions that "
 "are called on a particular instance of a type."
 msgstr ""
+"有些函数与特定类型相关联。这些函数有两种形式：关联函数和方法。关联函数是在类型上定义的函数，"
+"而方法是在类型的特定实例上调用的关联函数。"
 
 #: src/fn/methods.md:13
 msgid ""
 "// Implementation block, all `Point` associated functions & methods go in "
 "here\n"
 msgstr ""
+"// 实现块，所有 `Point` 的关联函数和方法都在这里\n"
 
 #: src/fn/methods.md:16
 msgid ""
@@ -5152,10 +5174,14 @@ msgid ""
 "    // Associated functions don't need to be called with an instance.\n"
 "    // These functions are generally used like constructors.\n"
 msgstr ""
+"// 这是一个"关联函数"，因为这个函数与特定类型 Point 相关联。\n"
+"    //\n"
+"    // 关联函数不需要通过实例来调用。\n"
+"    // 这些函数通常用作构造函数。\n"
 
 #: src/fn/methods.md:25
 msgid "// Another associated function, taking two arguments:\n"
-msgstr ""
+msgstr "// 另一个关联函数，接受两个参数：\n"
 
 #: src/fn/methods.md:37
 msgid ""
@@ -5163,48 +5189,56 @@ msgid ""
 "    // `&self` is sugar for `self: &Self`, where `Self` is the type of the\n"
 "    // caller object. In this case `Self` = `Rectangle`\n"
 msgstr ""
+"// 这是一个方法\n"
+"    // `&self` 是 `self: &Self` 的语法糖，其中 `Self` 是调用者对象的类型。\n"
+"    // 在这个例子中 `Self` = `Rectangle`\n"
 
 #: src/fn/methods.md:41
 msgid "// `self` gives access to the struct fields via the dot operator\n"
-msgstr ""
+msgstr "// `self` 通过点运算符访问结构体字段\n"
 
 #: src/fn/methods.md:45
 msgid ""
 "// `abs` is a `f64` method that returns the absolute value of the\n"
 "        // caller\n"
 msgstr ""
+"// `abs` 是 `f64` 类型的方法，返回调用者的绝对值\n"
 
 #: src/fn/methods.md:57
 msgid ""
 "// This method requires the caller object to be mutable\n"
 "    // `&mut self` desugars to `self: &mut Self`\n"
 msgstr ""
+"// 这个方法要求调用者对象是可变的\n"
+"    // `&mut self` 是 `self: &mut Self` 的语法糖\n"
 
 #: src/fn/methods.md:67
 msgid "// `Pair` owns resources: two heap allocated integers\n"
-msgstr ""
+msgstr "// `Pair` 拥有资源：两个堆分配的整数\n"
 
 #: src/fn/methods.md:72
 msgid ""
 "// This method \"consumes\" the resources of the caller object\n"
 "    // `self` desugars to `self: Self`\n"
 msgstr ""
+"// 这个方法"消耗"调用者对象的资源\n"
+"    // `self` 是 `self: Self` 的语法糖\n"
 
 #: src/fn/methods.md:75
 msgid "// Destructure `self`\n"
-msgstr ""
+msgstr "// 解构 `self`\n"
 
 #: src/fn/methods.md:78
 msgid "\"Destroying Pair({}, {})\""
-msgstr ""
+msgstr "\"销毁 Pair({}, {})\""
 
 #: src/fn/methods.md:80
 msgid "// `first` and `second` go out of scope and get freed\n"
-msgstr ""
+msgstr "// `first` 和 `second` 超出作用域并被释放\n"
 
 #: src/fn/methods.md:86
 msgid "// Associated functions are called using double colons\n"
-msgstr ""
+msgstr "// 使用双冒号调用关联函数\n"
 
 #: src/fn/methods.md:91
 msgid ""
@@ -5212,14 +5246,17 @@ msgid ""
 "    // Note that the first argument `&self` is implicitly passed, i.e.\n"
 "    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
 msgstr ""
+"// 使用点运算符调用方法\n"
+"    // 注意，第一个参数 `&self` 是隐式传递的，即\n"
+"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
 
 #: src/fn/methods.md:94
 msgid "\"Rectangle perimeter: {}\""
-msgstr ""
+msgstr "\"矩形周长：{}\""
 
 #: src/fn/methods.md:95
 msgid "\"Rectangle area: {}\""
-msgstr ""
+msgstr "\"矩形面积：{}\""
 
 #: src/fn/methods.md:102
 msgid ""
@@ -5228,10 +5265,13 @@ msgid ""
 "    //rectangle.translate(1.0, 0.0);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！`rectangle` 是不可变的，但这个方法需要一个可变对象\n"
+"    //rectangle.translate(1.0, 0.0);\n"
+"    // TODO ^ 尝试取消注释这一行\n"
 
 #: src/fn/methods.md:107
 msgid "// Okay! Mutable objects can call mutable methods\n"
-msgstr ""
+msgstr "// 没问题！可变对象可以调用可变方法\n"
 
 #: src/fn/methods.md:114
 msgid ""
@@ -5239,12 +5279,16 @@ msgid ""
 "    //pair.destroy();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！之前的 `destroy` 调用已经"消耗"了 `pair`\n"
+"    //pair.destroy();\n"
+"    // TODO ^ 尝试取消注释这一行\n"
 
 #: src/fn/closures.md:3
 msgid ""
 "Closures are functions that can capture the enclosing environment. For "
 "example, a closure that captures the `x` variable:"
 msgstr ""
+"闭包是可以捕获周围环境的函数。例如，一个捕获 `x` 变量的闭包："
 
 #: src/fn/closures.md:10
 msgid ""
@@ -5253,24 +5297,27 @@ msgid ""
 "both input and return types _can_ be inferred and input variable names _must_ "
 "be specified."
 msgstr ""
+"闭包的语法和功能使它们非常适合即时使用。调用闭包与调用函数完全相同。然而，"
+"输入和返回类型**可以**被推断，而输入变量名**必须**被指定。"
 
 #: src/fn/closures.md:15
 msgid "Other characteristics of closures include:"
-msgstr ""
+msgstr "闭包的其他特征包括："
 
 #: src/fn/closures.md:16
 msgid "using `||` instead of `()` around input variables."
-msgstr ""
+msgstr "使用 `||` 而不是 `()` 来包围输入变量。"
 
 #: src/fn/closures.md:17
 msgid ""
 "optional body delimitation (`{}`) for a single line expression (mandatory "
 "otherwise)."
 msgstr ""
+"对于单行表达式，可以省略函数体定界符（`{}`）（其他情况是必需的）。"
 
 #: src/fn/closures.md:18
 msgid "the ability to capture the outer environment variables."
-msgstr ""
+msgstr "能够捕获外部环境的变量。"
 
 #: src/fn/closures.md:24
 msgid ""
@@ -5280,6 +5327,10 @@ msgid ""
 "compiler\n"
 "    // suggests that we define a closure instead.\n"
 msgstr ""
+"// 常规函数不能引用封闭环境中的变量\n"
+"    //fn function(i: i32) -> i32 { i + outer_var }\n"
+"    // TODO：取消上面这行的注释，看看编译器错误。编译器\n"
+"    // 建议我们定义一个闭包来代替。\n"
 
 #: src/fn/closures.md:29
 msgid ""
@@ -5288,18 +5339,22 @@ msgid ""
 "    // as are the `{}` wrapping the body. These nameless functions\n"
 "    // are assigned to appropriately named variables.\n"
 msgstr ""
+"// 闭包是匿名的，这里我们将它们绑定到引用。\n"
+"    // 注解与函数注解相同，但是可选的\n"
+"    // 包裹函数体的 `{}` 也是可选的。这些无名函数\n"
+"    // 被赋值给适当命名的变量。\n"
 
 #: src/fn/closures.md:36
 msgid "// Call the closures.\n"
-msgstr ""
+msgstr "// 调用闭包。\n"
 
 #: src/fn/closures.md:37
 msgid "\"closure_annotated: {}\""
-msgstr ""
+msgstr "\"closure_annotated: {}\""
 
 #: src/fn/closures.md:38
 msgid "\"closure_inferred: {}\""
-msgstr ""
+msgstr "\"closure_inferred: {}\""
 
 #: src/fn/closures.md:39
 msgid ""
@@ -5309,16 +5364,21 @@ msgid ""
 "closure_inferred(42i64));\n"
 "    // TODO: uncomment the line above and see the compiler error.\n"
 msgstr ""
+"// 一旦闭包的类型被推断出来，就不能再用另一种类型进行推断。\n"
+"    //println!(\"不能用另一种类型重用 closure_inferred：{}\", "
+"closure_inferred(42i64));\n"
 
 #: src/fn/closures.md:43
 msgid ""
 "// A closure taking no arguments which returns an `i32`.\n"
 "    // The return type is inferred.\n"
 msgstr ""
+"// 一个不接受参数并返回 `i32` 的闭包。\n"
+"    // 返回类型是推断出来的。\n"
 
 #: src/fn/closures.md:46
 msgid "\"closure returning one: {}\""
-msgstr ""
+msgstr "\"返回 1 的闭包：{}\""
 
 #: src/fn/closures/capture.md:3
 msgid ""
@@ -5327,28 +5387,29 @@ msgid ""
 "flexibly adapt to the use case, sometimes moving and sometimes borrowing. "
 "Closures can capture variables:"
 msgstr ""
+"闭包本质上是灵活的，它们会根据功能需求自动适应，无需注解就能正常工作。这种灵活性使得捕获可以根据使用场景进行调整，有时是移动，有时是借用。闭包可以通过以下方式捕获变量："
 
 #: src/fn/closures/capture.md:8
 msgid "by reference: `&T`"
-msgstr ""
+msgstr "通过引用：`&T`"
 
 #: src/fn/closures/capture.md:9
 msgid "by mutable reference: `&mut T`"
-msgstr ""
+msgstr "通过可变引用：`&mut T`"
 
 #: src/fn/closures/capture.md:10
 msgid "by value: `T`"
-msgstr ""
+msgstr "通过值：`T`"
 
 #: src/fn/closures/capture.md:12
 msgid ""
 "They preferentially capture variables by reference and only go lower when "
 "required."
-msgstr ""
+msgstr "它们优先通过引用捕获变量，只有在必要时才会使用更低级别的捕获方式。"
 
 #: src/fn/closures/capture.md:19
 msgid "\"green\""
-msgstr ""
+msgstr "\"green\""
 
 #: src/fn/closures/capture.md:21
 msgid ""
@@ -5360,24 +5421,32 @@ msgid ""
 "doesn't\n"
 "    // impose anything more restrictive.\n"
 msgstr ""
+"// 一个打印 `color` 的闭包，它立即借用（`&`）`color` 并\n"
+"    // 将借用和闭包存储在 `print` 变量中。它将保持\n"
+"    // 借用状态直到 `print` 最后一次被使用。\n"
+"    //\n"
+"    // `println!` 只需要通过不可变引用传递参数，所以它\n"
+"    // 不会施加任何更严格的限制。\n"
 
 #: src/fn/closures/capture.md:27
 msgid "\"`color`: {}\""
-msgstr ""
+msgstr "\"`color`: {}\""
 
 #: src/fn/closures/capture.md:29
 msgid "// Call the closure using the borrow.\n"
-msgstr ""
+msgstr "// 使用借用调用闭包。\n"
 
 #: src/fn/closures/capture.md:32
 msgid ""
 "// `color` can be borrowed immutably again, because the closure only holds\n"
 "    // an immutable reference to `color`. \n"
 msgstr ""
+"// `color` 可以再次被不可变借用，因为闭包只持有\n"
+"    // `color` 的不可变引用。\n"
 
 #: src/fn/closures/capture.md:37
 msgid "// A move or reborrow is allowed after the final use of `print`\n"
-msgstr ""
+msgstr "// 在 `print` 的最后一次使用之后，可以移动或重新借用\n"
 
 #: src/fn/closures/capture.md:42
 msgid ""
@@ -5388,14 +5457,20 @@ msgid ""
 "    // A `mut` is required on `inc` because a `&mut` is stored inside. Thus,\n"
 "    // calling the closure mutates `count` which requires a `mut`.\n"
 msgstr ""
+"// 一个用于增加 `count` 的闭包可以接受 `&mut count` 或 `count`\n"
+"    // 但 `&mut count` 限制更少，所以选择它。立即\n"
+"    // 借用 `count`。\n"
+"    //\n"
+"    // `inc` 需要 `mut` 因为内部存储了一个 `&mut`。因此，\n"
+"    // 调用闭包会改变 `count`，这需要一个 `mut`。\n"
 
 #: src/fn/closures/capture.md:50
 msgid "\"`count`: {}\""
-msgstr ""
+msgstr "\"`count`: {}\""
 
 #: src/fn/closures/capture.md:53
 msgid "// Call the closure using a mutable borrow.\n"
-msgstr ""
+msgstr "// 使用可变借用调用闭包。\n"
 
 #: src/fn/closures/capture.md:56
 msgid ""
@@ -5404,16 +5479,22 @@ msgid ""
 "    // let _reborrow = &count; \n"
 "    // ^ TODO: try uncommenting this line.\n"
 msgstr ""
+"// 闭包仍然可变地借用 `count`，因为它稍后会被调用。\n"
+"    // 尝试重新借用会导致错误。\n"
+"    // let _reborrow = &count; \n"
+"    // ^ TODO：尝试取消注释这一行。\n"
 
 #: src/fn/closures/capture.md:62
 msgid ""
 "// The closure no longer needs to borrow `&mut count`. Therefore, it is\n"
 "    // possible to reborrow without an error\n"
 msgstr ""
+"// 闭包不再需要借用 `&mut count`。因此，可以\n"
+"    // 在没有错误的情况下重新借用\n"
 
 #: src/fn/closures/capture.md:67
 msgid "// A non-copy type.\n"
-msgstr ""
+msgstr "// 一个不可复制类型。\n"
 
 #: src/fn/closures/capture.md:70
 msgid ""
@@ -5422,30 +5503,36 @@ msgid ""
 "    // A non-copy must move and so `movable` immediately moves into\n"
 "    // the closure.\n"
 msgstr ""
+"// `mem::drop` 需要 `T`，所以这里必须通过值获取。可复制类型\n"
+"    // 会被复制到闭包中，原始值保持不变。\n"
+"    // 不可复制类型必须移动，所以 `movable` 立即移动到\n"
+"    // 闭包中。\n"
 
 #: src/fn/closures/capture.md:75
 msgid "\"`movable`: {:?}\""
-msgstr ""
+msgstr "\"`movable`: {:?}\""
 
 #: src/fn/closures/capture.md:79
 msgid "// `consume` consumes the variable so this can only be called once.\n"
-msgstr ""
+msgstr "// `consume` 消耗了变量，所以这只能被调用一次。\n"
 
 #: src/fn/closures/capture.md:81
 msgid ""
 "// consume();\n"
 "    // ^ TODO: Try uncommenting this line.\n"
 msgstr ""
+"// consume();\n"
+"    // ^ TODO：尝试取消注释这一行。\n"
 
 #: src/fn/closures/capture.md:86
 msgid ""
 "Using `move` before vertical pipes forces closure to take ownership of "
 "captured variables:"
-msgstr ""
+msgstr "在竖线前使用 `move` 强制闭包获取捕获变量的所有权："
 
 #: src/fn/closures/capture.md:91
 msgid "// `Vec` has non-copy semantics.\n"
-msgstr ""
+msgstr "// `Vec` 具有非复制语义。\n"
 
 #: src/fn/closures/capture.md:99
 msgid ""
@@ -5454,6 +5541,10 @@ msgid ""
 "    // because borrow checker doesn't allow re-using variable after it\n"
 "    // has been moved.\n"
 msgstr ""
+"// println!(\"vec 中有 {} 个元素\", haystack.len());\n"
+"    // ^ 取消上面这行的注释会导致编译时错误\n"
+"    // 因为借用检查器不允许在变量被移动后重新使用。\n"
+"    \n"
 
 #: src/fn/closures/capture.md:104
 msgid ""
@@ -5461,12 +5552,17 @@ msgid ""
 "    // to borrow _haystack_ variable immutably, hence _haystack_ is still\n"
 "    // available and uncommenting above line will not cause an error.\n"
 msgstr ""
+"// 从闭包的签名中移除 `move` 将导致闭包\n"
+"    // 不可变地借用 _haystack_ 变量，因此 _haystack_ 仍然\n"
+"    // 可用，取消注释上面的行不会导致错误。\n"
 
 #: src/fn/closures/capture.md:112
 msgid ""
 "[`Box`](../../std/box.md) and [`std::mem::drop`](https://doc.rust-lang.org/"
 "std/mem/fn.drop.html)"
 msgstr ""
+"[`Box`](../../std/box.md) 和 [`std::mem::drop`](https://doc.rust-lang.org/"
+"std/mem/fn.drop.html)"
 
 #: src/fn/closures/input_parameters.md:3
 msgid ""
@@ -5477,25 +5573,26 @@ msgid ""
 "closure does with captured value. In order of decreasing restriction, they "
 "are:"
 msgstr ""
+"虽然 Rust 在大多数情况下可以自动选择如何捕获变量而无需类型注解，但在编写函数时不允许这种模糊性。当将闭包作为输入参数时，必须使用以下 `traits` 中的一个来注解闭包的完整类型，这些 traits 由闭包对捕获值的处理方式决定。按限制程度递减的顺序，它们是："
 
 #: src/fn/closures/input_parameters.md:10
 msgid "`Fn`: the closure uses the captured value by reference (`&T`)"
-msgstr ""
+msgstr "`Fn`：闭包通过引用使用捕获的值（`&T`）"
 
 #: src/fn/closures/input_parameters.md:11
 msgid ""
 "`FnMut`: the closure uses the captured value by mutable reference (`&mut T`)"
-msgstr ""
+msgstr "`FnMut`：闭包通过可变引用使用捕获的值（`&mut T`）"
 
 #: src/fn/closures/input_parameters.md:12
 msgid "`FnOnce`: the closure uses the captured value by value (`T`)"
-msgstr ""
+msgstr "`FnOnce`：闭包通过值使用捕获的值（`T`）"
 
 #: src/fn/closures/input_parameters.md:14
 msgid ""
 "On a variable-by-variable basis, the compiler will capture variables in the "
 "least restrictive manner possible."
-msgstr ""
+msgstr "编译器会以尽可能最少限制的方式逐个捕获变量。"
 
 #: src/fn/closures/input_parameters.md:17
 msgid ""
@@ -5503,6 +5600,7 @@ msgid ""
 "the closure _may_ capture by `&T`, `&mut T`, or `T`, but the compiler will "
 "ultimately choose based on how the captured variables are used in the closure."
 msgstr ""
+"例如，考虑一个注解为 `FnOnce` 的参数。这指定闭包**可能**通过 `&T`、`&mut T` 或 `T` 进行捕获，但编译器最终会根据捕获变量在闭包中的使用方式来选择。"
 
 #: src/fn/closures/input_parameters.md:22
 msgid ""
@@ -5511,94 +5609,105 @@ msgid ""
 "`Fn`, then capturing variables by `&mut T` or `T` are not allowed. However, "
 "`&T` is allowed."
 msgstr ""
+"这是因为如果可以移动，那么任何类型的借用也应该是可能的。注意反过来并不成立。如果参数被注解为 `Fn`，那么通过 `&mut T` 或 `T` 捕获变量是不允许的。然而，`&T` 是允许的。"
 
 #: src/fn/closures/input_parameters.md:27
 msgid ""
 "In the following example, try swapping the usage of `Fn`, `FnMut`, and "
 "`FnOnce` to see what happens:"
-msgstr ""
+msgstr "在下面的例子中，尝试交换 `Fn`、`FnMut` 和 `FnOnce` 的用法，看看会发生什么："
 
 #: src/fn/closures/input_parameters.md:31
 msgid ""
 "// A function which takes a closure as an argument and calls it.\n"
 "// <F> denotes that F is a \"Generic type parameter\"\n"
 msgstr ""
+"// 一个接受闭包作为参数并调用它的函数。\n"
+"// <F> 表示 F 是一个"泛型类型参数"\n"
 
 #: src/fn/closures/input_parameters.md:34
 msgid "// The closure takes no input and returns nothing.\n"
-msgstr ""
+msgstr "// 这个闭包不接受输入也不返回任何值。\n"
 
 #: src/fn/closures/input_parameters.md:36
 msgid "// ^ TODO: Try changing this to `Fn` or `FnMut`.\n"
-msgstr ""
+msgstr "// ^ TODO：尝试将其改为 `Fn` 或 `FnMut`。\n"
 
 #: src/fn/closures/input_parameters.md:40
 msgid "// A function which takes a closure and returns an `i32`.\n"
-msgstr ""
+msgstr "// 一个接受闭包并返回 `i32` 的函数。\n"
 
 #: src/fn/closures/input_parameters.md:43
 msgid "// The closure takes an `i32` and returns an `i32`.\n"
-msgstr ""
+msgstr "// 这个闭包接受一个 `i32` 并返回一个 `i32`。\n"
 
 #: src/fn/closures/input_parameters.md:53
 msgid ""
 "// A non-copy type.\n"
 "    // `to_owned` creates owned data from borrowed one\n"
 msgstr ""
+"// 一个非复制类型。\n"
+"    // `to_owned` 从借用的数据创建所有权数据\n"
 
 #: src/fn/closures/input_parameters.md:55
 msgid "\"goodbye\""
-msgstr ""
+msgstr "\"goodbye\""
 
 #: src/fn/closures/input_parameters.md:57
 msgid ""
 "// Capture 2 variables: `greeting` by reference and\n"
 "    // `farewell` by value.\n"
 msgstr ""
+"// 捕获两个变量：通过引用捕获 `greeting`，\n"
+"    // 通过值捕获 `farewell`。\n"
 
 #: src/fn/closures/input_parameters.md:60
 msgid "// `greeting` is by reference: requires `Fn`.\n"
-msgstr ""
+msgstr "// `greeting` 是通过引用：需要 `Fn`。\n"
 
 #: src/fn/closures/input_parameters.md:61
 msgid "\"I said {}.\""
-msgstr ""
+msgstr "\"I said {}.\""
 
 #: src/fn/closures/input_parameters.md:63
 msgid ""
 "// Mutation forces `farewell` to be captured by\n"
 "        // mutable reference. Now requires `FnMut`.\n"
 msgstr ""
+"// 修改强制 `farewell` 通过可变引用捕获。\n"
+"        // 现在需要 `FnMut`。\n"
 
 #: src/fn/closures/input_parameters.md:65
 msgid "\"!!!\""
-msgstr ""
+msgstr "\"!!!\""
 
 #: src/fn/closures/input_parameters.md:66
 msgid "\"Then I screamed {}.\""
-msgstr ""
+msgstr "\"Then I screamed {}.\""
 
 #: src/fn/closures/input_parameters.md:67
 msgid "\"Now I can sleep. zzzzz\""
-msgstr ""
+msgstr "\"Now I can sleep. zzzzz\""
 
 #: src/fn/closures/input_parameters.md:69
 msgid ""
 "// Manually calling drop forces `farewell` to\n"
 "        // be captured by value. Now requires `FnOnce`.\n"
 msgstr ""
+"// 手动调用 drop 强制 `farewell` 通过值捕获。\n"
+"        // 现在需要 `FnOnce`。\n"
 
 #: src/fn/closures/input_parameters.md:74
 msgid "// Call the function which applies the closure.\n"
-msgstr ""
+msgstr "// 调用应用闭包的函数。\n"
 
 #: src/fn/closures/input_parameters.md:77
 msgid "// `double` satisfies `apply_to_3`'s trait bound\n"
-msgstr ""
+msgstr "// `double` 满足 `apply_to_3` 的 trait 约束\n"
 
 #: src/fn/closures/input_parameters.md:80
 msgid "\"3 doubled: {}\""
-msgstr ""
+msgstr "\"3 doubled: {}\""
 
 #: src/fn/closures/input_parameters.md:86
 msgid ""
@@ -5608,6 +5717,11 @@ msgid ""
 "(../../generics/where.md) and [`FnOnce`](https://doc.rust-lang.org/std/ops/"
 "trait.FnOnce.html)"
 msgstr ""
+"[`std::mem::drop`](https://doc.rust-lang.org/std/mem/fn.drop.html)、[`Fn`]"
+"(https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`](https://doc.rust-"
+"lang.org/std/ops/trait.FnMut.html)、[泛型](../../generics.md)、[where]"
+"(../../generics/where.md) 和 [`FnOnce`](https://doc.rust-lang.org/std/ops/"
+"trait.FnOnce.html)"
 
 #: src/fn/closures/anonymity.md:3
 msgid ""
@@ -5616,10 +5730,11 @@ msgid ""
 "parameter requires [generics](../../generics.md), which is necessary because "
 "of how they are defined:"
 msgstr ""
+"闭包简洁地从封闭作用域中捕获变量。这会有什么后果吗？当然会有。观察一下如何将闭包作为函数参数使用需要[泛型](../../generics.md)，这是因为它们的定义方式所必需的："
 
 #: src/fn/closures/anonymity.md:9
 msgid "// `F` must be generic.\n"
-msgstr ""
+msgstr "// `F` 必须是泛型。\n"
 
 #: src/fn/closures/anonymity.md:16
 msgid ""
@@ -5629,6 +5744,7 @@ msgid ""
 "unknown type. This type is assigned to the variable which is stored until "
 "calling."
 msgstr ""
+"当定义一个闭包时，编译器会隐式创建一个新的匿名结构来存储内部捕获的变量，同时通过 `traits` 之一：`Fn`、`FnMut` 或 `FnOnce` 为这个未知类型实现功能。这个类型被分配给变量，并存储直到调用。"
 
 #: src/fn/closures/anonymity.md:22
 msgid ""
@@ -5637,6 +5753,7 @@ msgid ""
 "and not be allowed. Thus, bounding by one of the `traits`: `Fn`, `FnMut`, or "
 "`FnOnce` (which it implements) is sufficient to specify its type."
 msgstr ""
+"由于这个新类型是未知类型，在函数中的任何使用都需要泛型。然而，一个无界的类型参数 `<T>` 仍然会是模糊的，不被允许。因此，通过 `traits` 之一：`Fn`、`FnMut` 或 `FnOnce`（它实现的）来约束就足以指定其类型。"
 
 #: src/fn/closures/anonymity.md:28
 msgid ""
@@ -5644,12 +5761,17 @@ msgid ""
 "// inputs and returns nothing - exactly what is required\n"
 "// for `print`.\n"
 msgstr ""
+"// `F` 必须实现 `Fn` 用于一个不接受输入且不返回任何内容的闭包\n"
+"// - 这正是 `print` 所需要的。\n"
+"\n"
 
 #: src/fn/closures/anonymity.md:39
 msgid ""
 "// Capture `x` into an anonymous type and implement\n"
 "    // `Fn` for it. Store it in `print`.\n"
 msgstr ""
+"// 将 `x` 捕获到一个匿名类型中并为其实现\n"
+"    // `Fn`。将其存储在 `print` 中。\n"
 
 #: src/fn/closures/anonymity.md:49
 msgid ""
@@ -5658,6 +5780,10 @@ msgid ""
 "(https://doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://"
 "doc.rust-lang.org/std/ops/trait.FnOnce.html)"
 msgstr ""
+"[深入分析](https://huonw.github.io/blog/2015/05/finding-closure-in-"rust/)、"
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`]"
+"(https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://"
+"doc.rust-lang.org/std/ops/trait.FnOnce.html)"
 
 #: src/fn/closures/input_functions.md:3
 msgid ""
@@ -5666,34 +5792,37 @@ msgid ""
 "takes a closure as parameter, then any function that satisfies the trait "
 "bound of that closure can be passed as a parameter."
 msgstr ""
+"既然闭包可以作为参数使用，你可能会想知道函数是否也可以这样。确实可以！如果你声明一个函数，它接受一个闭包作为参数，那么任何满足该闭包 trait 约束的函数都可以作为参数传递。"
 
 #: src/fn/closures/input_functions.md:9
 msgid ""
 "// Define a function which takes a generic `F` argument\n"
 "// bounded by `Fn`, and calls it\n"
 msgstr ""
+"// 定义一个函数，它接受一个由 `Fn` 约束的泛型参数 `F` ，并调用它\n"
 
 #: src/fn/closures/input_functions.md:14
 msgid "// Define a wrapper function satisfying the `Fn` bound\n"
-msgstr ""
+msgstr "// 定义一个满足 `Fn` 约束的包装函数\n"
 
 #: src/fn/closures/input_functions.md:17
 msgid "\"I'm a function!\""
-msgstr ""
+msgstr "\"I'm a function!\""
 
 #: src/fn/closures/input_functions.md:21
 msgid "// Define a closure satisfying the `Fn` bound\n"
-msgstr ""
+msgstr "// 定义一个满足 `Fn` 约束的闭包\n"
 
 #: src/fn/closures/input_functions.md:22
 msgid "\"I'm a closure!\""
-msgstr ""
+msgstr "\"I'm a closure!\""
 
 #: src/fn/closures/input_functions.md:29
 msgid ""
 "As an additional note, the `Fn`, `FnMut`, and `FnOnce` `traits` dictate how a "
 "closure captures variables from the enclosing scope."
 msgstr ""
+"作为附加说明，`Fn`、`FnMut` 和 `FnOnce` `traits` 决定了闭包如何从封闭作用域中捕获变量。"
 
 #: src/fn/closures/input_functions.md:34
 msgid ""
@@ -5701,6 +5830,9 @@ msgid ""
 "doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://doc.rust-"
 "lang.org/std/ops/trait.FnOnce.html)"
 msgstr ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://doc.rust-"
+"lang.org/std/ops/trait.FnOnce.html)"
 
 #: src/fn/closures/output_parameters.md:3
 msgid ""
@@ -5708,22 +5840,23 @@ msgid ""
 "parameters should also be possible. However, anonymous closure types are, by "
 "definition, unknown, so we have to use `impl Trait` to return them."
 msgstr ""
+"闭包既然可以作为输入参数，那么将闭包作为输出参数返回也应该是可以的。然而，匿名闭包类型根据定义是未知的，所以我们必须使用 `impl Trait` 来返回它们。"
 
 #: src/fn/closures/output_parameters.md:8
 msgid "The valid traits for returning a closure are:"
-msgstr ""
+msgstr "返回闭包的有效 traits 是："
 
 #: src/fn/closures/output_parameters.md:10
 msgid "`Fn`"
-msgstr ""
+msgstr "`Fn`"
 
 #: src/fn/closures/output_parameters.md:11
 msgid "`FnMut`"
-msgstr ""
+msgstr "`FnMut`"
 
 #: src/fn/closures/output_parameters.md:12
 msgid "`FnOnce`"
-msgstr ""
+msgstr "`FnOnce`"
 
 #: src/fn/closures/output_parameters.md:14
 msgid ""
@@ -5732,24 +5865,25 @@ msgid ""
 "dropped as soon as the function exited, leaving invalid references in the "
 "closure."
 msgstr ""
+"除此之外，必须使用 `move` 关键字，它表示所有捕获都通过值进行。这是必需的，因为任何通过引用的捕获都会在函数退出时立即被丢弃，在闭包中留下无效的引用。"
 
 #: src/fn/closures/output_parameters.md:21
 msgid "\"Fn\""
-msgstr ""
+msgstr "\"Fn\""
 
 #: src/fn/closures/output_parameters.md:23
 #: src/fn/closures/output_parameters.md:29
 #: src/fn/closures/output_parameters.md:35
 msgid "\"This is a: {}\""
-msgstr ""
+msgstr "\"这是一个：{}\""
 
 #: src/fn/closures/output_parameters.md:27
 msgid "\"FnMut\""
-msgstr ""
+msgstr "\"FnMut\""
 
 #: src/fn/closures/output_parameters.md:33
 msgid "\"FnOnce\""
-msgstr ""
+msgstr "\"FnOnce\""
 
 #: src/fn/closures/output_parameters.md:51
 msgid ""
@@ -5757,11 +5891,14 @@ msgid ""
 "doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md) "
 "and [impl Trait](../../trait/impl_trait.md)."
 msgstr ""
+"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`](https://"
+"doc.rust-lang.org/std/ops/trait.FnMut.html)、[泛型](../../generics.md)"
+"和 [impl Trait](../../trait/impl_trait.md)。"
 
 #: src/fn/closures/closure_examples.md:3
 msgid ""
 "This section contains a few examples of using closures from the `std` library."
-msgstr ""
+msgstr "本节包含一些使用 `std` 库中闭包的示例。"
 
 #: src/fn/closures/closure_examples/iter_any.md:3
 msgid ""
@@ -5769,17 +5906,21 @@ msgid ""
 "`true` if any element satisfies the predicate. Otherwise `false`. Its "
 "signature:"
 msgstr ""
+"`Iterator::any` 是一个函数，当传入一个迭代器时，如果任何元素满足谓词，则返回 "
+"`true`。否则返回 `false`。它的签名如下："
 
 #: src/fn/closures/closure_examples/iter_any.md:9
 #: src/fn/closures/closure_examples/iter_find.md:9
 msgid "// The type being iterated over.\n"
-msgstr ""
+msgstr "// 被迭代的类型。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:12
 msgid ""
 "// `any` takes `&mut self` meaning the caller may be borrowed\n"
 "    // and modified, but not consumed.\n"
 msgstr ""
+"// `any` 接受 `&mut self`，意味着调用者可能被借用\n"
+"    // 和修改，但不会被消耗。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:15
 msgid ""
@@ -5787,35 +5928,37 @@ msgid ""
 "        // modified, not consumed. `Self::Item` states it takes\n"
 "        // arguments to the closure by value.\n"
 msgstr ""
+"// `FnMut` 意味着任何捕获的变量最多可以被修改，而不是被消耗。\n"
+"        // `Self::Item` 表示它通过值将参数传递给闭包。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:27
 msgid "// `iter()` for vecs yields `&i32`. Destructure to `i32`.\n"
-msgstr ""
+msgstr "// 对 vec 使用 `iter()` 产生 `&i32`。解构为 `i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:28
 msgid "\"2 in vec1: {}\""
-msgstr ""
+msgstr "\"2 在 vec1 中：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:29
 msgid "// `into_iter()` for vecs yields `i32`. No destructuring required.\n"
-msgstr ""
+msgstr "// 对 vec 使用 `into_iter()` 产生 `i32`。不需要解构。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:30
 msgid "\"2 in vec2: {}\""
-msgstr ""
+msgstr "\"2 在 vec2 中：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:32
 msgid ""
 "// `iter()` only borrows `vec1` and its elements, so they can be used again\n"
-msgstr ""
+msgstr "// `iter()` 只借用 `vec1` 及其元素，所以它们可以再次使用\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:33
 msgid "\"vec1 len: {}\""
-msgstr ""
+msgstr "\"vec1 长度：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:34
 msgid "\"First element of vec1 is: {}\""
-msgstr ""
+msgstr "\"vec1 的第一个元素是：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:35
 msgid ""
@@ -5825,28 +5968,34 @@ msgid ""
 "    // println!(\"vec2 len: {}\", vec2.len());\n"
 "    // TODO: uncomment two lines above and see compiler errors.\n"
 msgstr ""
+"// `into_iter()` 会移动 `vec2` 及其元素，所以它们不能再次使用\n"
+"    // println!(\"vec2 的第一个元素是：{}\", vec2[0]);\n"
+"    // println!(\"vec2 长度：{}\", vec2.len());\n"
+"    // TODO：取消上面两行的注释，查看编译器错误。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:43
 msgid "// `iter()` for arrays yields `&i32`.\n"
-msgstr ""
+msgstr "// 对数组使用 `iter()` 产生 `&i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:44
 msgid "\"2 in array1: {}\""
-msgstr ""
+msgstr "\"2 在 array1 中：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:45
 msgid "// `into_iter()` for arrays yields `i32`.\n"
-msgstr ""
+msgstr "// 对数组使用 `into_iter()` 产生 `i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:46
 msgid "\"2 in array2: {}\""
-msgstr ""
+msgstr "\"2 在 array2 中：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:52
 msgid ""
 "[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.any)"
 msgstr ""
+"[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.any)"
 
 #: src/fn/closures/closure_examples/iter_find.md:3
 msgid ""
@@ -5854,12 +6003,16 @@ msgid ""
 "for the first value which satisfies some condition. If none of the values "
 "satisfy the condition, it returns `None`. Its signature:"
 msgstr ""
+"`Iterator::find` 是一个函数，它遍历一个迭代器并搜索满足某个条件的第一个值。"
+"如果没有值满足条件，它返回 `None`。它的签名如下："
 
 #: src/fn/closures/closure_examples/iter_find.md:12
 msgid ""
 "// `find` takes `&mut self` meaning the caller may be borrowed\n"
 "    // and modified, but not consumed.\n"
 msgstr ""
+"// `find` 接受 `&mut self`，意味着调用者可能被借用\n"
+"    // 和修改，但不会被消耗。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:15
 msgid ""
@@ -5867,56 +6020,63 @@ msgid ""
 "        // modified, not consumed. `&Self::Item` states it takes\n"
 "        // arguments to the closure by reference.\n"
 msgstr ""
+"// `FnMut` 意味着任何捕获的变量最多可以被修改，而不是被消耗。\n"
+"        // `&Self::Item` 表示它通过引用将参数传递给闭包。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:27
 msgid "// `iter()` for vecs yields `&i32`.\n"
-msgstr ""
+msgstr "// 对 vec 使用 `iter()` 产生 `&i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:29
 msgid "// `into_iter()` for vecs yields `i32`.\n"
-msgstr ""
+msgstr "// 对 vec 使用 `into_iter()` 产生 `i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:32
 msgid ""
 "// `iter()` for vecs yields `&i32`, and we want to reference one of its\n"
 "    // items, so we have to destructure `&&i32` to `i32`\n"
 msgstr ""
+"// 对 vec 使用 `iter()` 产生 `&i32`，我们想要引用其中的一个\n"
+"    // 项，所以我们必须将 `&&i32` 解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:34
 msgid "\"Find 2 in vec1: {:?}\""
-msgstr ""
+msgstr "\"在 vec1 中查找 2：{:?}\""
 
 #: src/fn/closures/closure_examples/iter_find.md:35
 msgid ""
 "// `into_iter()` for vecs yields `i32`, and we want to reference one of\n"
 "    // its items, so we have to destructure `&i32` to `i32`\n"
 msgstr ""
+"// 对 vec 使用 `into_iter()` 产生 `i32`，我们想要引用其中的\n"
+"    // 一个项，所以我们必须将 `&i32` 解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:37
 msgid "\"Find 2 in vec2: {:?}\""
-msgstr ""
+msgstr "\"在 vec2 中查找 2：{:?}\""
 
 #: src/fn/closures/closure_examples/iter_find.md:42
 msgid "// `iter()` for arrays yields `&&i32`\n"
-msgstr ""
+msgstr "// 对数组使用 `iter()` 产生 `&&i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:43
 msgid "\"Find 2 in array1: {:?}\""
-msgstr ""
+msgstr "\"在 array1 中查找 2：{:?}\""
 
 #: src/fn/closures/closure_examples/iter_find.md:44
 msgid "// `into_iter()` for arrays yields `&i32`\n"
-msgstr ""
+msgstr "// 对数组使用 `into_iter()` 产生 `&i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:45
 msgid "\"Find 2 in array2: {:?}\""
-msgstr ""
+msgstr "\"在 array2 中查找 2：{:?}\""
 
 #: src/fn/closures/closure_examples/iter_find.md:49
 msgid ""
 "`Iterator::find` gives you a reference to the item. But if you want the "
 "_index_ of the item, use `Iterator::position`."
 msgstr ""
+"`Iterator::find` 给你一个项的引用。但如果你想要项的**索引**，使用 `Iterator::position`。"
 
 #: src/fn/closures/closure_examples/iter_find.md:56
 msgid ""
@@ -5924,6 +6084,8 @@ msgid ""
 "reference, so\n"
 "    // we have to destructure `&i32` to `i32`\n"
 msgstr ""
+"// 对 vec 使用 `iter()` 产生 `&i32`，而 `position()` 不接受引用，所以\n"
+"    // 我们必须将 `&i32` 解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:61
 msgid ""
@@ -5931,30 +6093,40 @@ msgid ""
 "reference, so\n"
 "    // we do not have to destructure    \n"
 msgstr ""
+"// 对 vec 使用 `into_iter()` 产生 `i32`，而 `position()` 不接受引用，所以\n"
+"    // 我们不需要解构\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:70
 msgid ""
 "[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.find)"
 msgstr ""
+"[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find)"
 
 #: src/fn/closures/closure_examples/iter_find.md:72
 msgid ""
 "[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.find_map)"
 msgstr ""
+"[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.find_map)"
 
 #: src/fn/closures/closure_examples/iter_find.md:74
 msgid ""
 "[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.position)"
 msgstr ""
+"[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.position)"
 
 #: src/fn/closures/closure_examples/iter_find.md:76
 msgid ""
 "[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.rposition)"
 msgstr ""
+"[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
+"Iterator.html#method.rposition)"
 
 #: src/fn/hof.md:3
 msgid ""
@@ -5962,60 +6134,63 @@ msgid ""
 "or more functions and/or produce a more useful function. HOFs and lazy "
 "iterators give Rust its functional flavor."
 msgstr ""
+"Rust 提供了高阶函数（Higher Order Functions, HOF）。这些函数接受一个或多个函数作为参数，并且/或者产生一个更有用的函数。HOF 和惰性迭代器赋予了 Rust 函数式编程的风格。"
 
 #: src/fn/hof.md:13
 msgid "\"Find the sum of all the numbers with odd squares under 1000\""
-msgstr ""
+msgstr "\"找出所有平方为奇数且小于 1000 的数字之和\""
 
 #: src/fn/hof.md:16
 msgid ""
 "// Imperative approach\n"
 "    // Declare accumulator variable\n"
 msgstr ""
+"// 命令式方法\n"
+"    // 声明累加器变量\n"
 
 #: src/fn/hof.md:19
 msgid "// Iterate: 0, 1, 2, ... to infinity\n"
-msgstr ""
+msgstr "// 迭代：0, 1, 2, ... 直到无穷大\n"
 
 #: src/fn/hof.md:21
 msgid "// Square the number\n"
-msgstr ""
+msgstr "// 对数字求平方\n"
 
 #: src/fn/hof.md:25
 msgid "// Break loop if exceeded the upper limit\n"
-msgstr ""
+msgstr "// 如果超过上限则跳出循环\n"
 
 #: src/fn/hof.md:28
 msgid "// Accumulate value, if it's odd\n"
-msgstr ""
+msgstr "// 如果是奇数，则累加值\n"
 
 #: src/fn/hof.md:32
 msgid "\"imperative style: {}\""
-msgstr ""
+msgstr "\"命令式风格：{}\""
 
 #: src/fn/hof.md:34
 msgid "// Functional approach\n"
-msgstr ""
+msgstr "// 函数式方法\n"
 
 #: src/fn/hof.md:36
 msgid "// All natural numbers squared\n"
-msgstr ""
+msgstr "// 所有自然数的平方\n"
 
 #: src/fn/hof.md:37
 msgid "// Below upper limit\n"
-msgstr ""
+msgstr "// 低于上限\n"
 
 #: src/fn/hof.md:38
 msgid "// That are odd\n"
-msgstr ""
+msgstr "// 是奇数\n"
 
 #: src/fn/hof.md:39
 msgid "// Sum them\n"
-msgstr ""
+msgstr "// 求和\n"
 
 #: src/fn/hof.md:40
 msgid "\"functional style: {}\""
-msgstr ""
+msgstr "\"函数式风格：{}\""
 
 #: src/fn/hof.md:44
 msgid ""
@@ -6023,16 +6198,19 @@ msgid ""
 "[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) implement "
 "their fair share of HOFs."
 msgstr ""
+"[Option](https://doc.rust-lang.org/core/option/enum.Option.html) 和 "
+"[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) 实现了相当多的高阶函数。"
 
 #: src/fn/diverging.md:3
 msgid ""
 "Diverging functions never return. They are marked using `!`, which is an "
 "empty type."
 msgstr ""
+"发散函数永不返回。它们使用 `!` 标记，这是一个空类型。"
 
 #: src/fn/diverging.md:7 src/fn/diverging.md:35
 msgid "\"This call never returns.\""
-msgstr ""
+msgstr "\"这个调用永不返回。\""
 
 #: src/fn/diverging.md:11
 msgid ""
@@ -6040,26 +6218,29 @@ msgid ""
 "the set of all possible values this type can have is empty. Note that, it is "
 "different from the `()` type, which has exactly one possible value."
 msgstr ""
+"与所有其他类型相反，这个类型不能被实例化，因为这个类型可能拥有的所有可能值的集合是空的。注意，它与 `()` 类型不同，后者恰好有一个可能的值。"
 
 #: src/fn/diverging.md:15
 msgid ""
 "For example, this function returns as usual, although there is no information "
 "in the return value."
 msgstr ""
+"例如，这个函数像往常一样返回，尽管返回值中没有信息。"
 
 #: src/fn/diverging.md:25
 msgid "\"This function returns and you can see this line.\""
-msgstr ""
+msgstr "\"这个函数返回，你可以看到这一行。\""
 
 #: src/fn/diverging.md:29
 msgid ""
 "As opposed to this function, which will never return the control back to the "
 "caller."
 msgstr ""
+"与之相对的是这个函数，它永远不会将控制权返回给调用者。"
 
 #: src/fn/diverging.md:36
 msgid "\"You will never see this line!\""
-msgstr ""
+msgstr "\"你永远不会看到这一行！\""
 
 #: src/fn/diverging.md:40
 msgid ""
@@ -6069,16 +6250,19 @@ msgid ""
 "required, such as in match branches. This flexibility allows us to write code "
 "like this:"
 msgstr ""
+"虽然这看起来像是一个抽象的概念，但它实际上非常有用且经常派上用场。这种类型的主要优势是它可以被转换为任何其他类型，这使得它在需要精确类型的情况下非常灵活，比如在 match 分支中。这种灵活性允许我们编写如下代码："
 
 #: src/fn/diverging.md:50
 msgid ""
 "// Notice that the return type of this match expression must be u32\n"
 "            // because of the type of the \"addition\" variable.\n"
 msgstr ""
+"// 注意这个 match 表达式的返回类型必须是 u32\n"
+"            // 因为 \"addition\" 变量的类型。\n"
 
 #: src/fn/diverging.md:53
 msgid "// The \"i\" variable is of type u32, which is perfectly fine.\n"
-msgstr ""
+msgstr "// \"i\" 变量的类型是 u32，这完全没问题。\n"
 
 #: src/fn/diverging.md:55
 msgid ""
@@ -6088,16 +6272,20 @@ msgid ""
 "                // does not violate the type requirements of the match "
 "expression.\n"
 msgstr ""
+"// 另一方面，\"continue\" 表达式不返回\n"
+"                // u32，但这仍然可以，因为它永远不会返回，因此\n"
+"                // 不违反 match 表达式的类型要求。\n"
 
 #: src/fn/diverging.md:64
 msgid "\"Sum of odd numbers up to 9 (excluding): {}\""
-msgstr ""
+msgstr "\"9 以下（不包括 9）的奇数之和：{}\""
 
 #: src/fn/diverging.md:68
 msgid ""
 "It is also the return type of functions that loop forever (e.g. `loop {}`) "
 "like network servers or functions that terminate the process (e.g. `exit()`)."
 msgstr ""
+"它也是永远循环的函数（例如 `loop {}`）的返回类型，比如网络服务器或终止进程的函数（例如 `exit()`）。"
 
 #: src/mod.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2712,7 +2712,7 @@ msgid ""
 "The `enum` keyword allows the creation of a type which may be one of a few "
 "different variants. Any variant which is valid as a `struct` is also valid in "
 "an `enum`."
-msgstr ""
+msgstr "`enum` 关键字允许创建一个可能是几个不同变体之一的类型。任何作为 `struct` 有效的变体在 `enum` 中也是有效的。"
 
 #: src/custom_types/enum.md:8
 msgid ""
@@ -2721,105 +2721,112 @@ msgid ""
 "// `PageLoad != PageUnload` and `KeyPress(char) != Paste(String)`.\n"
 "// Each is different and independent.\n"
 msgstr ""
+"// 创建一个 `enum` 来分类网页事件。注意名称和类型信息如何一起指定变体：\n"
+"// `PageLoad != PageUnload` 且 `KeyPress(char) != Paste(String)`。\n"
+"// 每个都是不同且独立的。\n"
 
 #: src/custom_types/enum.md:13
 msgid "// An `enum` variant may either be `unit-like`,\n"
-msgstr ""
+msgstr "// 一个 `enum` 变体可以是 `unit-like`（类单元结构体），\n"
 
 #: src/custom_types/enum.md:16
 msgid "// like tuple structs,\n"
-msgstr ""
+msgstr "// 像元组结构体，\n"
 
 #: src/custom_types/enum.md:19
 msgid "// or c-like structures.\n"
-msgstr ""
+msgstr "// 或者像 C 语言风格的结构体。\n"
 
 #: src/custom_types/enum.md:22
 msgid ""
 "// A function which takes a `WebEvent` enum as an argument and\n"
 "// returns nothing.\n"
 msgstr ""
+"// 一个接受 `WebEvent` 枚举作为参数并且\n"
+"// 不返回任何值的函数。\n"
 
 #: src/custom_types/enum.md:27
 msgid "\"page loaded\""
-msgstr ""
+msgstr "\"页面已加载\""
 
 #: src/custom_types/enum.md:28
 msgid "\"page unloaded\""
-msgstr ""
+msgstr "\"页面已卸载\""
 
 #: src/custom_types/enum.md:29
 msgid "// Destructure `c` from inside the `enum` variant.\n"
-msgstr ""
+msgstr "// 从 `enum` 变体内部解构 `c`。\n"
 
 #: src/custom_types/enum.md:30
 msgid "\"pressed '{}'.\""
-msgstr ""
+msgstr "\"按下了 '{}'。\""
 
 #: src/custom_types/enum.md:31
 msgid "\"pasted \\\"{}\\\".\""
-msgstr ""
+msgstr "\"粘贴了 \\\"{}\\\"。\""
 
 #: src/custom_types/enum.md:32
 msgid "// Destructure `Click` into `x` and `y`.\n"
-msgstr ""
+msgstr "// 将 `Click` 解构为 `x` 和 `y`。\n"
 
 #: src/custom_types/enum.md:34
 msgid "\"clicked at x={}, y={}.\""
-msgstr ""
+msgstr "\"点击了 x={}, y={}。\""
 
 #: src/custom_types/enum.md:40
 msgid "'x'"
-msgstr ""
+msgstr "'x'"
 
 #: src/custom_types/enum.md:41
 msgid "// `to_owned()` creates an owned `String` from a string slice.\n"
-msgstr ""
+msgstr "// `to_owned()` 从字符串切片创建一个有所有权的 `String`。\n"
 
 #: src/custom_types/enum.md:42
 msgid "\"my text\""
-msgstr ""
+msgstr "\"我的文本\""
 
 #: src/custom_types/enum.md:56
 msgid "Type aliases"
-msgstr ""
+msgstr "类型别名"
 
 #: src/custom_types/enum.md:58
 msgid ""
 "If you use a type alias, you can refer to each enum variant via its alias. "
 "This might be useful if the enum's name is too long or too generic, and you "
 "want to rename it."
-msgstr ""
+msgstr "如果你使用类型别名，你可以通过别名引用每个枚举变体。如果枚举的名称太长或太通用，而你想重命名它时，这可能会很有用。"
 
 #: src/custom_types/enum.md:67
 msgid "// Creates a type alias\n"
-msgstr ""
+msgstr "// 创建一个类型别名\n"
 
 #: src/custom_types/enum.md:72
 msgid ""
 "// We can refer to each variant via its alias, not its long and inconvenient\n"
 "    // name.\n"
 msgstr ""
+"// 我们可以通过别名引用每个变体，而不是它的又长又不方便的\n"
+"    // 名称。\n"
 
 #: src/custom_types/enum.md:78
 msgid ""
 "The most common place you'll see this is in `impl` blocks using the `Self` "
 "alias."
-msgstr ""
+msgstr "你最常见到这种用法的地方是在使用 `Self` 别名的 `impl` 块中。"
 
 #: src/custom_types/enum.md:96
 msgid ""
 "To learn more about enums and type aliases, you can read the [stabilization "
 "report](https://github.com/rust-lang/rust/pull/61682/#issuecomment-502472847) "
 "from when this feature was stabilized into Rust."
-msgstr ""
+msgstr "要了解更多关于枚举和类型别名的信息，你可以阅读这个特性被稳定到 Rust 时的[稳定化报告](https://github.com/rust-lang/rust/pull/61682/#issuecomment-502472847)。"
 
 #: src/custom_types/enum.md:102
 msgid ""
 "[`match`](../flow_control/match.md), [`fn`](../fn.md), and [`String`](../std/"
 "str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
 "rfcs/2338-type-alias-enum-variants.html)"
-msgstr ""
+msgstr "[`match`](../flow_control/match.md)、[`fn`](../fn.md) 和 [`String`](../std/str.md)、[\"类型别名枚举变体\" RFC](https://rust-lang.github.io/rfcs/2338-type-alias-enum-variants.html)"
 
 #: src/custom_types/enum/enum_use.md:3
 msgid "The `use` declaration can be used so manual scoping isn't needed:"

--- a/po/zh.po
+++ b/po/zh.po
@@ -4994,14 +4994,14 @@ msgstr ""
 
 #: src/flow_control/let_else.md:4
 msgid "🛈 stable since: rust 1.65"
-msgstr "🛈 自 rust 1.65 版本起稳定"
+msgstr "🛈 自 Rust 1.65 版本起稳定"
 
 #: src/flow_control/let_else.md:6
 msgid ""
 "🛈 you can target specific edition by compiling like this `rustc --"
 "edition=2021 main.rs`"
 msgstr ""
-"🛈 你可以通过这样编译来指定特定版本 `rustc --edition=2021 main.rs`"
+"🛈 你可以通过这种方式编译来指定特定版本：`rustc --edition=2021 main.rs`"
 
 #: src/flow_control/let_else.md:10
 msgid ""
@@ -5009,7 +5009,8 @@ msgid ""
 "surrounding scope like a normal `let`, or else diverge (e.g. `break`, "
 "`return`, `panic!`) when the pattern doesn't match."
 msgstr ""
-"使用 `let`\\-`else`，可反驳模式可以像普通的 `let` 一样匹配并绑定周围作用域中的变量，或者在模式不匹配时发散（例如 `break`、`return`、`panic!`）。"
+"`let`-`else` 语法允许可能失败的模式匹配像普通 `let` 一样绑定变量到当前作用域，"
+"或在匹配失败时执行中断操作（如 `break`、`return`、`panic!`）。"
 
 #: src/flow_control/let_else.md:18 src/flow_control/let_else.md:41
 #: src/std/str.md:41
@@ -5038,14 +5039,15 @@ msgid ""
 "`match` or `if let`\\-`else` expressions. You could previously approximate "
 "these patterns with an unfortunate bit of repetition and an outer `let`:"
 msgstr ""
-"名称绑定的作用域是使其与 `match` 或 `if let`\\-`else` 表达式不同的主要原因。你之前可以通过一些冗余的重复和外部的 `let` 来近似这些模式："
+"名称绑定的作用域是使其区别于 `match` 或 `if let`-`else` 表达式的主要特点。"
+"在此之前，你可能需要通过一些冗余的重复和外部 `let` 来近似实现这些模式："
 
 #: src/flow_control/let_else.md:59
 msgid ""
 "[option](../std/option.md), [match](./match.md), [if let](./if_let.md) and "
 "the [let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)."
 msgstr ""
-"[option](../std/option.md)，[match](./match.md)，[if let](./if_let.md) 和 "
+"[Option](../std/option.md)、[match](./match.md)、[if let](./if_let.md) 和 "
 "[let-else RFC](https://rust-lang.github.io/rfcs/3137-let-else.html)。"
 
 #: src/flow_control/while_let.md:3
@@ -5053,15 +5055,16 @@ msgid ""
 "Similar to `if let`, `while let` can make awkward `match` sequences more "
 "tolerable. Consider the following sequence that increments `i`:"
 msgstr ""
-"与 `if let` 类似，`while let` 可以使别扭的 `match` 序列更易于处理。考虑下面这个递增 `i` 的序列："
+"与 `if let` 类似，`while let` 可以简化繁琐的 `match` 序列。"
+"让我们来看一个递增 `i` 的例子："
 
 #: src/flow_control/while_let.md:9
 msgid "// Repeatedly try this test.\n"
-msgstr "// 重复尝试这个测试。\n"
+msgstr "// 重复执行此测试。\n"
 
 #: src/flow_control/while_let.md:13
 msgid "// If `optional` destructures, evaluate the block.\n"
-msgstr "// 如果 `optional` 解构成功，就执行语句块。\n"
+msgstr "// 如果 `optional` 解构成功，则执行代码块。\n"
 
 #: src/flow_control/while_let.md:16 src/flow_control/while_let.md:42
 msgid "\"Greater than 9, quit!\""
@@ -5081,41 +5084,33 @@ msgstr "// 当解构失败时退出循环：\n"
 
 #: src/flow_control/while_let.md:26
 msgid "// ^ Why should this be required? There must be a better way!\n"
-msgstr "// ^ 为什么这是必需的？一定有更好的方法！\n"
+msgstr "// ^ 为什么需要这样？一定有更好的方法！\n"
 
 #: src/flow_control/while_let.md:31
 msgid "Using `while let` makes this sequence much nicer:"
-msgstr "使用 `while let` 使这个序列更加优雅："
+msgstr "使用 `while let` 可以让这个序列更加简洁："
 
 #: src/flow_control/while_let.md:38
 msgid ""
 "// This reads: \"while `let` destructures `optional` into\n"
 "    // `Some(i)`, evaluate the block (`{}`). Else `break`.\n"
 msgstr ""
-"// 这读作：当 `let` 把 `optional` 解构成 `Some(i)` 时，\n"
-"    // 执行语句块（`{}`）。否则 `break`。\n"
+"// 这段代码的含义是：当 `let` 将 `optional` 解构为 `Some(i)` 时，\n"
+"    // 执行代码块 `{}`，否则 `break`。\n"
 
 #: src/flow_control/while_let.md:48
 msgid ""
 "// ^ Less rightward drift and doesn't require\n"
 "        // explicitly handling the failing case.\n"
 msgstr ""
-
-#: src/flow_control/while_let.md:48
-msgid ""
-"// ^ Less rightward drift and doesn't require\n"
-"        // explicitly handling the failing case.\n"
-msgstr ""
-"// ^ 减少了向右偏移，并且不需要\n"
-"        // 显式处理失败的情况。\n"
+"// ^ 减少了代码缩进右移，无需显式处理失败情况\n"
 
 #: src/flow_control/while_let.md:51
 msgid ""
 "// ^ `if let` had additional optional `else`/`else if`\n"
 "    // clauses. `while let` does not have these.\n"
 msgstr ""
-"// ^ `if let` 有额外的可选 `else`/`else if`\n"
-"    // 子句。`while let` 没有这些。\n"
+"// ^ `if let` 可以有额外的 `else`/`else if` 子句，`while let` 则没有。\n"
 
 #: src/flow_control/while_let.md:58
 msgid ""
@@ -5131,8 +5126,8 @@ msgid ""
 "annotated, just like variables, and, if the function returns a value, the "
 "return type must be specified after an arrow `->`."
 msgstr ""
-"函数使用 `fn` 关键字声明。它的参数需要标注类型，就像变量一样，如果函数返回一个值，"
-"返回类型必须在箭头 `->` 之后指定。"
+"函数使用 `fn` 关键字声明。函数参数需要标注类型，就像变量一样。"
+"如果函数返回值，则必须在箭头 `->` 后指定返回类型。"
 
 #: src/fn.md:7
 msgid ""
@@ -5140,22 +5135,22 @@ msgid ""
 "Alternatively, the `return` statement can be used to return a value earlier "
 "from within the function, even from inside loops or `if` statements."
 msgstr ""
-"函数中的最后一个表达式将被用作返回值。或者，可以使用 `return` 语句从函数内部提前返回一个值，"
-"甚至可以从循环或 `if` 语句内部返回。"
+"函数的最后一个表达式将作为返回值。另外，可以使用 `return` 语句在函数内部提前返回值，"
+"甚至可以在循环或 `if` 语句内部使用。"
 
 #: src/fn.md:11
 msgid "Let's rewrite FizzBuzz using functions!"
-msgstr "让我们用函数重写 FizzBuzz！"
+msgstr "让我们用函数重写 FizzBuzz 吧！"
 
 #: src/fn.md:14
 msgid ""
 "// Unlike C/C++, there's no restriction on the order of function definitions\n"
 msgstr ""
-"// 与 C/C++ 不同，函数定义的顺序没有限制\n"
+"// 与 C/C++ 不同，Rust 中函数定义的顺序没有限制\n"
 
 #: src/fn.md:16
 msgid "// We can use this function here, and define it somewhere later\n"
-msgstr "// 我们可以在这里使用这个函数，并在稍后的某个地方定义它\n"
+msgstr "// 我们可以在这里使用函数，并在稍后的某处定义它\n"
 
 #: src/fn.md:19
 msgid "// Function that returns a boolean value\n"
@@ -5167,14 +5162,14 @@ msgstr "// 特殊情况，提前返回\n"
 
 #: src/fn.md:27
 msgid "// This is an expression, the `return` keyword is not necessary here\n"
-msgstr "// 这是一个表达式，这里不需要 `return` 关键字\n"
+msgstr "// 这是一个表达式，此处不需要 `return` 关键字\n"
 
 #: src/fn.md:30
 msgid ""
 "// Functions that \"don't\" return a value, actually return the unit type "
 "`()`\n"
 msgstr ""
-"// \"不\"返回值的函数实际上返回单元类型 `()`\n"
+"// \"无返回值\"的函数实际上返回单元类型 `()`\n"
 
 #: src/fn.md:43
 msgid ""
@@ -5194,8 +5189,8 @@ msgid ""
 "are defined on a type generally, while methods are associated functions that "
 "are called on a particular instance of a type."
 msgstr ""
-"有些函数与特定类型相关联。这些函数有两种形式：关联函数和方法。关联函数是在类型上定义的函数，"
-"而方法是在类型的特定实例上调用的关联函数。"
+"某些函数与特定类型相关联。这些函数有两种形式：关联函数和方法。"
+"关联函数是在类型上定义的函数，而方法是在类型的特定实例上调用的关联函数。"
 
 #: src/fn/methods.md:13
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -5197,7 +5197,7 @@ msgid ""
 "// Implementation block, all `Point` associated functions & methods go in "
 "here\n"
 msgstr ""
-"// 实现块，所有 `Point` 的关联函数和方法都在这里\n"
+"// 实现块，所有 `Point` 的关联函数和方法都在此处定义\n"
 
 #: src/fn/methods.md:16
 msgid ""
@@ -5215,7 +5215,7 @@ msgstr ""
 
 #: src/fn/methods.md:25
 msgid "// Another associated function, taking two arguments:\n"
-msgstr "// 另一个关联函数，接受两个参数：\n"
+msgstr "// 另一个接受两个参数的关联函数：\n"
 
 #: src/fn/methods.md:37
 msgid ""
@@ -5243,19 +5243,19 @@ msgid ""
 "// This method requires the caller object to be mutable\n"
 "    // `&mut self` desugars to `self: &mut Self`\n"
 msgstr ""
-"// 这个方法要求调用者对象是可变的\n"
+"// 这个方法要求调用对象是可变的\n"
 "    // `&mut self` 是 `self: &mut Self` 的语法糖\n"
 
 #: src/fn/methods.md:67
 msgid "// `Pair` owns resources: two heap allocated integers\n"
-msgstr "// `Pair` 持有资源：两个堆分配的整数\n"
+msgstr "// `Pair` 拥有两个堆分配的整数资源\n"
 
 #: src/fn/methods.md:72
 msgid ""
 "// This method \"consumes\" the resources of the caller object\n"
 "    // `self` desugars to `self: Self`\n"
 msgstr ""
-"// 这个方法"消耗"调用者对象的资源\n"
+"// 这个方法会"消耗"调用对象的资源\n"
 "    // `self` 是 `self: Self` 的语法糖\n"
 
 #: src/fn/methods.md:75
@@ -5264,7 +5264,7 @@ msgstr "// 解构 `self`\n"
 
 #: src/fn/methods.md:78
 msgid "\"Destroying Pair({}, {})\""
-msgstr "\"销毁 Pair({}, {})\""
+msgstr "\"正在销毁 Pair({}, {})\""
 
 #: src/fn/methods.md:80
 msgid "// `first` and `second` go out of scope and get freed\n"
@@ -5281,8 +5281,8 @@ msgid ""
 "    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
 msgstr ""
 "// 使用点运算符调用方法\n"
-"    // 注意，第一个参数 `&self` 是隐式传递的，即\n"
-"    // `rectangle.perimeter()` === `Rectangle::perimeter(&rectangle)`\n"
+"    // 注意，第一个参数 `&self` 是隐式传递的\n"
+"    // 即 `rectangle.perimeter()` 等同于 `Rectangle::perimeter(&rectangle)`\n"
 
 #: src/fn/methods.md:94
 msgid "\"Rectangle perimeter: {}\""
@@ -5299,13 +5299,13 @@ msgid ""
 "    //rectangle.translate(1.0, 0.0);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 报错！`rectangle` 是不可变的，但这个方法需要一个可变对象\n"
+"// 错误！`rectangle` 是不可变的，但这个方法需要可变对象\n"
 "    //rectangle.translate(1.0, 0.0);\n"
-"    // TODO ^ 尝试取消注释这一行\n"
+"    // TODO ^ 尝试取消这行的注释\n"
 
 #: src/fn/methods.md:107
 msgid "// Okay! Mutable objects can call mutable methods\n"
-msgstr "// 没问题！可变对象可以调用可变方法\n"
+msgstr "// 正确！可变对象可以调用可变方法\n"
 
 #: src/fn/methods.md:114
 msgid ""
@@ -5321,8 +5321,7 @@ msgstr ""
 msgid ""
 "Closures are functions that can capture the enclosing environment. For "
 "example, a closure that captures the `x` variable:"
-msgstr ""
-"闭包是可以捕获周围环境的函数。例如，一个捕获 `x` 变量的闭包："
+msgstr "闭包是可以捕获周围环境的函数。例如，下面是一个捕获变量 `x` 的闭包："
 
 #: src/fn/closures.md:10
 msgid ""
@@ -5331,12 +5330,11 @@ msgid ""
 "both input and return types _can_ be inferred and input variable names _must_ "
 "be specified."
 msgstr ""
-"闭包的语法和功能使它们非常适合即时使用。调用闭包与调用函数完全相同。然而，"
-"输入和返回类型**可以**被推断，而输入变量名**必须**被指定。"
+"闭包的语法和功能使其非常适合即时使用。调用闭包与调用函数完全相同。不过，闭包的输入和返回类型**可以**被推断，而输入变量名**必须**指定。"
 
 #: src/fn/closures.md:15
 msgid "Other characteristics of closures include:"
-msgstr "闭包的其他特征包括："
+msgstr "闭包的其他特点包括："
 
 #: src/fn/closures.md:16
 msgid "using `||` instead of `()` around input variables."
@@ -5346,12 +5344,11 @@ msgstr "使用 `||` 而不是 `()` 来包围输入变量。"
 msgid ""
 "optional body delimitation (`{}`) for a single line expression (mandatory "
 "otherwise)."
-msgstr ""
-"对于单行表达式，可以省略函数体定界符（`{}`）（其他情况是必需的）。"
+msgstr "单行表达式可省略函数体定界符（`{}`），其他情况则必须使用"
 
 #: src/fn/closures.md:18
 msgid "the ability to capture the outer environment variables."
-msgstr "能够捕获外部环境的变量。"
+msgstr "能够捕获外部环境的变量"
 
 #: src/fn/closures.md:24
 msgid ""
@@ -5361,10 +5358,10 @@ msgid ""
 "compiler\n"
 "    // suggests that we define a closure instead.\n"
 msgstr ""
-"// 常规函数不能引用封闭环境中的变量\n"
+"// 常规函数无法引用外部环境的变量\n"
 "    //fn function(i: i32) -> i32 { i + outer_var }\n"
-"    // TODO：取消上面这行的注释，看看编译器错误。编译器\n"
-"    // 建议我们定义一个闭包来代替。\n"
+"    // TODO：取消上面这行的注释，查看编译器错误\n"
+"    // 编译器会建议我们定义一个闭包来替代\n"
 
 #: src/fn/closures.md:29
 msgid ""
@@ -5373,22 +5370,22 @@ msgid ""
 "    // as are the `{}` wrapping the body. These nameless functions\n"
 "    // are assigned to appropriately named variables.\n"
 msgstr ""
-"// 闭包是匿名的，这里我们将它们绑定到引用。\n"
+"// 闭包是匿名的，这里我们将它们绑定到引用\n"
 "    // 注解与函数注解相同，但是可选的\n"
-"    // 包裹函数体的 `{}` 也是可选的。这些无名函数\n"
-"    // 被赋值给适当命名的变量。\n"
+"    // 包裹函数体的 `{}` 也是可选的\n"
+"    // 这些无名函数被赋值给适当命名的变量\n"
 
 #: src/fn/closures.md:36
 msgid "// Call the closures.\n"
-msgstr "// 调用闭包。\n"
+msgstr "// 调用闭包\n"
 
 #: src/fn/closures.md:37
 msgid "\"closure_annotated: {}\""
-msgstr "\"closure_annotated: {}\""
+msgstr "\"closure_annotated：{}\""
 
 #: src/fn/closures.md:38
 msgid "\"closure_inferred: {}\""
-msgstr "\"closure_inferred: {}\""
+msgstr "\"closure_inferred：{}\""
 
 #: src/fn/closures.md:39
 msgid ""
@@ -5398,17 +5395,18 @@ msgid ""
 "closure_inferred(42i64));\n"
 "    // TODO: uncomment the line above and see the compiler error.\n"
 msgstr ""
-"// 一旦闭包的类型被推断出来，就不能再用另一种类型进行推断。\n"
-"    //println!(\"不能用另一种类型重用 closure_inferred：{}\", "
+"// 闭包类型一旦被推断，就不能再用其他类型重新推断。\n"
+"    //println!(\"不能用其他类型重用 closure_inferred：{}\", "
 "closure_inferred(42i64));\n"
+"    // TODO：取消上面这行的注释，观察编译器错误。\n"
 
 #: src/fn/closures.md:43
 msgid ""
 "// A closure taking no arguments which returns an `i32`.\n"
 "    // The return type is inferred.\n"
 msgstr ""
-"// 一个不接受参数并返回 `i32` 的闭包。\n"
-"    // 返回类型是推断出来的。\n"
+"// 一个无参数并返回 `i32` 的闭包。\n"
+"    // 返回类型是推断的。\n"
 
 #: src/fn/closures.md:46
 msgid "\"closure returning one: {}\""
@@ -5421,7 +5419,7 @@ msgid ""
 "flexibly adapt to the use case, sometimes moving and sometimes borrowing. "
 "Closures can capture variables:"
 msgstr ""
-"闭包本质上是灵活的，它们会根据功能需求自动适应，无需注解就能正常工作。这种灵活性使得捕获可以根据使用场景进行调整，有时是移动，有时是借用。闭包可以通过以下方式捕获变量："
+"闭包本质上很灵活，无需注解就能根据功能需求自动适应。这使得捕获可以灵活地适应不同场景，有时移动，有时借用。闭包可以通过以下方式捕获变量："
 
 #: src/fn/closures/capture.md:8
 msgid "by reference: `&T`"
@@ -5439,7 +5437,7 @@ msgstr "通过值：`T`"
 msgid ""
 "They preferentially capture variables by reference and only go lower when "
 "required."
-msgstr "它们优先通过引用捕获变量，只有在必要时才会使用更低级别的捕获方式。"
+msgstr "闭包优先通过引用捕获变量，仅在必要时才使用更底部的的捕获方式。"
 
 #: src/fn/closures/capture.md:19
 msgid "\"green\""
@@ -5455,12 +5453,12 @@ msgid ""
 "doesn't\n"
 "    // impose anything more restrictive.\n"
 msgstr ""
-"// 一个打印 `color` 的闭包，它立即借用（`&`）`color` 并\n"
-"    // 将借用和闭包存储在 `print` 变量中。它将保持\n"
-"    // 借用状态直到 `print` 最后一次被使用。\n"
+"// 打印 `color` 的闭包，立即借用（`&`）`color` 并\n"
+"    // 将借用和闭包存储在 `print` 变量中。借用状态\n"
+"    // 将持续到 `print` 最后一次使用。\n"
 "    //\n"
-"    // `println!` 只需要通过不可变引用传递参数，所以它\n"
-"    // 不会施加任何更严格的限制。\n"
+"    // `println!` 只需要不可变引用参数，所以\n"
+"    // 不会施加更多限制。\n"
 
 #: src/fn/closures/capture.md:27
 msgid "\"`color`: {}\""
@@ -5480,7 +5478,7 @@ msgstr ""
 
 #: src/fn/closures/capture.md:37
 msgid "// A move or reborrow is allowed after the final use of `print`\n"
-msgstr "// 在 `print` 的最后一次使用之后，可以移动或重新借用\n"
+msgstr "// `print` 最后一次使用后，允许移动或重新借用\n"
 
 #: src/fn/closures/capture.md:42
 msgid ""
@@ -5491,12 +5489,12 @@ msgid ""
 "    // A `mut` is required on `inc` because a `&mut` is stored inside. Thus,\n"
 "    // calling the closure mutates `count` which requires a `mut`.\n"
 msgstr ""
-"// 一个用于增加 `count` 的闭包可以接受 `&mut count` 或 `count`\n"
+"// 增加 `count` 的闭包可以接受 `&mut count` 或 `count`，\n"
 "    // 但 `&mut count` 限制更少，所以选择它。立即\n"
 "    // 借用 `count`。\n"
 "    //\n"
-"    // `inc` 需要 `mut` 因为内部存储了一个 `&mut`。因此，\n"
-"    // 调用闭包会改变 `count`，这需要一个 `mut`。\n"
+"    // `inc` 需要 `mut` 因为内部存储了 `&mut`。因此，\n"
+"    // 调用闭包会修改 `count`，这需要 `mut`。\n"
 
 #: src/fn/closures/capture.md:50
 msgid "\"`count`: {}\""
@@ -5513,22 +5511,22 @@ msgid ""
 "    // let _reborrow = &count; \n"
 "    // ^ TODO: try uncommenting this line.\n"
 msgstr ""
-"// 闭包仍然可变地借用 `count`，因为它稍后会被调用。\n"
+"// 闭包仍然可变借用 `count`，因为它稍后会被调用。\n"
 "    // 尝试重新借用会导致错误。\n"
 "    // let _reborrow = &count; \n"
-"    // ^ TODO：尝试取消注释这一行。\n"
+"    // ^ TODO：尝试取消注释这行。\n"
 
 #: src/fn/closures/capture.md:62
 msgid ""
 "// The closure no longer needs to borrow `&mut count`. Therefore, it is\n"
 "    // possible to reborrow without an error\n"
 msgstr ""
-"// 闭包不再需要借用 `&mut count`。因此，可以\n"
-"    // 在没有错误的情况下重新借用\n"
+"// 闭包不再需要借用 `&mut count`。因此，\n"
+"    // 可以在没有错误的情况下重新借用\n"
 
 #: src/fn/closures/capture.md:67
 msgid "// A non-copy type.\n"
-msgstr "// 一个不可复制类型。\n"
+msgstr "// 不可复制类型。\n"
 
 #: src/fn/closures/capture.md:70
 msgid ""
@@ -5539,8 +5537,7 @@ msgid ""
 msgstr ""
 "// `mem::drop` 需要 `T`，所以这里必须通过值获取。可复制类型\n"
 "    // 会被复制到闭包中，原始值保持不变。\n"
-"    // 不可复制类型必须移动，所以 `movable` 立即移动到\n"
-"    // 闭包中。\n"
+"    // 不可复制类型必须移动，所以 `movable` 立即移动到闭包中。\n"
 
 #: src/fn/closures/capture.md:75
 msgid "\"`movable`: {:?}\""
@@ -5548,7 +5545,7 @@ msgstr "\"`movable`: {:?}\""
 
 #: src/fn/closures/capture.md:79
 msgid "// `consume` consumes the variable so this can only be called once.\n"
-msgstr "// `consume` 消耗了变量，所以这只能被调用一次。\n"
+msgstr "// `consume` 消耗了变量，所以只能调用一次。\n"
 
 #: src/fn/closures/capture.md:81
 msgid ""
@@ -5556,7 +5553,7 @@ msgid ""
 "    // ^ TODO: Try uncommenting this line.\n"
 msgstr ""
 "// consume();\n"
-"    // ^ TODO：尝试取消注释这一行。\n"
+"    // ^ TODO：尝试取消注释这行。\n"
 
 #: src/fn/closures/capture.md:86
 msgid ""
@@ -5566,7 +5563,7 @@ msgstr "在竖线前使用 `move` 强制闭包获取捕获变量的所有权："
 
 #: src/fn/closures/capture.md:91
 msgid "// `Vec` has non-copy semantics.\n"
-msgstr "// `Vec` 具有非复制语义。\n"
+msgstr "// `Vec` 是非复制语义。\n"
 
 #: src/fn/closures/capture.md:99
 msgid ""
@@ -5577,7 +5574,7 @@ msgid ""
 msgstr ""
 "// println!(\"vec 中有 {} 个元素\", haystack.len());\n"
 "    // ^ 取消上面这行的注释会导致编译时错误\n"
-"    // 因为借用检查器不允许在变量被移动后重新使用。\n"
+"    // 因为借用检查器不允许在变量被移动后重用。\n"
 "    \n"
 
 #: src/fn/closures/capture.md:104
@@ -5586,17 +5583,17 @@ msgid ""
 "    // to borrow _haystack_ variable immutably, hence _haystack_ is still\n"
 "    // available and uncommenting above line will not cause an error.\n"
 msgstr ""
-"// 从闭包的签名中移除 `move` 将导致闭包\n"
-"    // 不可变地借用 _haystack_ 变量，因此 _haystack_ 仍然\n"
-"    // 可用，取消注释上面的行不会导致错误。\n"
+"// 从闭包签名中移除 `move` 将导致闭包\n"
+"    // 不可变借用 _haystack_ 变量，因此 _haystack_ 仍可用，\n"
+"    // 取消注释上面的行不会导致错误。\n"
 
 #: src/fn/closures/capture.md:112
 msgid ""
 "[`Box`](../../std/box.md) and [`std::mem::drop`](https://doc.rust-lang.org/"
 "std/mem/fn.drop.html)"
 msgstr ""
-"[`Box`](../../std/box.md) 和 [`std::mem::drop`](https://doc.rust-lang.org/"
-"std/mem/fn.drop.html)"
+"[`Box`](../../std/box.md) 和 [`std::mem::drop`]"
+"(https://doc.rust-lang.org/std/mem/fn.drop.html)"
 
 #: src/fn/closures/input_parameters.md:3
 msgid ""
@@ -5607,7 +5604,9 @@ msgid ""
 "closure does with captured value. In order of decreasing restriction, they "
 "are:"
 msgstr ""
-"虽然 Rust 在大多数情况下可以自动选择如何捕获变量而无需类型标注，但在编写函数时不允许这种模糊性。当将闭包作为输入参数时，必须使用以下 `traits` 中的一个来注解闭包的完整类型，这些 traits 由闭包对捕获值的处理方式决定。按限制程度递减的顺序，它们是："
+"Rust 通常能自动选择如何捕获变量，无需类型标注。但在编写函数时，这种模糊性是不允许的。"
+"当将闭包作为输入参数时，必须使用特定的 `trait` 来注解闭包的完整类型。这些 trait "
+"由闭包对捕获值的处理方式决定。按限制程度从高到低排列如下："
 
 #: src/fn/closures/input_parameters.md:10
 msgid "`Fn`: the closure uses the captured value by reference (`&T`)"
@@ -5634,7 +5633,8 @@ msgid ""
 "the closure _may_ capture by `&T`, `&mut T`, or `T`, but the compiler will "
 "ultimately choose based on how the captured variables are used in the closure."
 msgstr ""
-"例如，考虑一个注解为 `FnOnce` 的参数。这指定闭包**可能**通过 `&T`、`&mut T` 或 `T` 进行捕获，但编译器最终会根据捕获变量在闭包中的使用方式来选择。"
+"例如，考虑一个注解为 `FnOnce` 的参数。这表示闭包**可能**通过 `&T`、`&mut T` 或 `T` "
+"进行捕获，但编译器最终会根据捕获变量在闭包中的使用方式来决定。"
 
 #: src/fn/closures/input_parameters.md:22
 msgid ""
@@ -5643,7 +5643,8 @@ msgid ""
 "`Fn`, then capturing variables by `&mut T` or `T` are not allowed. However, "
 "`&T` is allowed."
 msgstr ""
-"这是因为如果可以移动，那么任何类型的借用也应该是可能的。注意反过来并不成立。如果参数被注解为 `Fn`，那么通过 `&mut T` 或 `T` 捕获变量是不允许的。然而，`&T` 是允许的。"
+"这是因为如果可以移动，那么任何类型的借用也应该是可能的。注意反过来并不成立。"
+"如果参数被注解为 `Fn`，那么通过 `&mut T` 或 `T` 捕获变量是不允许的。但 `&T` 是允许的。"
 
 #: src/fn/closures/input_parameters.md:27
 msgid ""
@@ -5656,32 +5657,32 @@ msgid ""
 "// A function which takes a closure as an argument and calls it.\n"
 "// <F> denotes that F is a \"Generic type parameter\"\n"
 msgstr ""
-"// 一个接受闭包作为参数并调用它的函数。\n"
+"// 这个函数接受一个闭包作为参数并调用它\n"
 "// <F> 表示 F 是一个"泛型类型参数"\n"
 
 #: src/fn/closures/input_parameters.md:34
 msgid "// The closure takes no input and returns nothing.\n"
-msgstr "// 这个闭包不接受输入也不返回任何值。\n"
+msgstr "// 这个闭包不接受输入也不返回任何值\n"
 
 #: src/fn/closures/input_parameters.md:36
 msgid "// ^ TODO: Try changing this to `Fn` or `FnMut`.\n"
-msgstr "// ^ TODO：尝试将其改为 `Fn` 或 `FnMut`。\n"
+msgstr "// ^ TODO：试着将其改为 `Fn` 或 `FnMut`\n"
 
 #: src/fn/closures/input_parameters.md:40
 msgid "// A function which takes a closure and returns an `i32`.\n"
-msgstr "// 一个接受闭包并返回 `i32` 的函数。\n"
+msgstr "// 这个函数接受一个闭包并返回 `i32`\n"
 
 #: src/fn/closures/input_parameters.md:43
 msgid "// The closure takes an `i32` and returns an `i32`.\n"
-msgstr "// 这个闭包接受一个 `i32` 并返回一个 `i32`。\n"
+msgstr "// 这个闭包接受一个 `i32` 并返回一个 `i32`\n"
 
 #: src/fn/closures/input_parameters.md:53
 msgid ""
 "// A non-copy type.\n"
 "    // `to_owned` creates owned data from borrowed one\n"
 msgstr ""
-"// 一个非复制类型。\n"
-"    // `to_owned` 从借用的数据创建所有权数据\n"
+"// 一个非复制类型\n"
+"    // `to_owned` 从借用的数据创建拥有所有权的数据\n"
 
 #: src/fn/closures/input_parameters.md:55
 msgid "\"goodbye\""
@@ -5693,47 +5694,47 @@ msgid ""
 "    // `farewell` by value.\n"
 msgstr ""
 "// 捕获两个变量：通过引用捕获 `greeting`，\n"
-"    // 通过值捕获 `farewell`。\n"
+"    // 通过值捕获 `farewell`\n"
 
 #: src/fn/closures/input_parameters.md:60
 msgid "// `greeting` is by reference: requires `Fn`.\n"
-msgstr "// `greeting` 是通过引用：需要 `Fn`。\n"
+msgstr "// `greeting` 是通过引用捕获的：需要 `Fn`\n"
 
 #: src/fn/closures/input_parameters.md:61
 msgid "\"I said {}.\""
-msgstr "\"I said {}.\""
+msgstr "\"我说{}。\""
 
 #: src/fn/closures/input_parameters.md:63
 msgid ""
 "// Mutation forces `farewell` to be captured by\n"
 "        // mutable reference. Now requires `FnMut`.\n"
 msgstr ""
-"// 修改强制 `farewell` 通过可变引用捕获。\n"
-"        // 现在需要 `FnMut`。\n"
+"// 修改强制 `farewell` 通过可变引用捕获\n"
+"        // 现在需要 `FnMut`\n"
 
 #: src/fn/closures/input_parameters.md:65
 msgid "\"!!!\""
-msgstr "\"!!!\""
+msgstr "\"！！！\""
 
 #: src/fn/closures/input_parameters.md:66
 msgid "\"Then I screamed {}.\""
-msgstr "\"Then I screamed {}.\""
+msgstr "\"然后我喊{}。\""
 
 #: src/fn/closures/input_parameters.md:67
 msgid "\"Now I can sleep. zzzzz\""
-msgstr "\"Now I can sleep. zzzzz\""
+msgstr "\"现在我可以睡觉了。呼呼\""
 
 #: src/fn/closures/input_parameters.md:69
 msgid ""
 "// Manually calling drop forces `farewell` to\n"
 "        // be captured by value. Now requires `FnOnce`.\n"
 msgstr ""
-"// 手动调用 drop 强制 `farewell` 通过值捕获。\n"
-"        // 现在需要 `FnOnce`。\n"
+"// 手动调用 drop 强制 `farewell` 通过值捕获\n"
+"        // 现在需要 `FnOnce`\n"
 
 #: src/fn/closures/input_parameters.md:74
 msgid "// Call the function which applies the closure.\n"
-msgstr "// 调用应用闭包的函数。\n"
+msgstr "// 调用应用闭包的函数\n"
 
 #: src/fn/closures/input_parameters.md:77
 msgid "// `double` satisfies `apply_to_3`'s trait bound\n"
@@ -5741,7 +5742,7 @@ msgstr "// `double` 满足 `apply_to_3` 的 trait 约束\n"
 
 #: src/fn/closures/input_parameters.md:80
 msgid "\"3 doubled: {}\""
-msgstr "\"3 doubled: {}\""
+msgstr "\"3 的两倍是：{}\""
 
 #: src/fn/closures/input_parameters.md:86
 msgid ""
@@ -5764,11 +5765,11 @@ msgid ""
 "parameter requires [generics](../../generics.md), which is necessary because "
 "of how they are defined:"
 msgstr ""
-"闭包简洁地从封闭作用域中捕获变量。这会有什么后果吗？当然会有。观察一下如何将闭包作为函数参数使用需要[泛型](../../generics.md)，这是因为它们的定义方式所必需的："
+"闭包能简洁地从外部作用域捕获变量。这会有什么影响吗？当然会有。注意观察如何将闭包作为函数参数使用时需要[泛型](../../generics.md)，这是由于闭包的定义方式所决定的："
 
 #: src/fn/closures/anonymity.md:9
 msgid "// `F` must be generic.\n"
-msgstr "// `F` 必须是泛型。\n"
+msgstr "// `F` 必须是泛型\n"
 
 #: src/fn/closures/anonymity.md:16
 msgid ""
@@ -5778,7 +5779,7 @@ msgid ""
 "unknown type. This type is assigned to the variable which is stored until "
 "calling."
 msgstr ""
-"当定义一个闭包时，编译器会隐式创建一个新的匿名结构来存储内部捕获的变量，同时通过 `traits` 之一：`Fn`、`FnMut` 或 `FnOnce` 为这个未知类型实现功能。这个类型被分配给变量，并存储直到调用。"
+"当定义一个闭包时，编译器会隐式创建一个新的匿名结构来存储内部捕获的变量，同时通过 `Fn`、`FnMut` 或 `FnOnce` 这些 `trait` 之一为这个未知类型实现功能。这个类型被赋给变量并存储，直到被调用。"
 
 #: src/fn/closures/anonymity.md:22
 msgid ""
@@ -5787,7 +5788,7 @@ msgid ""
 "and not be allowed. Thus, bounding by one of the `traits`: `Fn`, `FnMut`, or "
 "`FnOnce` (which it implements) is sufficient to specify its type."
 msgstr ""
-"由于这个新类型是未知类型，在函数中的任何使用都需要泛型。然而，一个无界的类型参数 `<T>` 仍然会是模糊的，不被允许。因此，通过 `traits` 之一：`Fn`、`FnMut` 或 `FnOnce`（它实现的）来约束就足以指定其类型。"
+"由于这个新类型是未知类型，在函数中使用时就需要泛型。然而，一个无界的类型参数 `<T>` 仍然会是模糊的，不被允许。因此，通过 `Fn`、`FnMut` 或 `FnOnce` 这些 `trait` 之一（它实现的）来约束就足以指定其类型。"
 
 #: src/fn/closures/anonymity.md:28
 msgid ""
@@ -5796,16 +5797,15 @@ msgid ""
 "// for `print`.\n"
 msgstr ""
 "// `F` 必须实现 `Fn` 用于一个不接受输入且不返回任何内容的闭包\n"
-"// - 这正是 `print` 所需要的。\n"
-"\n"
+"// - 这正是 `print` 所需要的\n"
 
 #: src/fn/closures/anonymity.md:39
 msgid ""
 "// Capture `x` into an anonymous type and implement\n"
 "    // `Fn` for it. Store it in `print`.\n"
 msgstr ""
-"// 将 `x` 捕获到一个匿名类型中并为其实现\n"
-"    // `Fn`。将其存储在 `print` 中。\n"
+"// 将 `x` 捕获到一个匿名类型中并为其实现 `Fn`\n"
+"    // 将其存储在 `print` 中\n"
 
 #: src/fn/closures/anonymity.md:49
 msgid ""
@@ -5814,7 +5814,7 @@ msgid ""
 "(https://doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://"
 "doc.rust-lang.org/std/ops/trait.FnOnce.html)"
 msgstr ""
-"[深入分析](https://huonw.github.io/blog/2015/05/finding-closure-in-"rust/)、"
+"[深入分析](https://huonw.github.io/blog/2015/05/finding-closure-in-rust/)、"
 "[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`]"
 "(https://doc.rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://"
 "doc.rust-lang.org/std/ops/trait.FnOnce.html)"
@@ -5833,7 +5833,7 @@ msgid ""
 "// Define a function which takes a generic `F` argument\n"
 "// bounded by `Fn`, and calls it\n"
 msgstr ""
-"// 定义一个函数，它接受一个由 `Fn` 约束的泛型参数 `F` ，并调用它\n"
+"// 定义一个函数，它接受一个由 `Fn` 约束的泛型参数 `F`，并调用它\n"
 
 #: src/fn/closures/input_functions.md:14
 msgid "// Define a wrapper function satisfying the `Fn` bound\n"
@@ -5841,7 +5841,7 @@ msgstr "// 定义一个满足 `Fn` 约束的包装函数\n"
 
 #: src/fn/closures/input_functions.md:17
 msgid "\"I'm a function!\""
-msgstr "\"I'm a function!\""
+msgstr "\"我是函数！\""
 
 #: src/fn/closures/input_functions.md:21
 msgid "// Define a closure satisfying the `Fn` bound\n"
@@ -5849,14 +5849,14 @@ msgstr "// 定义一个满足 `Fn` 约束的闭包\n"
 
 #: src/fn/closures/input_functions.md:22
 msgid "\"I'm a closure!\""
-msgstr "\"I'm a closure!\""
+msgstr "\"我是闭包！\""
 
 #: src/fn/closures/input_functions.md:29
 msgid ""
 "As an additional note, the `Fn`, `FnMut`, and `FnOnce` `traits` dictate how a "
 "closure captures variables from the enclosing scope."
 msgstr ""
-"作为附加说明，`Fn`、`FnMut` 和 `FnOnce` `traits` 决定了闭包如何从封闭作用域中捕获变量。"
+"另外需要注意的是，`Fn`、`FnMut` 和 `FnOnce` 这些 trait 决定了闭包如何从外部作用域捕获变量。"
 
 #: src/fn/closures/input_functions.md:34
 msgid ""
@@ -5864,9 +5864,11 @@ msgid ""
 "doc.rust-lang.org/std/ops/trait.FnMut.html), and [`FnOnce`](https://doc.rust-"
 "lang.org/std/ops/trait.FnOnce.html)"
 msgstr ""
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`](https://"
-"doc.rust-lang.org/std/ops/trait.FnMut.html) 和 [`FnOnce`](https://doc.rust-"
-"lang.org/std/ops/trait.FnOnce.html)"
+"[`Fn`]、[`FnMut`] 和 [`FnOnce`]\n"
+"\n"
+"[`Fn`]: https://doc.rust-lang.org/std/ops/trait.Fn.html\n"
+"[`FnMut`]: https://doc.rust-lang.org/std/ops/trait.FnMut.html\n"
+"[`FnOnce`]: https://doc.rust-lang.org/std/ops/trait.FnOnce.html"
 
 #: src/fn/closures/output_parameters.md:3
 msgid ""
@@ -5874,11 +5876,11 @@ msgid ""
 "parameters should also be possible. However, anonymous closure types are, by "
 "definition, unknown, so we have to use `impl Trait` to return them."
 msgstr ""
-"闭包既然可以作为输入参数，那么将闭包作为输出参数返回也应该是可以的。然而，匿名闭包类型根据定义是未知的，所以我们必须使用 `impl Trait` 来返回它们。"
+"既然闭包可以作为输入参数，那么将闭包作为输出参数返回也应该是可行的。然而，匿名闭包类型本质上是未知的，因此我们必须使用 `impl Trait` 来返回它们。"
 
 #: src/fn/closures/output_parameters.md:8
 msgid "The valid traits for returning a closure are:"
-msgstr "返回闭包的有效 traits 是："
+msgstr "可用于返回闭包的有效 trait 包括："
 
 #: src/fn/closures/output_parameters.md:10
 msgid "`Fn`"
@@ -5899,7 +5901,7 @@ msgid ""
 "dropped as soon as the function exited, leaving invalid references in the "
 "closure."
 msgstr ""
-"除此之外，必须使用 `move` 关键字，它表示所有捕获都通过值进行。这是必需的，因为任何通过引用的捕获都会在函数退出时立即被丢弃，在闭包中留下无效的引用。"
+"此外，必须使用 `move` 关键字，它表示所有捕获都是按值进行的。这是必要的，因为任何通过引用捕获的变量都会在函数退出时被丢弃，从而在闭包中留下无效的引用。"
 
 #: src/fn/closures/output_parameters.md:21
 msgid "\"Fn\""
@@ -5925,9 +5927,12 @@ msgid ""
 "doc.rust-lang.org/std/ops/trait.FnMut.html), [Generics](../../generics.md) "
 "and [impl Trait](../../trait/impl_trait.md)."
 msgstr ""
-"[`Fn`](https://doc.rust-lang.org/std/ops/trait.Fn.html)、[`FnMut`](https://"
-"doc.rust-lang.org/std/ops/trait.FnMut.html)、[泛型](../../generics.md)"
-"和 [impl Trait](../../trait/impl_trait.md)。"
+"[`Fn`]、[`FnMut`]、[泛型]和 [impl Trait]\n"
+"\n"
+"[`Fn`]: https://doc.rust-lang.org/std/ops/trait.Fn.html\n"
+"[`FnMut`]: https://doc.rust-lang.org/std/ops/trait.FnMut.html\n"
+"[泛型]: ../../generics.md\n"
+"[impl Trait]: ../../trait/impl_trait.md"
 
 #: src/fn/closures/closure_examples.md:3
 msgid ""
@@ -5940,13 +5945,12 @@ msgid ""
 "`true` if any element satisfies the predicate. Otherwise `false`. Its "
 "signature:"
 msgstr ""
-"`Iterator::any` 是一个函数，当传入一个迭代器时，如果任何元素满足谓词，则返回 "
-"`true`。否则返回 `false`。它的签名如下："
+"`Iterator::any` 是一个函数，它接受一个迭代器作为参数。如果任何元素满足给定的条件，则返回 `true`，否则返回 `false`。其签名如下："
 
 #: src/fn/closures/closure_examples/iter_any.md:9
 #: src/fn/closures/closure_examples/iter_find.md:9
 msgid "// The type being iterated over.\n"
-msgstr "// 被迭代的类型。\n"
+msgstr "// 被迭代的类型\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:12
 msgid ""
@@ -5954,7 +5958,7 @@ msgid ""
 "    // and modified, but not consumed.\n"
 msgstr ""
 "// `any` 接受 `&mut self`，意味着调用者可能被借用\n"
-"    // 和修改，但不会被消耗。\n"
+"    // 和修改，但不会被消耗\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:15
 msgid ""
@@ -5962,12 +5966,12 @@ msgid ""
 "        // modified, not consumed. `Self::Item` states it takes\n"
 "        // arguments to the closure by value.\n"
 msgstr ""
-"// `FnMut` 意味着任何捕获的变量最多可以被修改，而不是被消耗。\n"
-"        // `Self::Item` 表示它通过值将参数传递给闭包。\n"
+"// `FnMut` 表示任何捕获的变量最多只能被修改，不能被消耗\n"
+"        // `Self::Item` 表示它通过值将参数传递给闭包\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:27
 msgid "// `iter()` for vecs yields `&i32`. Destructure to `i32`.\n"
-msgstr "// 对 vec 使用 `iter()` 产生 `&i32`。解构为 `i32`。\n"
+msgstr "// 对 vec 使用 `iter()` 产生 `&i32`，解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:28
 msgid "\"2 in vec1: {}\""
@@ -5975,7 +5979,7 @@ msgstr "\"2 在 vec1 中：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:29
 msgid "// `into_iter()` for vecs yields `i32`. No destructuring required.\n"
-msgstr "// 对 vec 使用 `into_iter()` 产生 `i32`。不需要解构。\n"
+msgstr "// 对 vec 使用 `into_iter()` 产生 `i32`，无需解构\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:30
 msgid "\"2 in vec2: {}\""
@@ -6005,11 +6009,11 @@ msgstr ""
 "// `into_iter()` 会移动 `vec2` 及其元素，所以它们不能再次使用\n"
 "    // println!(\"vec2 的第一个元素是：{}\", vec2[0]);\n"
 "    // println!(\"vec2 长度：{}\", vec2.len());\n"
-"    // TODO：取消上面两行的注释，查看编译器错误。\n"
+"    // TODO：取消上面两行的注释，观察编译器错误\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:43
 msgid "// `iter()` for arrays yields `&i32`.\n"
-msgstr "// 对数组使用 `iter()` 产生 `&i32`。\n"
+msgstr "// 对数组使用 `iter()` 产生 `&i32`\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:44
 msgid "\"2 in array1: {}\""
@@ -6017,7 +6021,7 @@ msgstr "\"2 在 array1 中：{}\""
 
 #: src/fn/closures/closure_examples/iter_any.md:45
 msgid "// `into_iter()` for arrays yields `i32`.\n"
-msgstr "// 对数组使用 `into_iter()` 产生 `i32`。\n"
+msgstr "// 对数组使用 `into_iter()` 产生 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_any.md:46
 msgid "\"2 in array2: {}\""
@@ -6028,8 +6032,9 @@ msgid ""
 "[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.any)"
 msgstr ""
-"[`std::iter::Iterator::any`](https://doc.rust-lang.org/std/iter/trait."
-"Iterator.html#method.any)"
+"[`std::iter::Iterator::any`]\n"
+"\n"
+"[`std::iter::Iterator::any`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.any"
 
 #: src/fn/closures/closure_examples/iter_find.md:3
 msgid ""
@@ -6037,15 +6042,14 @@ msgid ""
 "for the first value which satisfies some condition. If none of the values "
 "satisfy the condition, it returns `None`. Its signature:"
 msgstr ""
-"`Iterator::find` 是一个函数，它遍历一个迭代器并搜索满足某个条件的第一个值。"
-"如果没有值满足条件，它返回 `None`。它的签名如下："
+"`Iterator::find` 是一个函数，它遍历迭代器并搜索满足特定条件的第一个值。如果没有值满足条件，则返回 `None`。其签名如下："
 
 #: src/fn/closures/closure_examples/iter_find.md:12
 msgid ""
 "// `find` takes `&mut self` meaning the caller may be borrowed\n"
 "    // and modified, but not consumed.\n"
 msgstr ""
-"// `find` 接受 `&mut self`，意味着调用者可能被借用\n"
+"// `find` 接受 `&mut self`，这意味着调用者可能被借用\n"
 "    // 和修改，但不会被消耗。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:15
@@ -6054,24 +6058,24 @@ msgid ""
 "        // modified, not consumed. `&Self::Item` states it takes\n"
 "        // arguments to the closure by reference.\n"
 msgstr ""
-"// `FnMut` 意味着任何捕获的变量最多可以被修改，而不是被消耗。\n"
+"// `FnMut` 表示任何捕获的变量最多只能被修改，不能被消耗。\n"
 "        // `&Self::Item` 表示它通过引用将参数传递给闭包。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:27
 msgid "// `iter()` for vecs yields `&i32`.\n"
-msgstr "// 对 vec 使用 `iter()` 产生 `&i32`。\n"
+msgstr "// 对 vec 使用 `iter()` 会产生 `&i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:29
 msgid "// `into_iter()` for vecs yields `i32`.\n"
-msgstr "// 对 vec 使用 `into_iter()` 产生 `i32`。\n"
+msgstr "// 对 vec 使用 `into_iter()` 会产生 `i32`。\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:32
 msgid ""
 "// `iter()` for vecs yields `&i32`, and we want to reference one of its\n"
 "    // items, so we have to destructure `&&i32` to `i32`\n"
 msgstr ""
-"// 对 vec 使用 `iter()` 产生 `&i32`，我们想要引用其中的一个\n"
-"    // 项，所以我们必须将 `&&i32` 解构为 `i32`\n"
+"// 对 vec 使用 `iter()` 会产生 `&i32`，而我们想要引用其中的一个\n"
+"    // 元素，所以我们必须将 `&&i32` 解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:34
 msgid "\"Find 2 in vec1: {:?}\""
@@ -6082,8 +6086,8 @@ msgid ""
 "// `into_iter()` for vecs yields `i32`, and we want to reference one of\n"
 "    // its items, so we have to destructure `&i32` to `i32`\n"
 msgstr ""
-"// 对 vec 使用 `into_iter()` 产生 `i32`，我们想要引用其中的\n"
-"    // 一个项，所以我们必须将 `&i32` 解构为 `i32`\n"
+"// 对 vec 使用 `into_iter()` 会产生 `i32`，而我们想要引用其中的\n"
+"    // 一个元素，所以我们必须将 `&i32` 解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:37
 msgid "\"Find 2 in vec2: {:?}\""
@@ -6091,7 +6095,7 @@ msgstr "\"在 vec2 中查找 2：{:?}\""
 
 #: src/fn/closures/closure_examples/iter_find.md:42
 msgid "// `iter()` for arrays yields `&&i32`\n"
-msgstr "// 对数组使用 `iter()` 产生 `&&i32`\n"
+msgstr "// 对数组使用 `iter()` 会产生 `&&i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:43
 msgid "\"Find 2 in array1: {:?}\""
@@ -6099,7 +6103,7 @@ msgstr "\"在 array1 中查找 2：{:?}\""
 
 #: src/fn/closures/closure_examples/iter_find.md:44
 msgid "// `into_iter()` for arrays yields `&i32`\n"
-msgstr "// 对数组使用 `into_iter()` 产生 `&i32`\n"
+msgstr "// 对数组使用 `into_iter()` 会产生 `&i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:45
 msgid "\"Find 2 in array2: {:?}\""
@@ -6110,7 +6114,7 @@ msgid ""
 "`Iterator::find` gives you a reference to the item. But if you want the "
 "_index_ of the item, use `Iterator::position`."
 msgstr ""
-"`Iterator::find` 给你一个项的引用。但如果你想要项的**索引**，使用 `Iterator::position`。"
+"`Iterator::find` 返回元素的引用。如果需获取元素的**索引**，则使用 `Iterator::position`。"
 
 #: src/fn/closures/closure_examples/iter_find.md:56
 msgid ""
@@ -6118,7 +6122,7 @@ msgid ""
 "reference, so\n"
 "    // we have to destructure `&i32` to `i32`\n"
 msgstr ""
-"// 对 vec 使用 `iter()` 产生 `&i32`，而 `position()` 不接受引用，所以\n"
+"// 对 vec 使用 `iter()` 会产生 `&i32`，而 `position()` 不接受引用，所以\n"
 "    // 我们必须将 `&i32` 解构为 `i32`\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:61
@@ -6127,40 +6131,44 @@ msgid ""
 "reference, so\n"
 "    // we do not have to destructure    \n"
 msgstr ""
-"// 对 vec 使用 `into_iter()` 产生 `i32`，而 `position()` 不接受引用，所以\n"
-"    // 我们不需要解构\n"
+"// 对 vec 使用 `into_iter()` 会产生 `i32`，而 `position()` 不接受引用，所以\n"
+"    // 我们不需要进行解构\n"
 
 #: src/fn/closures/closure_examples/iter_find.md:70
 msgid ""
 "[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.find)"
 msgstr ""
-"[`std::iter::Iterator::find`](https://doc.rust-lang.org/std/iter/trait."
-"Iterator.html#method.find)"
+"[`std::iter::Iterator::find`]\n"
+"\n"
+"[`std::iter::Iterator::find`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find"
 
 #: src/fn/closures/closure_examples/iter_find.md:72
 msgid ""
 "[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.find_map)"
 msgstr ""
-"[`std::iter::Iterator::find_map`](https://doc.rust-lang.org/std/iter/trait."
-"Iterator.html#method.find_map)"
+"[`std::iter::Iterator::find_map`]\n"
+"\n"
+"[`std::iter::Iterator::find_map`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.find_map"
 
 #: src/fn/closures/closure_examples/iter_find.md:74
 msgid ""
 "[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.position)"
 msgstr ""
-"[`std::iter::Iterator::position`](https://doc.rust-lang.org/std/iter/trait."
-"Iterator.html#method.position)"
+"[`std::iter::Iterator::position`]\n"
+"\n"
+"[`std::iter::Iterator::position`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.position"
 
 #: src/fn/closures/closure_examples/iter_find.md:76
 msgid ""
 "[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
 "Iterator.html#method.rposition)"
 msgstr ""
-"[`std::iter::Iterator::rposition`](https://doc.rust-lang.org/std/iter/trait."
-"Iterator.html#method.rposition)"
+"[`std::iter::Iterator::rposition`]\n"
+"\n"
+"[`std::iter::Iterator::rposition`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.rposition"
 
 #: src/fn/hof.md:3
 msgid ""
@@ -6168,7 +6176,7 @@ msgid ""
 "or more functions and/or produce a more useful function. HOFs and lazy "
 "iterators give Rust its functional flavor."
 msgstr ""
-"Rust 提供了高阶函数（Higher Order Functions, HOF）。这些函数接受一个或多个函数作为参数，并且/或者产生一个更有用的函数。HOF 和惰性迭代器赋予了 Rust 函数式编程的风格。"
+"Rust 提供了高阶函数（Higher Order Functions，HOF）。这些函数接受一个或多个函数作为参数，并/或产生一个更有用的函数。HOF 和惰性迭代器赋予了 Rust 函数式编程的特性。"
 
 #: src/fn/hof.md:13
 msgid "\"Find the sum of all the numbers with odd squares under 1000\""
@@ -6184,11 +6192,11 @@ msgstr ""
 
 #: src/fn/hof.md:19
 msgid "// Iterate: 0, 1, 2, ... to infinity\n"
-msgstr "// 迭代：0, 1, 2, ... 直到无穷大\n"
+msgstr "// 迭代：从 0, 1, 2, ... 到无穷大\n"
 
 #: src/fn/hof.md:21
 msgid "// Square the number\n"
-msgstr "// 对数字求平方\n"
+msgstr "// 计算数字的平方\n"
 
 #: src/fn/hof.md:25
 msgid "// Break loop if exceeded the upper limit\n"
@@ -6212,11 +6220,11 @@ msgstr "// 所有自然数的平方\n"
 
 #: src/fn/hof.md:37
 msgid "// Below upper limit\n"
-msgstr "// 低于上限\n"
+msgstr "// 小于上限\n"
 
 #: src/fn/hof.md:38
 msgid "// That are odd\n"
-msgstr "// 是奇数\n"
+msgstr "// 筛选奇数\n"
 
 #: src/fn/hof.md:39
 msgid "// Sum them\n"
@@ -6232,8 +6240,10 @@ msgid ""
 "[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) implement "
 "their fair share of HOFs."
 msgstr ""
-"[Option](https://doc.rust-lang.org/core/option/enum.Option.html) 和 "
-"[Iterator](https://doc.rust-lang.org/core/iter/trait.Iterator.html) 实现了相当多的高阶函数。"
+"[Option] 和 [Iterator] 实现了相当多的高阶函数。\n"
+"\n"
+"[Option]: https://doc.rust-lang.org/core/option/enum.Option.html\n"
+"[Iterator]: https://doc.rust-lang.org/core/iter/trait.Iterator.html"
 
 #: src/fn/diverging.md:3
 msgid ""
@@ -6244,7 +6254,7 @@ msgstr ""
 
 #: src/fn/diverging.md:7 src/fn/diverging.md:35
 msgid "\"This call never returns.\""
-msgstr "\"这个调用永不返回。\""
+msgstr "\"此调用永不返回。\""
 
 #: src/fn/diverging.md:11
 msgid ""
@@ -6259,11 +6269,11 @@ msgid ""
 "For example, this function returns as usual, although there is no information "
 "in the return value."
 msgstr ""
-"例如，这个函数像往常一样返回，尽管返回值中没有信息。"
+"例如，这个函数像往常一样返回，尽管返回值中没有任何信息。"
 
 #: src/fn/diverging.md:25
 msgid "\"This function returns and you can see this line.\""
-msgstr "\"这个函数返回，你可以看到这一行。\""
+msgstr "\"这个函数返回了，你可以看到这一行。\""
 
 #: src/fn/diverging.md:29
 msgid ""
@@ -6284,15 +6294,15 @@ msgid ""
 "required, such as in match branches. This flexibility allows us to write code "
 "like this:"
 msgstr ""
-"虽然这看起来像是一个抽象的概念，但它实际上非常有用且经常派上用场。这种类型的主要优势是它可以被转换为任何其他类型，这使得它在需要精确类型的情况下非常灵活，比如在 match 分支中。这种灵活性允许我们编写如下代码："
+"虽然这看起来像是一个抽象概念，但它实际上非常有用且经常派上用场。这种类型的主要优势是它可以被转换为任何其他类型，这使得它在需要精确类型的情况下非常灵活，比如在 match 分支中。这种灵活性允许我们编写如下代码："
 
 #: src/fn/diverging.md:50
 msgid ""
 "// Notice that the return type of this match expression must be u32\n"
 "            // because of the type of the \"addition\" variable.\n"
 msgstr ""
-"// 注意这个 match 表达式的返回类型必须是 u32\n"
-"            // 因为 \"addition\" 变量的类型。\n"
+"// 注意这个 match 表达式的返回类型必须是 u32，\n"
+"            // 因为 \"addition\" 变量的类型是 u32。\n"
 
 #: src/fn/diverging.md:53
 msgid "// The \"i\" variable is of type u32, which is perfectly fine.\n"
@@ -6306,9 +6316,9 @@ msgid ""
 "                // does not violate the type requirements of the match "
 "expression.\n"
 msgstr ""
-"// 另一方面，\"continue\" 表达式不返回\n"
-"                // u32，但这仍然可以，因为它永远不会返回，因此\n"
-"                // 不违反 match 表达式的类型要求。\n"
+"// 另一方面，\"continue\" 表达式不返回 u32，\n"
+"                // 但这仍然可以，因为它永远不会返回，\n"
+"                // 因此不违反 match 表达式的类型要求。\n"
 
 #: src/fn/diverging.md:64
 msgid "\"Sum of odd numbers up to 9 (excluding): {}\""
@@ -6319,7 +6329,7 @@ msgid ""
 "It is also the return type of functions that loop forever (e.g. `loop {}`) "
 "like network servers or functions that terminate the process (e.g. `exit()`)."
 msgstr ""
-"它也是永远循环的函数（例如 `loop {}`）的返回类型，比如网络服务器或终止进程的函数（例如 `exit()`）。"
+"它也是永远循环的函数（例如 `loop {}`）的返回类型，比如网络服务器，或终止进程的函数（例如 `exit()`）。"
 
 #: src/mod.md:3
 msgid ""
@@ -6369,7 +6379,8 @@ msgid ""
 "// Items can access other items in the same module,\n"
 "    // even when private.\n"
 msgstr ""
-"// 项可以访问同一模块中的其他项，即使是私有的。\n"
+"// 同一模块中的项可以访问其他项，\n"
+"    // 即使是私有的。\n"
 
 #: src/mod/visibility.md:23
 msgid "\"called `my_mod::indirect_access()`, that\\n> \""
@@ -6392,7 +6403,7 @@ msgid ""
 "// Functions declared using `pub(in path)` syntax are only visible\n"
 "        // within the given path. `path` must be a parent or ancestor module\n"
 msgstr ""
-"// 使用 `pub(in path)` 语法声明的函数只在给定的路径中可见\n"
+"// 使用 `pub(in path)` 语法声明的函数只在给定的路径中可见。\n"
 "        // `path` 必须是父模块或祖先模块\n"
 
 #: src/mod/visibility.md:41
@@ -6404,7 +6415,7 @@ msgid ""
 "// Functions declared using `pub(self)` syntax are only visible within\n"
 "        // the current module, which is the same as leaving them private\n"
 msgstr ""
-"// 使用 `pub(self)` 语法声明的函数只在当前模块中可见\n"
+"// 使用 `pub(self)` 语法声明的函数只在当前模块中可见，\n"
 "        // 这与将它们保持为私有是一样的\n"
 
 #: src/mod/visibility.md:48
@@ -6416,7 +6427,7 @@ msgid ""
 "// Functions declared using `pub(super)` syntax are only visible within\n"
 "        // the parent module\n"
 msgstr ""
-"// 使用 `pub(super)` 语法声明的函数只在父模块中可见\n"
+"// 使用 `pub(super)` 语法声明的函数仅在父模块中可见\n"
 "        \n"
 
 #: src/mod/visibility.md:54
@@ -6433,7 +6444,7 @@ msgstr "\"> \""
 
 #: src/mod/visibility.md:65
 msgid "// pub(crate) makes functions visible only within the current crate\n"
-msgstr "// pub(crate) 使函数只在当前 crate 中可见\n"
+msgstr "// pub(crate) 使函数仅在当前 crate 内可见\n"
 
 #: src/mod/visibility.md:67
 msgid "\"called `my_mod::public_function_in_crate()`\""
@@ -6452,8 +6463,8 @@ msgid ""
 "// Private parent items will still restrict the visibility of a child item,\n"
 "        // even if it is declared as visible within a bigger scope.\n"
 msgstr ""
-"// 私有的父项仍然会限制子项的可见性，\n"
-"        // 即使它被声明为在更大范围内可见。\n"
+"// 私有父项仍会限制子项的可见性，\n"
+"        // 即使子项被声明为在更大范围内可见。\n"
 
 #: src/mod/visibility.md:81
 msgid "\"called `my_mod::private_nested::restricted_function()`\""
@@ -6466,19 +6477,18 @@ msgstr "\"调用了 `function()`\""
 
 #: src/mod/visibility.md:91
 msgid "// Modules allow disambiguation between items that have the same name.\n"
-msgstr "// 模块允许消除具有相同名称的项之间的歧义。\n"
+msgstr "// 模块允许消除同名项之间的歧义。\n"
 
 #: src/mod/visibility.md:95
 msgid ""
 "// Public items, including those inside nested modules, can be\n"
 "    // accessed from outside the parent module.\n"
 msgstr ""
-"// 公有项，包括那些在嵌套模块内的，可以\n"
-"    // 从父模块外部访问。\n"
+"// 公有项（包括嵌套模块内的）可以从父模块外部访问。\n"
 
 #: src/mod/visibility.md:101
 msgid "// pub(crate) items can be called from anywhere in the same crate\n"
-msgstr "// pub(crate) 项可以从同一个 crate 中的任何地方调用\n"
+msgstr "// pub(crate) 项可以在同一个 crate 的任何地方调用\n"
 
 #: src/mod/visibility.md:104
 msgid ""
@@ -6487,17 +6497,17 @@ msgid ""
 "    //my_mod::nested::public_function_in_my_mod();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// pub(in path) 项只能从指定的模块内部调用\n"
-"    // 报错！函数 `public_function_in_my_mod` 是私有的\n"
+"// pub(in path) 项只能在指定的模块内调用\n"
+"    // 错误！函数 `public_function_in_my_mod` 是私有的\n"
 "    //my_mod::nested::public_function_in_my_mod();\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/visibility.md:109
 msgid ""
 "// Private items of a module cannot be directly accessed, even if\n"
 "    // nested in a public module:\n"
 msgstr ""
-"// 模块的私有项不能被直接访问，即使嵌套在一个公有模块中：\n"
+"// 模块的私有项不能被直接访问，即使它们嵌套在公有模块中：\n"
 
 #: src/mod/visibility.md:112
 msgid ""
@@ -6505,9 +6515,9 @@ msgid ""
 "    //my_mod::private_function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 报错！`private_function` 是私有的\n"
+"// 错误！`private_function` 是私有的\n"
 "    //my_mod::private_function();\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/visibility.md:116
 msgid ""
@@ -6515,9 +6525,9 @@ msgid ""
 "    //my_mod::nested::private_function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 报错！`private_function` 是私有的\n"
+"// 错误！`private_function` 是私有的\n"
 "    //my_mod::nested::private_function();\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/visibility.md:120
 msgid ""
@@ -6525,9 +6535,9 @@ msgid ""
 "    //my_mod::private_nested::function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 报错！`private_nested` 是一个私有模块\n"
+"// 错误！`private_nested` 是一个私有模块\n"
 "    //my_mod::private_nested::function();\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/visibility.md:124
 msgid ""
@@ -6535,9 +6545,9 @@ msgid ""
 "    //my_mod::private_nested::restricted_function();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 报错！`private_nested` 是一个私有模块\n"
+"// 错误！`private_nested` 是一个私有模块\n"
 "    //my_mod::private_nested::restricted_function();\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/struct_visibility.md:3
 msgid ""
@@ -6546,15 +6556,16 @@ msgid ""
 "visibility only matters when a struct is accessed from outside the module "
 "where it is defined, and has the goal of hiding information (encapsulation)."
 msgstr ""
-"结构体的字段有额外的可见性级别。可见性默认为私有，可以使用 `pub` 修饰符来覆盖。这种可见性只在从定义结构体的模块外部访问结构体时才有意义，其目的是隐藏信息（封装）。"
+"结构体的字段具有额外的可见性级别。字段默认为私有，可以使用 `pub` 修饰符来覆盖。"
+"这种可见性只在从结构体定义模块外部访问时才有意义，其目的是实现信息隐藏（封装）。"
 
 #: src/mod/struct_visibility.md:10
 msgid "// A public struct with a public field of generic type `T`\n"
-msgstr "// 一个带有泛型类型 `T` 的公有字段的公有结构体\n"
+msgstr "// 一个具有泛型类型 `T` 公有字段的公有结构体\n"
 
 #: src/mod/struct_visibility.md:15
 msgid "// A public struct with a private field of generic type `T`\n"
-msgstr "// 一个带有泛型类型 `T` 的私有字段的公有结构体\n"
+msgstr "// 一个具有泛型类型 `T` 私有字段的公有结构体\n"
 
 #: src/mod/struct_visibility.md:21
 msgid "// A public constructor method\n"
@@ -6562,7 +6573,7 @@ msgstr "// 一个公有的构造方法\n"
 
 #: src/mod/struct_visibility.md:31
 msgid "// Public structs with public fields can be constructed as usual\n"
-msgstr "// 带有公有字段的公有结构体可以像往常一样构造\n"
+msgstr "// 具有公有字段的公有结构体可以正常构造\n"
 
 #: src/mod/struct_visibility.md:32
 msgid "\"public information\""
@@ -6570,7 +6581,7 @@ msgstr "\"公开信息\""
 
 #: src/mod/struct_visibility.md:34
 msgid "// and their fields can be normally accessed.\n"
-msgstr "// 并且可以正常访问它们的字段。\n"
+msgstr "// 且可以正常访问其字段。\n"
 
 #: src/mod/struct_visibility.md:35
 msgid "\"The open box contains: {}\""
@@ -6585,17 +6596,17 @@ msgid ""
 "information\" };\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 带有私有字段的公有结构体不能使用字段名来构造。\n"
-"    // 报错！`ClosedBox` 有私有字段\n"
+"// 具有私有字段的公有结构体不能使用字段名来构造。\n"
+"    // 错误！`ClosedBox` 有私有字段\n"
 "    //let closed_box = my::ClosedBox { contents: \"机密信息\" };\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/struct_visibility.md:42
 msgid ""
 "// However, structs with private fields can be created using\n"
 "    // public constructors\n"
 msgstr ""
-"// 然而，带有私有字段的结构体可以使用公有构造函数来创建\n"
+"// 然而，具有私有字段的结构体可以使用公有构造函数创建\n"
 
 #: src/mod/struct_visibility.md:44
 msgid "\"classified information\""
@@ -6608,10 +6619,10 @@ msgid ""
 "    //println!(\"The closed box contains: {}\", _closed_box.contents);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 并且不能访问公有结构体的私有字段。\n"
-"    // 报错！`contents` 字段是私有的\n"
+"// 且无法访问公有结构体的私有字段。\n"
+"    // 错误！`contents` 字段是私有的\n"
 "    //println!(\"封闭的盒子包含：{}\", _closed_box.contents);\n"
-"    // TODO ^ 尝试取消这一行的注释\n"
+"    // TODO ^ 尝试取消此行注释\n"
 
 #: src/mod/struct_visibility.md:55
 msgid "[generics](../generics.md) and [methods](../fn/methods.md)"
@@ -6621,7 +6632,8 @@ msgstr "[泛型](../generics.md)和[方法](../fn/methods.md)"
 msgid ""
 "The `use` declaration can be used to bind a full path to a new name, for "
 "easier access. It is often used like this:"
-msgstr "`use` 声明可以将完整路径绑定到一个新的名称，以便更容易访问。它通常像这样使用："
+msgstr ""
+"`use` 声明可以将完整路径绑定到新名称，以便更轻松地访问。它通常这样使用："
 
 #: src/mod/use.md:18
 msgid "You can use the `as` keyword to bind imports to a different name:"
@@ -6633,15 +6645,15 @@ msgstr "// 将 `deeply::nested::function` 路径绑定到 `other_function`。\n"
 
 #: src/mod/use.md:31
 msgid "\"called `deeply::nested::function()`\""
-msgstr "\"调用 `deeply::nested::function()`\""
+msgstr "\"调用了 `deeply::nested::function()`\""
 
 #: src/mod/use.md:37
 msgid "// Easier access to `deeply::nested::function`\n"
-msgstr "// 更容易访问 `deeply::nested::function`\n"
+msgstr "// 更方便地访问 `deeply::nested::function`\n"
 
 #: src/mod/use.md:40
 msgid "\"Entering block\""
-msgstr "\"进入块\""
+msgstr "\"进入代码块\""
 
 #: src/mod/use.md:42
 msgid ""
@@ -6657,29 +6669,30 @@ msgid ""
 "        // shadowing of `function()` is only in this block.\n"
 msgstr ""
 "// `use` 绑定具有局部作用域。在这种情况下，\n"
-"        // `function()` 的遮蔽仅在此块内有效。\n"
+"        // `function()` 的遮蔽仅在此代码块内有效。\n"
 
 #: src/mod/use.md:50
 msgid "\"Leaving block\""
-msgstr "\"离开块\""
+msgstr "\"离开代码块\""
 
 #: src/mod/super.md:3
 msgid ""
 "The `super` and `self` keywords can be used in the path to remove ambiguity "
 "when accessing items and to prevent unnecessary hardcoding of paths."
-msgstr "`super` 和 `self` 关键字可以在路径中使用，以消除访问项目时的歧义，并防止不必要的路径硬编码。"
+msgstr ""
+"`super` 和 `self` 关键字可以在路径中使用，以消除访问项目时的歧义，并避免不必要的路径硬编码。"
 
 #: src/mod/super.md:13
 msgid "\"called `cool::function()`\""
-msgstr "\"调用 `cool::function()`\""
+msgstr "\"调用了 `cool::function()`\""
 
 #: src/mod/super.md:19 src/mod/split.md:49
 msgid "\"called `my::function()`\""
-msgstr "\"调用 `my::function()`\""
+msgstr "\"调用了 `my::function()`\""
 
 #: src/mod/super.md:24
 msgid "\"called `my::cool::function()`\""
-msgstr "\"调用 `my::cool::function()`\""
+msgstr "\"调用了 `my::cool::function()`\""
 
 #: src/mod/super.md:29
 msgid "// Let's access all the functions named `function` from this scope!\n"
@@ -6687,7 +6700,7 @@ msgstr "// 让我们从这个作用域访问所有名为 `function` 的函数！
 
 #: src/mod/super.md:30
 msgid "\"called `my::indirect_call()`, that\\n> \""
-msgstr "\"调用 `my::indirect_call()`，它\\n> \""
+msgstr "\"调用了 `my::indirect_call()`，它\\n> \""
 
 #: src/mod/super.md:32
 msgid ""
@@ -6696,9 +6709,9 @@ msgid ""
 "give\n"
 "        // the same result, because they refer to the same function.\n"
 msgstr ""
-"// `self` 关键字指的是当前模块作用域 - 在这种情况下是 `my`。\n"
+"// `self` 关键字指的是当前模块作用域 - 在这里是 `my`。\n"
 "        // 调用 `self::function()` 和直接调用 `function()` 都会\n"
-"        // 得到相同的结果，因为它们指的是同一个函数。\n"
+"        // 得到相同的结果，因为它们指向同一个函数。\n"
 
 #: src/mod/super.md:38
 msgid "// We can also use `self` to access another module inside `my`:\n"
@@ -6721,7 +6734,8 @@ msgstr ""
 msgid ""
 "Modules can be mapped to a file/directory hierarchy. Let's break down the "
 "[visibility example](visibility.md) in files:"
-msgstr "模块可以映射到文件/目录层次结构。让我们将[可见性示例](visibility.md)拆分到多个文件中："
+msgstr ""
+"模块可以映射到文件/目录层次结构。让我们将[可见性示例](visibility.md)拆分到多个文件中："
 
 #: src/mod/split.md:16
 msgid "In `split.rs`:"
@@ -6732,7 +6746,8 @@ msgid ""
 "// This declaration will look for a file named `my.rs` and will\n"
 "// insert its contents inside a module named `my` under this scope\n"
 msgstr ""
-"// 这个声明会查找一个名为 `my.rs` 的文件，并将其内容插入到这个作用域下名为 `my` 的模块中\n"
+"// 这个声明会查找名为 `my.rs` 的文件，并将其内容\n"
+"// 插入到这个作用域下名为 `my` 的模块中\n"
 
 #: src/mod/split.md:39
 msgid "In `my.rs`:"

--- a/po/zh.po
+++ b/po/zh.po
@@ -6575,7 +6575,7 @@ msgid ""
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
 "// 并且不能访问公有结构体的私有字段。\n"
-"    // 错误！`contents` 字段是私有的\n"
+"    // 报错！`contents` 字段是私有的\n"
 "    //println!(\"封闭的盒子包含：{}\", _closed_box.contents);\n"
 "    // TODO ^ 尝试取消这一行的注释\n"
 
@@ -6754,6 +6754,7 @@ msgid ""
 "_before_ running the compiler over it. In other words, modules do _not_ get "
 "compiled individually, only crates get compiled."
 msgstr ""
+"crate 是 Rust 中的编译单元。每当调用 `rustc some_file.rs` 时，`some_file.rs` 就被视为**crate 文件**。如果 `some_file.rs` 中有 `mod` 声明，那么模块文件的内容会在编译器运行之前被插入到 crate 文件中 `mod` 声明的位置。换句话说，模块**不会**被单独编译，只有 crate 才会被编译。"
 
 #: src/crates.md:10
 msgid ""
@@ -6761,26 +6762,27 @@ msgid ""
 "will produce a binary from a crate. This behavior can be overridden by "
 "passing the `--crate-type` flag to `lib`."
 msgstr ""
+"一个 crate 可以被编译成二进制文件或库。默认情况下，`rustc` 会从 crate 生成二进制文件。这个行为可以通过向 `lib` 传递 `--crate-type` 标志来改变。"
 
 #: src/crates/lib.md:3
 msgid "Let's create a library, and then see how to link it to another crate."
-msgstr ""
+msgstr "让我们创建一个库，然后看看如何将它链接到另一个 crate。"
 
 #: src/crates/lib.md:5
 msgid "In `rary.rs`:"
-msgstr ""
+msgstr "在 `rary.rs` 中："
 
 #: src/crates/lib.md:9 src/attribute/crate.md:19
 msgid "\"called rary's `public_function()`\""
-msgstr ""
+msgstr "\"调用了 rary 的 `public_function()`\""
 
 #: src/crates/lib.md:13 src/attribute/crate.md:23
 msgid "\"called rary's `private_function()`\""
-msgstr ""
+msgstr "\"调用了 rary 的 `private_function()`\""
 
 #: src/crates/lib.md:17 src/attribute/crate.md:27
 msgid "\"called rary's `indirect_access()`, that\\n> \""
-msgstr ""
+msgstr "\"调用了 rary 的 `indirect_access()`，它\\n> \""
 
 #: src/crates/lib.md:29
 msgid ""
@@ -6789,6 +6791,7 @@ msgid ""
 "crate-name` option to `rustc` or by using the [`crate_name` attribute](../"
 "attribute/crate.md)."
 msgstr ""
+"库的名称前缀为 \"lib\"，默认情况下它们以 crate 文件命名，但这个默认名称可以通过向 `rustc` 传递 `--crate-name` 选项或使用 [`crate_name` 属性](../attribute/crate.md) 来覆盖。"
 
 #: src/crates/using_lib.md:3
 msgid ""
@@ -6796,17 +6799,21 @@ msgid ""
 "All of its items will then be imported under a module named the same as the "
 "library. This module generally behaves the same way as any other module."
 msgstr ""
+"要将一个 crate 链接到这个新库，你可以使用 `rustc` 的 `--extern` 标志。然后，它的所有项目都会被导入到一个与库同名的模块下。这个模块通常的行为与任何其他模块相同。"
 
 #: src/crates/using_lib.md:8
 msgid ""
 "// extern crate rary; // May be required for Rust 2015 edition or earlier\n"
 msgstr ""
+"// extern crate rary; // 可能在 Rust 2015 版本或更早版本中需要\n"
 
 #: src/crates/using_lib.md:13
 msgid ""
 "// Error! `private_function` is private\n"
 "    //rary::private_function();\n"
 msgstr ""
+"// 报错！`private_function` 是私有的\n"
+"    //rary::private_function();\n"
 
 #: src/cargo.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -12481,15 +12481,15 @@ msgid ""
 "Here, we rewrite the previous example using `?`. As a result, the `map_err` "
 "will go away when `From::from` is implemented for our error type:"
 msgstr ""
-"在这里，我们使用 `?` 重写了前面的例子。因此，当为我们的错误类型实现 `From::from` 时，`map_err` 将会消失："
+"在这里，我们使用 `?` 重写了前面的例子。当为我们的错误类型实现 `From::from` 后，`map_err` 就不再需要了："
 
 #: src/error/multiple_error_types/reenter_question_mark.md:42
 msgid ""
 "// The same structure as before but rather than chain all `Results`\n"
 "// and `Options` along, we `?` to get the inner value out immediately.\n"
 msgstr ""
-"// 结构与之前相同，但我们不再链接所有的 `Results` 和 `Options`，\n"
-"// 而是使用 `?` 来立即获取内部值。\n"
+"// 结构与之前相同，但不再链式处理所有的 `Result` 和 `Option`，\n"
+"// 而是使用 `?` 立即获取内部值。\n"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:69
 msgid ""
@@ -12497,8 +12497,8 @@ msgid ""
 "very similar to replacing the `unwrap` calls with `?` except that the return "
 "types are `Result`. As a result, they must be destructured at the top level."
 msgstr ""
-"这段代码已经相当清晰了。与原始的 `panic` 相比，它非常类似于用 `?` 替换 `unwrap` 调用，"
-"只是返回类型是 `Result`。因此，它们必须在顶层进行解构。"
+"现在代码变得相当简洁了。与原来使用 `panic` 的版本相比，这种方法非常类似于用 `?` 替换 `unwrap` 调用，"
+"只是返回类型变成了 `Result`。因此，需要在顶层对结果进行解构。"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:76
 msgid ""
@@ -12506,20 +12506,20 @@ msgid ""
 "`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
 "question-mark-operator)"
 msgstr ""
-"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`?"
-"`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
-"question-mark-operator)"
+"[`From::from`]（https://doc.rust-lang.org/std/convert/trait.From.html）和"
+"[`?`运算符]（https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
+"question-mark-operator）"
 
 #: src/error/multiple_error_types/wrap_error.md:3
 msgid "An alternative to boxing errors is to wrap them in your own error type."
-msgstr "另一种替代装箱错误的方法是将它们包装在你自己的错误类型中。"
+msgstr "除了将错误装箱外，另一种方法是将它们包装在你自定义的错误类型中。"
 
 #: src/error/multiple_error_types/wrap_error.md:16
 msgid ""
 "// We will defer to the parse error implementation for their error.\n"
 "    // Supplying extra info requires adding more data to the type.\n"
 msgstr ""
-"// 我们将延迟到解析错误实现中处理它们的错误。\n"
+"// 我们将使用解析错误的实现来处理它们的错误。\n"
 "    // 提供额外信息需要向类型添加更多数据。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:25
@@ -12531,7 +12531,7 @@ msgid ""
 "// The wrapped error contains additional information and is available\n"
 "            // via the source() method.\n"
 msgstr ""
-"// 包装的错误包含额外信息，可以通过 source() 方法获取。\n"
+"// 包装的错误包含额外信息，可通过 source() 方法获取。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:29
 msgid "\"the provided string could not be parsed as int\""
@@ -12544,7 +12544,7 @@ msgid ""
 "the\n"
 "            // underlying type already implements the `Error` trait.\n"
 msgstr ""
-"// 原因是底层实现的错误类型。它被隐式地\n"
+"// 错误原因是底层实现的错误类型。它被隐式地\n"
 "            // 转换为 trait 对象 `&error::Error`。这是可行的，因为\n"
 "            // 底层类型已经实现了 `Error` trait。\n"
 
@@ -12555,20 +12555,20 @@ msgid ""
 "// needs to be converted into a `DoubleError`.\n"
 msgstr ""
 "// 实现从 `ParseIntError` 到 `DoubleError` 的转换。\n"
-"// 如果需要将 `ParseIntError` 转换为 `DoubleError`，\n"
-"// 这将被 `?` 自动调用。\n"
+"// 当需要将 `ParseIntError` 转换为 `DoubleError` 时，\n"
+"// `?` 运算符会自动调用这个转换。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:57
 msgid ""
 "// Here we implicitly use the `ParseIntError` implementation of `From` (which\n"
 "    // we defined above) in order to create a `DoubleError`.\n"
 msgstr ""
-"// 这里我们隐式使用 `ParseIntError` 的 `From` 实现（我们在上面定义的）\n"
+"// 这里我们隐式使用了 `ParseIntError` 的 `From` 实现（我们在上面定义的）\n"
 "    // 来创建一个 `DoubleError`。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:70
 msgid "\"  Caused by: {}\""
-msgstr "\"  原因：{}\""
+msgstr "\"  错误原因：{}\""
 
 #: src/error/multiple_error_types/wrap_error.md:87
 msgid ""
@@ -12576,21 +12576,22 @@ msgid ""
 "in all applications. There are some libraries that can take care of the "
 "boilerplate for you."
 msgstr ""
-"这增加了一些处理错误的样板代码，可能并不是所有应用程序都需要。有一些库可以为你处理这些样板代码。"
+"这种方法增加了一些处理错误的样板代码，可能并非所有应用程序都需要。"
+"有一些库可以帮你处理这些样板代码。"
 
 #: src/error/multiple_error_types/wrap_error.md:93
 msgid ""
 "[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
 "[`Enums`](../../custom_types/enum.md)"
 msgstr ""
-"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) 和"
 "[`枚举`](../../custom_types/enum.md)"
 
 #: src/error/multiple_error_types/wrap_error.md:96
 msgid ""
 "[`Crates for handling errors`](https://crates.io/keywords/error-handling)"
 msgstr ""
-"[`处理错误的 crate`](https://crates.io/keywords/error-handling)"
+"[处理错误的 crate](https://crates.io/keywords/error-handling)"
 
 #: src/error/iter_result.md:3
 msgid "An `Iter::map` operation might fail, for example:"
@@ -12623,8 +12624,8 @@ msgid ""
 "`map_err` calls a function with the error, so by adding that to the previous "
 "`filter_map` solution we can save them off to the side while iterating."
 msgstr ""
-"`map_err` 使用错误调用一个函数，所以通过将其添加到之前的 `filter_map` 解决方案中，"
-"我们可以在迭代时将它们保存到一边。"
+"`map_err` 会对错误调用一个函数，因此将其添加到之前的 `filter_map` 解决方案中，"
+"我们可以在迭代时将错误项保存到一旁。"
 
 #: src/error/iter_result.md:40
 msgid "\"999\""
@@ -12651,16 +12652,17 @@ msgid ""
 "(`Result<Vec<T>, E>`). Once an `Result::Err` is found, the iteration will "
 "terminate."
 msgstr ""
-"`Result` 实现了 `FromIterator`，因此结果的向量（`Vec<Result<T, E>>`）可以转换为包裹着向量的结果"
-"（`Result<Vec<T>, E>`）。一旦找到 `Result::Err`，迭代将终止。"
+"`Result` 实现了 `FromIterator` trait，因此结果的向量（`Vec<Result<T, E>>`）"
+"可以转换为包含向量的结果（`Result<Vec<T>, E>`）。一旦遇到 `Result::Err`，"
+"迭代就会终止。"
 
 #: src/error/iter_result.md:69
 msgid "This same technique can be used with `Option`."
-msgstr "这种方式也可以用于 `Option`。"
+msgstr "这种技巧同样适用于 `Option`。"
 
 #: src/error/iter_result.md:71
 msgid "Collect all valid values and failures with `partition()`"
-msgstr "使用 `partition()` 收集所有有效值和错误"
+msgstr "使用 `partition()` 收集所有有效值和失败项"
 
 #: src/error/iter_result.md:85
 msgid ""
@@ -12674,15 +12676,15 @@ msgid ""
 "The `std` library provides many custom types which expands drastically on the "
 "`primitives`. Some of these include:"
 msgstr ""
-"`std` 库提供了许多自定义类型，这些类型大大扩展了`原生类型`。其中包括："
+"`std` 库提供了许多自定义类型，大大扩展了"原生类型"的功能。其中包括："
 
 #: src/std.md:6
 msgid "growable `String`s like: `\"hello world\"`"
-msgstr "可增长的 `String`，如：`\"hello world\"`"
+msgstr "可增长的 `String`，例如：`\"hello world\"`"
 
 #: src/std.md:7
 msgid "growable vectors: `[1, 2, 3]`"
-msgstr "可增长的向量：`[1, 2, 3]`"
+msgstr "可增长的向量（vector）：`[1, 2, 3]`"
 
 #: src/std.md:8
 msgid "optional types: `Option<i32>`"
@@ -12701,7 +12703,7 @@ msgid ""
 "[primitives](primitives.md) and [the std library](https://doc.rust-lang.org/"
 "std/)"
 msgstr ""
-"[原生类型](primitives.md) 和 [标准库](https://doc.rust-lang.org/std/)"
+"[原生类型](primitives.md)和[标准库](https://doc.rust-lang.org/std/)"
 
 #: src/std/box.md:3
 msgid ""
@@ -12712,7 +12714,7 @@ msgid ""
 "heap is freed."
 msgstr ""
 "在 Rust 中，所有值默认都是栈分配的。通过创建 `Box<T>`，可以将值**装箱**（在堆上分配）。"
-"Box 是指向堆分配的 `T` 类型值的智能指针。当 box 离开作用域时，它的析构函数被调用，"
+"Box 是指向堆分配的 `T` 类型值的智能指针。当 box 离开作用域时，会调用其析构函数，"
 "内部对象被销毁，堆上的内存被释放。"
 
 #: src/std/box.md:8
@@ -12720,14 +12722,14 @@ msgid ""
 "Boxed values can be dereferenced using the `*` operator; this removes one "
 "layer of indirection."
 msgstr ""
-"可以使用 `*` 运算符解引用装箱的值；这会移除一层间接引用。"
+"可以使用 `*` 运算符解引用装箱的值，这会移除一层间接引用。"
 
 #: src/std/box.md:20
 msgid ""
 "// A Rectangle can be specified by where its top left and bottom right \n"
 "// corners are in space\n"
 msgstr ""
-"// 可以通过指定左上角和右下角在空间中的位置来定义一个矩形\n"
+"// 可以通过指定左上角和右下角在空间中的位置来定义矩形\n"
 
 #: src/std/box.md:34
 msgid "// Allocate this point on the heap, and return a pointer to it\n"
@@ -12751,7 +12753,7 @@ msgstr "// 函数的输出可以被装箱\n"
 
 #: src/std/box.md:56
 msgid "// Double indirection\n"
-msgstr "// 两层装箱\n"
+msgstr "// 双重间接引用\n"
 
 #: src/std/box.md:59
 msgid "\"Point occupies {} bytes on the stack\""
@@ -12779,7 +12781,7 @@ msgstr "\"装箱的 box 在栈上占用 {} 字节\""
 
 #: src/std/box.md:72
 msgid "// Copy the data contained in `boxed_point` into `unboxed_point`\n"
-msgstr "// 将 `boxed_point` 中包含的数据复制到 `unboxed_point`\n"
+msgstr "// 将 `boxed_point` 中的数据复制到 `unboxed_point`\n"
 
 #: src/std/box.md:74
 msgid "\"Unboxed point occupies {} bytes on the stack\""
@@ -12791,8 +12793,8 @@ msgid ""
 "compile time, but they can grow or shrink at any time. A vector is "
 "represented using 3 parameters:"
 msgstr ""
-"向量（Vector）是可调整大小的数组。和切片（Slice）类似，它们的大小在编译时是未知的，但可以随时增长或缩小。"
-"向量使用 3 个参数表示："
+"向量（Vector）是可调整大小的数组。与切片（Slice）类似，它们的大小在编译时是未知的，但可以随时增长或缩小。"
+"向量由 3 个参数表示："
 
 #: src/std/vec.md:6
 msgid "pointer to the data"
@@ -12813,7 +12815,7 @@ msgid ""
 "threshold needs to be surpassed, the vector is reallocated with a larger "
 "capacity."
 msgstr ""
-"容量表示为向量保留了多少内存。只要长度小于容量，向量就可以增长。当需要超过这个阈值时，"
+"容量表示为向量预留的内存量。只要长度小于容量，向量就可以增长。当需要超过这个阈值时，"
 "向量会被重新分配更大的容量。"
 
 #: src/std/vec.md:16
@@ -12822,11 +12824,11 @@ msgstr "// 迭代器可以被收集到向量中\n"
 
 #: src/std/vec.md:18
 msgid "\"Collected (0..10) into: {:?}\""
-msgstr "\"收集 (0..10) 到：{:?}\""
+msgstr "\"将 (0..10) 收集到：{:?}\""
 
 #: src/std/vec.md:20
 msgid "// The `vec!` macro can be used to initialize a vector\n"
-msgstr "// `vec!` 宏可以用来初始化一个向量\n"
+msgstr "// 可以使用 `vec!` 宏初始化向量\n"
 
 #: src/std/vec.md:22
 msgid "\"Initial vector: {:?}\""
@@ -12834,7 +12836,7 @@ msgstr "\"初始向量：{:?}\""
 
 #: src/std/vec.md:24
 msgid "// Insert new element at the end of the vector\n"
-msgstr "// 在向量的末尾插入新元素\n"
+msgstr "// 在向量末尾插入新元素\n"
 
 #: src/std/vec.md:25
 msgid "\"Push 4 into the vector\""
@@ -12846,7 +12848,7 @@ msgstr "\"向量：{:?}\""
 
 #: src/std/vec.md:29
 msgid "// Error! Immutable vectors can't grow\n"
-msgstr "// 错误！不可变向量不能增长\n"
+msgstr "// 错误！不可变向量无法增长\n"
 
 #: src/std/vec.md:33
 msgid ""
@@ -12868,7 +12870,7 @@ msgstr "\"第二个元素：{}\""
 
 #: src/std/vec.md:39
 msgid "// `pop` removes the last element from the vector and returns it\n"
-msgstr "// `pop` 移除向量的最后一个元素并返回它\n"
+msgstr "// `pop` 移除并返回向量的最后一个元素\n"
 
 #: src/std/vec.md:40
 msgid "\"Pop last element: {:?}\""
@@ -12884,7 +12886,7 @@ msgstr "\"第四个元素：{}\""
 
 #: src/std/vec.md:46
 msgid "// `Vector`s can be easily iterated over\n"
-msgstr "// `Vector` 可以很容易地被迭代\n"
+msgstr "// 可以轻松地遍历 `Vector`\n"
 
 #: src/std/vec.md:47
 msgid "\"Contents of xs:\""
@@ -12895,20 +12897,20 @@ msgid ""
 "// A `Vector` can also be iterated over while the iteration\n"
 "    // count is enumerated in a separate variable (`i`)\n"
 msgstr ""
-"// `Vector` 也可以被迭代，同时迭代计数\n"
-"    // 被枚举在一个单独的变量中（`i`）\n"
+"// 遍历 `Vector` 时，可以同时用一个单独的变量（`i`）\n"
+"// 来枚举迭代计数\n"
 
 #: src/std/vec.md:55
 msgid "\"In position {} we have value {}\""
-msgstr "\"在位置 {} 我们有值 {}\""
+msgstr "\"在位置 {} 的值是 {}\""
 
 #: src/std/vec.md:58
 msgid ""
 "// Thanks to `iter_mut`, mutable `Vector`s can also be iterated\n"
 "    // over in a way that allows modifying each value\n"
 msgstr ""
-"// 多亏了 `iter_mut`，可变的 `Vector` 也可以被迭代\n"
-"    // 以一种允许修改每个值的方式\n"
+"// 借助 `iter_mut`，可变的 `Vector` 也可以被遍历，\n"
+"// 并且允许修改每个值\n"
 
 #: src/std/vec.md:63
 msgid "\"Updated vector: {:?}\""
@@ -12931,7 +12933,7 @@ msgid ""
 "always be a valid UTF-8 sequence. `String` is heap allocated, growable and "
 "not null terminated."
 msgstr ""
-"`String` 存储为字节向量（`Vec<u8>`），但保证了是有效的 UTF-8 序列。`String` 是堆分配的，可增长的，且不以 null 结尾。"
+"`String` 存储为字节向量（`Vec<u8>`），但保证始终是有效的 UTF-8 序列。`String` 在堆上分配，可增长，且不以 null 结尾。"
 
 #: src/std/str.md:9
 msgid ""
@@ -12945,32 +12947,32 @@ msgid ""
 "// (all the type annotations are superfluous)\n"
 "    // A reference to a string allocated in read only memory\n"
 msgstr ""
-"// （所有的类型标注都是多余的）\n"
+"// （所有的类型注解都不是必须的）\n"
 "    // 一个指向只读内存中分配的字符串的引用\n"
 
 #: src/std/str.md:16
 msgid "\"the quick brown fox jumps over the lazy dog\""
-msgstr "\"the quick brown fox jumps over the lazy dog\""
+msgstr "\"敏捷的棕色狐狸跳过懒惰的狗\""
 
 #: src/std/str.md:17
 msgid "\"Pangram: {}\""
-msgstr "\"Pangram: {}\""
+msgstr "\"全字母句：{}\""
 
 #: src/std/str.md:19
 msgid "// Iterate over words in reverse, no new string is allocated\n"
-msgstr "// 逆序迭代单词，不会分配新的字符串\n"
+msgstr "// 反向遍历单词，不会分配新的字符串\n"
 
 #: src/std/str.md:20
 msgid "\"Words in reverse\""
-msgstr "\"反向的单词\""
+msgstr "\"单词逆序\""
 
 #: src/std/str.md:25
 msgid "// Copy chars into a vector, sort and remove duplicates\n"
-msgstr "// 将字符复制到向量中，排序并移除重复项\n"
+msgstr "// 将字符复制到向量中，排序并去重\n"
 
 #: src/std/str.md:30
 msgid "// Create an empty and growable `String`\n"
-msgstr "// 创建一个空的可增长的 `String`\n"
+msgstr "// 创建一个空的、可增长的 `String`\n"
 
 #: src/std/str.md:33
 msgid "// Insert a char at the end of string\n"
@@ -12978,14 +12980,14 @@ msgstr "// 在字符串末尾插入一个字符\n"
 
 #: src/std/str.md:35
 msgid "// Insert a string at the end of string\n"
-msgstr "// 在字符串末尾插入一个字符串\n"
+msgstr "// 在字符串末尾追加另一个字符串\n"
 
 #: src/std/str.md:39
 msgid ""
 "// The trimmed string is a slice to the original string, hence no new\n"
 "    // allocation is performed\n"
 msgstr ""
-"// 修剪后的字符串是原始字符串的一个切片，因此不会进行新的分配\n"
+"// 修剪后的字符串是原始字符串的一个切片，因此不会进行新的内存分配\n"
 
 #: src/std/str.md:43
 msgid "\"Used characters: {}\""
@@ -12997,27 +12999,27 @@ msgstr "// 在堆上分配一个字符串\n"
 
 #: src/std/str.md:46
 msgid "\"I like dogs\""
-msgstr "\"I like dogs\""
+msgstr "\"我喜欢狗\""
 
 #: src/std/str.md:47
 msgid "// Allocate new memory and store the modified string there\n"
-msgstr "// 分配新的内存并在那里存储修改后的字符串\n"
+msgstr "// 分配新的内存并在其中存储修改后的字符串\n"
 
 #: src/std/str.md:48
 msgid "\"dog\""
-msgstr "\"dog\""
+msgstr "\"狗\""
 
 #: src/std/str.md:48
 msgid "\"cat\""
-msgstr "\"cat\""
+msgstr "\"猫\""
 
 #: src/std/str.md:50
 msgid "\"Alice says: {}\""
-msgstr "\"Alice 说：{}\""
+msgstr "\"爱丽丝说：{}\""
 
 #: src/std/str.md:51
 msgid "\"Bob says: {}\""
-msgstr "\"Bob 说：{}\""
+msgstr "\"鲍勃说：{}\""
 
 #: src/std/str.md:55
 msgid ""
@@ -13025,11 +13027,12 @@ msgid ""
 "rust-lang.org/std/str/) and [std::string](https://doc.rust-lang.org/std/"
 "string/) modules"
 msgstr ""
-"更多 `str`/`String` 方法可以在 [std::str](https://doc.rust-lang.org/std/str/) 和 [std::string](https://doc.rust-lang.org/std/string/) 模块中找到"
+"更多 `str` 和 `String` 的方法可以在 [std::str](https://doc.rust-lang.org/std/str/) "
+"和 [std::string](https://doc.rust-lang.org/std/string/) 模块中找到"
 
 #: src/std/str.md:60
 msgid "Literals and escapes"
-msgstr "字面值和转义"
+msgstr "字面值和转义字符"
 
 #: src/std/str.md:62
 msgid ""
@@ -13038,7 +13041,9 @@ msgid ""
 "most convenient to write. Similarly there are multiple ways to write byte "
 "string literals, which all result in `&[u8; N]`."
 msgstr ""
-"有多种方式可以编写包含特殊字符的字符串字面值。所有方式都会产生类似的 `&str`，所以最好使用最方便编写的形式。同样，也有多种方式可以编写字节字符串字面值，它们都会产生 `&[u8; N]`。"
+"有多种方式可以编写包含特殊字符的字符串字面值。所有方式都会产生类似的 `&str`，"
+"因此最好使用最方便编写的形式。同样，也有多种方式可以编写字节字符串字面值，"
+"它们都会产生 `&[u8; N]` 类型。"
 
 #: src/std/str.md:67
 msgid ""
@@ -13047,26 +13052,28 @@ msgid ""
 "ones that you don't know how to type. If you want a literal backslash, escape "
 "it with another one: `\\\\`"
 msgstr ""
-"通常特殊字符用反斜杠字符转义：`\\`。这样你可以在字符串中添加任何字符，甚至是不可打印的字符和你不知道如何输入的字符。如果你想要一个字面的反斜杠，用另一个反斜杠转义它：`\\\\`"
+"通常，特殊字符用反斜杠（`\\`）进行转义。这样你可以在字符串中添加任何字符，"
+"包括不可打印的字符和你不知道如何输入的字符。如果你想要一个字面的反斜杠，"
+"用另一个反斜杠转义它：`\\\\`"
 
 #: src/std/str.md:72
 msgid ""
 "String or character literal delimiters occurring within a literal must be "
 "escaped: `\"\\\"\"`, `'\\''`."
 msgstr ""
-"出现在字面值内的字符串或字符字面值分隔符必须被转义：`\"\\\"\"`, `'\\''`。"
+"出现在字面值内的字符串或字符字面值分隔符必须被转义：`\"\\\"\"` 和 `'\\''`。"
 
 #: src/std/str.md:76
 msgid "// You can use escapes to write bytes by their hexadecimal values...\n"
-msgstr "// 你可以使用转义来通过它们的十六进制值写入字节...\n"
+msgstr "// 你可以使用转义来通过十六进制值写入字节...\n"
 
 #: src/std/str.md:77
 msgid "\"I'm writing \\x52\\x75\\x73\\x74!\""
-msgstr "\"I'm writing \\x52\\x75\\x73\\x74!\""
+msgstr "\"我正在写 \\x52\\x75\\x73\\x74！\""
 
 #: src/std/str.md:78
 msgid "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
-msgstr "\"What are you doing\\x3F (\\\\x3F 表示 ?) {}\""
+msgstr "\"你在做什么\\x3F（\\\\x3F 表示 ?）{}\""
 
 #: src/std/str.md:80
 msgid "// ...or Unicode code points.\n"
@@ -13078,7 +13085,7 @@ msgstr "\"\\u{211D}\""
 
 #: src/std/str.md:82
 msgid "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
-msgstr "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
+msgstr "\"\\\"双线大写 R\\\"\""
 
 #: src/std/str.md:84
 msgid "\"Unicode character {} (U+211D) is called {}\""
@@ -13102,7 +13109,7 @@ msgid ""
 "just much more convenient to write a string out as-is. This is where raw "
 "string literals come into play."
 msgstr ""
-"有时需要转义的字符太多，或者直接按原样写出字符串会更方便。这就是原始字符串字面值发挥作用的地方。"
+"有时需要转义的字符太多，或者直接按原样写出字符串会更方便。这时就可以使用原始字符串字面值。"
 
 #: src/std/str.md:101
 msgid "r\"Escapes don't work here: \\x3F \\u{211D}\""
@@ -13110,11 +13117,11 @@ msgstr "r\"转义在这里不起作用：\\x3F \\u{211D}\""
 
 #: src/std/str.md:104
 msgid "// If you need quotes in a raw string, add a pair of #s\n"
-msgstr "// 如果你需要在原始字符串中使用引号，添加一对 #\n"
+msgstr "// 如果你需要在原始字符串中使用引号，可以添加一对 #\n"
 
 #: src/std/str.md:105
 msgid "r#\"And then I said: \"There is no escape!\"\"#"
-msgstr "r#\"然后我说：\"没有转义！\"\"#"
+msgstr "r#\"然后我说：\"无处可逃！\"\"#"
 
 #: src/std/str.md:108
 msgid ""
@@ -13122,7 +13129,7 @@ msgid ""
 "    // You can use up to 255 #s.\n"
 msgstr ""
 "// 如果你需要在字符串中使用 \"#，只需在分隔符中使用更多的 #。\n"
-"    // 你可以使用最多 255 个 #。\n"
+"    // 你最多可以使用 255 个 #。\n"
 
 #: src/std/str.md:110
 msgid "r###\"A string with \"# in it. And even \"##!\"###"
@@ -13134,15 +13141,15 @@ msgid ""
 "UTF-8). Or maybe you want an array of bytes that's mostly text? Byte strings "
 "to the rescue!"
 msgstr ""
-"想要一个非 UTF-8 的字符串？（记住，`str` 和 `String` 必须是有效的 UTF-8）。或者你想要一个主要是文本的字节数组？字节字符串来救场！"
+"想要一个非 UTF-8 的字符串吗？（请记住，`str` 和 `String` 必须是有效的 UTF-8）。或者你想要一个主要是文本的字节数组？字节字符串来帮忙！"
 
 #: src/std/str.md:122
 msgid "// Note that this is not actually a `&str`\n"
-msgstr "// 注意这实际上不是一个 `&str`\n"
+msgstr "// 注意，这实际上不是一个 `&str`\n"
 
 #: src/std/str.md:123
 msgid "b\"this is a byte string\""
-msgstr "b\"this is a byte string\""
+msgstr "b\"这是一个字节字符串\""
 
 #: src/std/str.md:125
 msgid ""
@@ -13157,19 +13164,19 @@ msgstr "\"一个字节字符串：{:?}\""
 
 #: src/std/str.md:128
 msgid "// Byte strings can have byte escapes...\n"
-msgstr "// 字节字符串可以有字节转义...\n"
+msgstr "// 字节字符串可以包含字节转义...\n"
 
 #: src/std/str.md:129
 msgid "b\"\\x52\\x75\\x73\\x74 as bytes\""
-msgstr "b\"\\x52\\x75\\x73\\x74 as bytes\""
+msgstr "b\"\\x52\\x75\\x73\\x74 作为字节\""
 
 #: src/std/str.md:130
 msgid ""
 "// ...but no unicode escapes\n"
 "    // let escaped = b\"\\u{211D} is not allowed\";\n"
 msgstr ""
-"// ...但不允许 unicode 转义\n"
-"    // let escaped = b\"\\u{211D} is not allowed\";\n"
+"// ...但不允许 Unicode 转义\n"
+"    // let escaped = b\"\\u{211D} 是不允许的\";\n"
 
 #: src/std/str.md:132
 msgid "\"Some escaped bytes: {:?}\""
@@ -13177,11 +13184,11 @@ msgstr "\"一些转义的字节：{:?}\""
 
 #: src/std/str.md:135
 msgid "// Raw byte strings work just like raw strings\n"
-msgstr "// 原始字节字符串和原始字符串的写法一样\n"
+msgstr "// 原始字节字符串的工作方式与原始字符串相同\n"
 
 #: src/std/str.md:136
 msgid "br\"\\u{211D} is not escaped here\""
-msgstr "br\"\\u{211D} is not escaped here\""
+msgstr "br\"\\u{211D} 在这里不会被转义\""
 
 #: src/std/str.md:139
 msgid "// Converting a byte array to `str` can fail\n"
@@ -13189,20 +13196,19 @@ msgstr "// 将字节数组转换为 `str` 可能会失败\n"
 
 #: src/std/str.md:141
 msgid "\"And the same as text: '{}'\""
-msgstr "\"同样作为文本：'{}'\""
+msgstr "\"作为文本的相同内容：'{}'\""
 
 #: src/std/str.md:144
 msgid ""
 "br#\"You can also use \"fancier\" formatting, \\\n"
 "                    like with normal raw strings\"#"
 msgstr ""
-"br#\"You can also use \"fancier\" formatting, \\\n"
-"                    like with normal raw strings\"#"
-"/*你也可以使用"更花哨的"格式，就像普通的原始字符串一样*/"
+"br#\"你也可以使用"更花哨的"格式，\\\n"
+"                    就像普通的原始字符串一样\"#"
 
 #: src/std/str.md:147
 msgid "// Byte strings don't have to be UTF-8\n"
-msgstr "// 字节字符串不必是 UTF-8\n"
+msgstr "// 字节字符串不必是 UTF-8 编码\n"
 
 #: src/std/str.md:148
 msgid "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
@@ -13214,7 +13220,7 @@ msgstr "// SHIFT-JIS 编码的 \"ようこそ\"\n"
 
 #: src/std/str.md:150
 msgid "// But then they can't always be converted to `str`\n"
-msgstr "// 但是它们并不总是能被转换为 `str`\n"
+msgstr "// 但它们并不总是能被转换为 `str`\n"
 
 #: src/std/str.md:152
 msgid "\"Conversion successful: '{}'\""
@@ -13237,7 +13243,7 @@ msgid ""
 "characters is given in the ['Tokens' chapter](https://doc.rust-lang.org/"
 "reference/tokens.html) of the Rust Reference."
 msgstr ""
-"关于编写字符串字面量和转义字符的更详细列表，请参阅 Rust 参考手册的 ['Tokens' 章节](https://doc.rust-lang.org/"
+"关于编写字符串字面值和转义字符的更详细说明，请参阅 Rust 参考手册的[「标记」章节](https://doc.rust-lang.org/"
 "reference/tokens.html)。"
 
 #: src/std/option.md:3
@@ -13245,7 +13251,7 @@ msgid ""
 "Sometimes it's desirable to catch the failure of some parts of a program "
 "instead of calling `panic!`; this can be accomplished using the `Option` enum."
 msgstr ""
-"有时我们希望捕获程序某些部分的失败，而不是调用 `panic!`；这可以通过使用 `Option` 枚举来实现。"
+"有时我们希望捕获程序某些部分的失败，而不是调用 `panic!`。这可以通过使用 `Option` 枚举来实现。"
 
 #: src/std/option.md:6
 msgid "The `Option<T>` enum has two variants:"
@@ -13253,19 +13259,19 @@ msgstr "`Option<T>` 枚举有两个变体："
 
 #: src/std/option.md:8
 msgid "`None`, to indicate failure or lack of value, and"
-msgstr "`None`，表示失败或缺少值，以及"
+msgstr "`None`：表示失败或缺少值，以及"
 
 #: src/std/option.md:9
 msgid "`Some(value)`, a tuple struct that wraps a `value` with type `T`."
-msgstr "`Some(value)`，一个包装了类型为 `T` 的 `value` 的元组结构体。"
+msgstr "`Some(value)`：一个元组结构体，包装了类型为 `T` 的 `value`。"
 
 #: src/std/option.md:12
 msgid "// An integer division that doesn't `panic!`\n"
-msgstr "// 一个不会 `panic!` 的整数除法\n"
+msgstr "// 一个不会触发 `panic!` 的整数除法\n"
 
 #: src/std/option.md:15
 msgid "// Failure is represented as the `None` variant\n"
-msgstr "// 失败表示为 `None` 变体\n"
+msgstr "// 失败用 `None` 变体表示\n"
 
 #: src/std/option.md:18
 msgid "// Result is wrapped in a `Some` variant\n"
@@ -13273,11 +13279,11 @@ msgstr "// 结果被包装在 `Some` 变体中\n"
 
 #: src/std/option.md:22
 msgid "// This function handles a division that may not succeed\n"
-msgstr "// 这个函数处理可能不成功的除法\n"
+msgstr "// 这个函数处理可能不成功的除法运算\n"
 
 #: src/std/option.md:25
 msgid "// `Option` values can be pattern matched, just like other enums\n"
-msgstr "// `Option` 值可以被模式匹配，就像其他枚举一样\n"
+msgstr "// `Option` 值可以进行模式匹配，就像其他枚举一样\n"
 
 #: src/std/option.md:27
 msgid "\"{} / {} failed!\""
@@ -13289,19 +13295,19 @@ msgstr "\"{} / {} = {}\""
 
 #: src/std/option.md:38
 msgid "// Binding `None` to a variable needs to be type annotated\n"
-msgstr "// 将 `None` 绑定到变量需要类型标注\n"
+msgstr "// 将 `None` 绑定到变量时需要进行类型注解\n"
 
 #: src/std/option.md:44
 msgid "// Unwrapping a `Some` variant will extract the value wrapped.\n"
-msgstr "// 解包 `Some` 变体将提取被包装的值。\n"
+msgstr "// 解包 `Some` 变体将提取其中包装的值。\n"
 
 #: src/std/option.md:45 src/std/option.md:48
 msgid "\"{:?} unwraps to {:?}\""
-msgstr "\"{:?} 解包为 {:?}\""
+msgstr "\"{:?} 解包后得到 {:?}\""
 
 #: src/std/option.md:47
 msgid "// Unwrapping a `None` variant will `panic!`\n"
-msgstr "// 解包 `None` 变体将会 `panic!`\n"
+msgstr "// 解包 `None` 变体将触发 `panic!`\n"
 
 #: src/std/result.md:3
 msgid ""
@@ -13310,7 +13316,7 @@ msgid ""
 "However, sometimes it is important to express _why_ an operation failed. To "
 "do this we have the `Result` enum."
 msgstr ""
-"我们已经了解到 `Option` 枚举可以作为可能失败的函数的返回值，其中 `None` 用于表示失败。\n"
+"我们已经看到 `Option` 枚举可以用作可能失败的函数的返回值，其中 `None` 用于表示失败。\n"
 "然而，有时表达操作失败的**原因**很重要。为此，我们有 `Result` 枚举。"
 
 #: src/std/result.md:8
@@ -13322,14 +13328,14 @@ msgid ""
 "`Ok(value)` which indicates that the operation succeeded, and wraps the "
 "`value` returned by the operation. (`value` has type `T`)"
 msgstr ""
-"`Ok(value)` 表示操作成功，并包装了操作返回的 `value`。（`value` 的类型为 `T`）"
+"`Ok(value)`：表示操作成功，并包装了操作返回的 `value`。（`value` 的类型为 `T`）"
 
 #: src/std/result.md:12
 msgid ""
 "`Err(why)`, which indicates that the operation failed, and wraps `why`, which "
 "(hopefully) explains the cause of the failure. (`why` has type `E`)"
 msgstr ""
-"`Err(why)`，表示操作失败，并包装了 `why`，它解释了失败的原因（但愿如此）。（`why` 的类型为 `E`）"
+"`Err(why)`：表示操作失败，并包装了 `why`，它（希望）解释了失败的原因。（`why` 的类型为 `E`）"
 
 #: src/std/result.md:17
 msgid "// Mathematical \"errors\" we want to catch\n"
@@ -13340,7 +13346,7 @@ msgid ""
 "// This operation would `fail`, instead let's return the reason of\n"
 "            // the failure wrapped in `Err`\n"
 msgstr ""
-"// 这个操作会"失败"，那么（与其让程序崩溃）不如让我们把失败原因包装在 `Err` 中返回\n"
+"// 这个操作会"失败"，所以我们返回包装在 `Err` 中的失败原因\n"
 
 #: src/std/result.md:33
 msgid "// This operation is valid, return the result wrapped in `Ok`\n"
@@ -13366,10 +13372,9 @@ msgid ""
 "where the `Err(err)` branch expands to an early `return Err(From::"
 "from(err))`, and the `Ok(ok)` branch expands to an `ok` expression."
 msgstr ""
-"嵌套使用 match 处理 result 可能会变得相当混乱；幸运的是，`?` 运算符可以让代码变得整洁。"
-"`?` 用在返回 `Result` 的表达式的末尾，相当于一个 match 表达式，"
-"其中 `Err(err)` 分支展开为提前返回的 `return Err(From::from(err))`，"
-"而 `Ok(ok)` 分支展开为 `ok` 表达式。"
+"使用 match 链式处理结果可能会变得相当混乱；幸运的是，我们可以使用 `?` 运算符来让代码变得整洁。"
+"`?` 运算符用在返回 `Result` 的表达式末尾，等效于一个 match 表达式。在这个表达式中，"
+"`Err(err)` 分支会展开为提前返回的 `return Err(From::from(err))`，而 `Ok(ok)` 分支则展开为 `ok` 表达式。"
 
 #: src/std/result/question_mark.md:44
 msgid "// Intermediate function\n"
@@ -13377,11 +13382,11 @@ msgstr "// 中间函数\n"
 
 #: src/std/result/question_mark.md:46
 msgid "// if `div` \"fails\", then `DivisionByZero` will be `return`ed\n"
-msgstr "// 如果 `div` "失败"，那么 `DivisionByZero` 将被 `return`\n"
+msgstr "// 如果 `div` "失败"，则会 `return` `DivisionByZero`\n"
 
 #: src/std/result/question_mark.md:49
 msgid "// if `ln` \"fails\", then `NonPositiveLogarithm` will be `return`ed\n"
-msgstr "// 如果 `ln` "失败"，那么 `NonPositiveLogarithm` 将被 `return`\n"
+msgstr "// 如果 `ln` "失败"，则会 `return` `NonPositiveLogarithm`\n"
 
 #: src/std/result/question_mark.md:59
 msgid "\"logarithm of non-positive number\""
@@ -13400,8 +13405,8 @@ msgid ""
 "Be sure to check the [documentation](https://doc.rust-lang.org/std/result/"
 "index.html), as there are many methods to map/compose `Result`."
 msgstr ""
-"记得查看[文档](https://doc.rust-lang.org/std/result/index.html)，"
-"因为其中有许多方法可以映射/组合 `Result`。"
+"请务必查阅 [文档](https://doc.rust-lang.org/std/result/index.html)，"
+"其中包含了许多用于映射和组合 `Result` 的方法。"
 
 #: src/std/panic.md:3
 msgid ""
@@ -13409,23 +13414,23 @@ msgid ""
 "stack. While unwinding, the runtime will take care of freeing all the "
 "resources _owned_ by the thread by calling the destructor of all its objects."
 msgstr ""
-"`panic!` 宏可以用来产生一个 panic 并开始展开（unwind）栈。在展开过程中，"
-"运行时将通过调用所有对象的析构函数来释放线程**拥有**的所有资源。"
+"`panic!` 宏可用于生成一个 panic 并开始展开其栈。在展开过程中，"
+"运行时会通过调用该线程所有对象的析构函数来释放线程**拥有**的所有资源。"
 
 #: src/std/panic.md:7
 msgid ""
 "Since we are dealing with programs with only one thread, `panic!` will cause "
 "the program to report the panic message and exit."
 msgstr ""
-"由于我们处理的是只有一个线程的程序，`panic!` 将导致程序报告 panic 消息并退出。"
+"由于我们处理的是只有一个线程的程序，`panic!` 会导致程序报告 panic 消息并退出。"
 
 #: src/std/panic.md:11
 msgid "// Re-implementation of integer division (/)\n"
-msgstr "// 重新实现整数除法 (/)\n"
+msgstr "// 重新实现整数除法（/）\n"
 
 #: src/std/panic.md:14
 msgid "// Division by zero triggers a panic\n"
-msgstr "// 除以零触发 panic\n"
+msgstr "// 除以零会触发 panic\n"
 
 #: src/std/panic.md:20
 msgid "// The `main` task\n"
@@ -13441,15 +13446,15 @@ msgstr "// 这个操作将触发任务失败\n"
 
 #: src/std/panic.md:29
 msgid "\"This point won't be reached!\""
-msgstr "\"这个点不会被达到！\""
+msgstr "\"这个点不会被执行到！\""
 
 #: src/std/panic.md:31
 msgid "// `_x` should get destroyed at this point\n"
-msgstr "// `_x` 应该在这一点被销毁\n"
+msgstr "// `_x` 应该在此处被销毁\n"
 
 #: src/std/panic.md:35
 msgid "Let's check that `panic!` doesn't leak memory."
-msgstr "让我们检查 `panic!` 是否不会泄漏内存。"
+msgstr "让我们验证 `panic!` 不会导致内存泄漏。"
 
 #: src/std/hash.md:3
 msgid ""
@@ -13457,7 +13462,7 @@ msgid ""
 "key. `HashMap` keys can be booleans, integers, strings, or any other type "
 "that implements the `Eq` and `Hash` traits. More on this in the next section."
 msgstr ""
-"动态数组（Vector）通过整数索引存储值，而 `HashMap` 通过键存储值。`HashMap` 的键可以是布尔值、"
+"向量（Vector）通过整数索引存储值，而 `HashMap` 则通过键存储值。`HashMap` 的键可以是布尔值、"
 "整数、字符串，或任何其他实现了 `Eq` 和 `Hash` trait 的类型。下一节将详细介绍这一点。"
 
 #: src/std/hash.md:8
@@ -13468,9 +13473,9 @@ msgid ""
 "`HashMap::new()` to get a HashMap with a default initial capacity "
 "(recommended)."
 msgstr ""
-"与动态数组类似，`HashMap` 也是可增长的，但 HashMap 在有多余空间时也可以自行收缩。"
-"你可以使用 `HashMap::with_capacity(uint)` 创建一个具有特定初始容量的 HashMap，"
-"或者使用 `HashMap::new()` 来获得一个具有默认初始容量的 HashMap（推荐）。"
+"与向量类似，`HashMap` 也可以增长，但当有多余空间时，HashMap 还能自动收缩。"
+"你可以使用 `HashMap::with_capacity(uint)` 创建一个具有指定初始容量的 HashMap，"
+"或使用 `HashMap::new()` 来获得一个具有默认初始容量的 HashMap（推荐）。"
 
 #: src/std/hash.md:19 src/std/hash.md:30
 msgid "\"798-1364\""
@@ -13481,7 +13486,7 @@ msgid ""
 "\"We're sorry, the call cannot be completed as dialed. \n"
 "            Please hang up and try again.\""
 msgstr ""
-"\"很抱歉，无法完成您拨打的电话。\n"
+"\"很抱歉，无法接通您拨打的电话。\n"
 "            请挂机后重试。\""
 
 #: src/std/hash.md:21 src/std/hash.md:31
@@ -13493,8 +13498,8 @@ msgid ""
 "\"Hello, this is Mr. Awesome's Pizza. My name is Fred.\n"
 "            What can I get for you today?\""
 msgstr ""
-"\"你好，这里是 Awesome 先生的披萨店。我是 Fred。\n"
-"            今天您想点些什么？\""
+"\"您好，这里是 Awesome 先生的披萨店。我是 Fred。\n"
+"            请问今天您想点些什么？\""
 
 #: src/std/hash.md:23
 msgid "\"Hi! Who is this again?\""
@@ -13534,14 +13539,14 @@ msgstr "\"正在呼叫 Daniel：{}\""
 
 #: src/std/hash.md:38
 msgid "\"Don't have Daniel's number.\""
-msgstr "\"没有 Daniel 的号码。\""
+msgstr "\"没有 Daniel 的电话号码。\""
 
 #: src/std/hash.md:41
 msgid ""
 "// `HashMap::insert()` returns `None`\n"
 "    // if the inserted value is new, `Some(value)` otherwise\n"
 msgstr ""
-"// `HashMap::insert()` 在插入新值时返回 `None`\n"
+"// 如果插入的值是新的，`HashMap::insert()` 返回 `None`\n"
 "    // 否则返回 `Some(value)`\n"
 
 #: src/std/hash.md:43
@@ -13554,19 +13559,19 @@ msgstr "\"正在呼叫 Ashley：{}\""
 
 #: src/std/hash.md:47
 msgid "\"Don't have Ashley's number.\""
-msgstr "\"没有 Ashley 的号码。\""
+msgstr "\"没有 Ashley 的电话号码。\""
 
 #: src/std/hash.md:52
 msgid ""
 "// `HashMap::iter()` returns an iterator that yields \n"
 "    // (&'a key, &'a value) pairs in arbitrary order.\n"
 msgstr ""
-"// `HashMap::iter()` 返回一个迭代器，该迭代器以任意顺序产生\n"
-"    // (&'a key, &'a value) 对。\n"
+"// `HashMap::iter()` 返回一个迭代器，该迭代器以任意顺序生成\n"
+"    // (&'a key, &'a value) 键值对。\n"
 
 #: src/std/hash.md:55
 msgid "\"Calling {}: {}\""
-msgstr "\"正在呼叫 {}：{}\""
+msgstr "\"正在呼叫{}：{}\""
 
 #: src/std/hash.md:60
 msgid ""
@@ -13574,8 +13579,8 @@ msgid ""
 "tables) work, have a look at [Hash Table Wikipedia](https://en.wikipedia.org/"
 "wiki/Hash_table)"
 msgstr ""
-"要了解更多关于哈希和哈希映射（有时称为哈希表）的工作原理，可以查看 "
-"[哈希表维基百科](https://en.wikipedia.org/wiki/Hash_table)"
+"要了解更多关于哈希和哈希映射（有时称为哈希表）的工作原理，请参阅[哈希表的维基百科页面]"
+"(https://en.wikipedia.org/wiki/Hash_table)"
 
 #: src/std/hash/alt_key_types.md:3
 msgid ""
@@ -13586,7 +13591,7 @@ msgstr ""
 
 #: src/std/hash/alt_key_types.md:6
 msgid "`bool` (though not very useful since there are only two possible keys)"
-msgstr "`bool`（虽然不是很有用，因为只有两个可能的键）"
+msgstr "`bool`（虽然用处不大，因为只有两个可能的键值）"
 
 #: src/std/hash/alt_key_types.md:7
 msgid "`int`, `uint`, and all variations thereof"
@@ -13598,7 +13603,7 @@ msgid ""
 "call `.get()` with an `&str`)"
 msgstr ""
 "`String` 和 `&str`（专业提示：你可以使用 `String` 作为 `HashMap` 的键，"
-"并用 `&str` 调用 `.get()`）"
+"并用 `&str` 调用 `.get()` 方法）"
 
 #: src/std/hash/alt_key_types.md:11
 msgid ""
@@ -13607,9 +13612,8 @@ msgid ""
 "Floating_point#Accuracy_problems) would make using them as hashmap keys "
 "horribly error-prone."
 msgstr ""
-"注意，`f32` 和 `f64` **没有**实现 `Hash`，这很大程度上是由于"
-"[浮点精度误差](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems)，"
-"因此使用它们作为哈希映射键容易出错。"
+"注意，`f32` 和 `f64` **并未**实现 `Hash` trait，这很可能是因为[浮点数精度误差]"
+"(https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems)会导致将它们用作哈希映射的键时极易出错。"
 
 #: src/std/hash/alt_key_types.md:15
 msgid ""
@@ -13617,8 +13621,8 @@ msgid ""
 "respectively implements `Eq` and `Hash`. For example, `Vec<T>` will implement "
 "`Hash` if `T` implements `Hash`."
 msgstr ""
-"如果集合类中包含的类型分别实现了 `Eq` 和 `Hash`，那么这些集合类也就实现了 `Eq` 和 `Hash`。"
-"例如，如果 `T` 实现了 `Hash`，那么 `Vec<T>` 也实现了 `Hash`。"
+"如果集合类中包含的类型分别实现了 `Eq` 和 `Hash`，那么这些集合类也会实现 `Eq` 和 `Hash`。"
+"例如，如果 `T` 实现了 `Hash`，那么 `Vec<T>` 也会实现 `Hash`。"
 
 #: src/std/hash/alt_key_types.md:19
 msgid ""
@@ -13633,7 +13637,7 @@ msgid ""
 "can implement `Eq` and/or `Hash` yourself. This guide will not cover the "
 "specifics of implementing `Hash`."
 msgstr ""
-"编译器会完成剩下的工作。如果你想对细节有更多控制，可以自己实现 `Eq` 和/或 `Hash`。"
+"编译器会完成剩余的工作。如果你想对细节有更多控制，可以自己实现 `Eq` 和/或 `Hash`。"
 "本指南不会涉及实现 `Hash` 的具体细节。"
 
 #: src/std/hash/alt_key_types.md:26
@@ -13641,7 +13645,7 @@ msgid ""
 "To play around with using a `struct` in `HashMap`, let's try making a very "
 "simple user logon system:"
 msgstr ""
-"为了尝试在 `HashMap` 中使用 `struct`，让我们试着制作一个非常简单的用户登录系统："
+"为了尝试在 `HashMap` 中使用 `struct`，让我们来创建一个非常简单的用户登录系统："
 
 #: src/std/hash/alt_key_types.md:31
 msgid "// Eq requires that you derive PartialEq on the type.\n"
@@ -13657,7 +13661,7 @@ msgstr "\"密码：{}\""
 
 #: src/std/hash/alt_key_types.md:50
 msgid "\"Attempting logon...\""
-msgstr "\"尝试登录...\""
+msgstr "\"正在尝试登录...\""
 
 #: src/std/hash/alt_key_types.md:59
 msgid "\"Successful logon!\""
@@ -13669,7 +13673,7 @@ msgstr "\"姓名：{}\""
 
 #: src/std/hash/alt_key_types.md:61
 msgid "\"Email: {}\""
-msgstr "\"邮箱：{}\""
+msgstr "\"电子邮箱：{}\""
 
 #: src/std/hash/alt_key_types.md:63
 msgid "\"Login failed!\""
@@ -13701,14 +13705,14 @@ msgid ""
 "Consider a `HashSet` as a `HashMap` where we just care about the keys "
 "( `HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`)."
 msgstr ""
-"可以将 `HashSet` 当作一个只关心键的 `HashMap`（实际上，`HashSet<T>` 只是 `HashMap<T, ()>` 的一个封装）。"
+"可以将 `HashSet` 视为一个只关心键的 `HashMap`（实际上，`HashSet<T>` 只是 `HashMap<T, ()>` 的封装）。"
 
 #: src/std/hash/hashset.md:6
 msgid ""
 "\"What's the point of that?\" you ask. \"I could just store the keys in a "
 "`Vec`.\""
 msgstr ""
-"你可能会问："这有什么意义？我可以直接把键存储在 `Vec` 中。""
+"你可能会问："这有什么意义？我可以直接把键存储在 `Vec` 中啊。""
 
 #: src/std/hash/hashset.md:8
 msgid ""
@@ -13717,7 +13721,8 @@ msgid ""
 "just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/"
 "std/collections/struct.BTreeSet.html))"
 msgstr ""
-"`HashSet` 的独特之处在于它保证不会有重复的元素。这是任何集合（Set）类型都应该满足的契约。`HashSet` 只是其中一种实现。（参见：[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
+"`HashSet` 的独特之处在于它保证不会有重复元素。这是所有集合类型都应满足的约定。`HashSet` 只是其中一种实现。（另请参阅：[`BTreeSet`]"
+"(https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
 
 #: src/std/hash/hashset.md:13
 msgid ""
@@ -13725,14 +13730,14 @@ msgid ""
 "value is equal to the existing and they both have the same hash), then the "
 "new value will replace the old."
 msgstr ""
-"如果你插入一个已经存在于 `HashSet` 中的值（即新值等于现有值，且它们的哈希值相同），那么新值将替换旧值。"
+"如果你插入一个已存在于 `HashSet` 中的值（即新值等于现有值，且它们的哈希值相同），那么新值将替换旧值。"
 
 #: src/std/hash/hashset.md:17
 msgid ""
 "This is great for when you never want more than one of something, or when you "
 "want to know if you've already got something."
 msgstr ""
-"当你不希望某样东西出现多次，或者想知道是否已经拥有某样东西时，这非常有用。"
+"当你不希望某个元素出现多次，或者想知道是否已经拥有某个元素时，这非常有用。"
 
 #: src/std/hash/hashset.md:20
 msgid "But sets can do more than that."
@@ -13774,11 +13779,11 @@ msgid ""
 "// `HashSet::insert()` returns false if\n"
 "    // there was a value already present.\n"
 msgstr ""
-"// 如果值已经存在，`HashSet::insert()` 返回 false。\n"
+"// 如果集合中已存在该值，`HashSet::insert()` 将返回 false。\n"
 
 #: src/std/hash/hashset.md:47
 msgid "\"Value 4 is already in set B!\""
-msgstr "\"值 4 已经在集合 B 中！\""
+msgstr "\"值 4 已存在于集合 B 中！\""
 
 #: src/std/hash/hashset.md:52
 msgid ""
@@ -13786,17 +13791,17 @@ msgid ""
 "    // then the collection implements `Debug`.\n"
 "    // It usually prints its elements in the format `[elem1, elem2, ...]`\n"
 msgstr ""
-"// 如果集合的元素类型实现了 `Debug`，\n"
-"    // 那么该集合也实现了 `Debug`。\n"
-"    // 它通常以 `[elem1, elem2, ...]` 的格式打印其元素\n"
+"// 如果集合的元素类型实现了 `Debug` 特征，\n"
+"    // 那么该集合也会实现 `Debug` 特征。\n"
+"    // 通常会以 `[elem1, elem2, ...]` 的格式打印其元素\n"
 
 #: src/std/hash/hashset.md:55
 msgid "\"A: {:?}\""
-msgstr "\"A: {:?}\""
+msgstr "\"A：{:?}\""
 
 #: src/std/hash/hashset.md:56
 msgid "\"B: {:?}\""
-msgstr "\"B: {:?}\""
+msgstr "\"B：{:?}\""
 
 #: src/std/hash/hashset.md:58
 msgid "// Print [1, 2, 3, 4, 5] in arbitrary order\n"
@@ -13808,7 +13813,7 @@ msgstr "\"并集：{:?}\""
 
 #: src/std/hash/hashset.md:61
 msgid "// This should print [1]\n"
-msgstr "// 这应该打印 [1]\n"
+msgstr "// 这里应该打印 [1]\n"
 
 #: src/std/hash/hashset.md:62
 msgid "\"Difference: {:?}\""
@@ -13816,7 +13821,7 @@ msgstr "\"差集：{:?}\""
 
 #: src/std/hash/hashset.md:64
 msgid "// Print [2, 3, 4] in arbitrary order.\n"
-msgstr "// 以任意顺序打印 [2, 3, 4]。\n"
+msgstr "// 以任意顺序打印 [2, 3, 4]\n"
 
 #: src/std/hash/hashset.md:65
 msgid "\"Intersection: {:?}\""
@@ -13835,7 +13840,7 @@ msgid ""
 "(Examples are adapted from the [documentation.](https://doc.rust-lang.org/std/"
 "collections/struct.HashSet.html#method.difference))"
 msgstr ""
-"（示例改编自[文档。](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.difference)）"
+"（示例改编自[官方文档](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.difference)）"
 
 #: src/std/rc.md:3
 msgid ""
@@ -13843,7 +13848,7 @@ msgid ""
 "keeps track of the number of the references which means the number of owners "
 "of the value wrapped inside an `Rc`."
 msgstr ""
-"当需要多个所有权时，可以使用 `Rc`（Reference Counting, 引用计数）。`Rc` 会跟踪引用的数量，也就是包裹在 `Rc` 内部的值的所有者数量。"
+"当需要多重所有权时，可以使用 `Rc`（引用计数，Reference Counting）。`Rc` 会跟踪引用的数量，即包裹在 `Rc` 内部的值的所有者数量。"
 
 #: src/std/rc.md:5
 msgid ""
@@ -13852,14 +13857,14 @@ msgid ""
 "`Rc`'s reference count becomes zero (which means there are no remaining "
 "owners), both the `Rc` and the value are all dropped."
 msgstr ""
-"每当克隆一个 `Rc` 时，引用计数就会增加 1，每当一个克隆的 `Rc` 离开作用域时，引用计数就会减少 1。当 `Rc` 的引用计数变为零（这意味着已经没有所有者了）时，`Rc` 和其中的值都会被丢弃。"
+"每当克隆一个 `Rc` 时，其引用计数就会增加 1；每当一个克隆的 `Rc` 离开作用域时，引用计数就会减少 1。当 `Rc` 的引用计数变为零（意味着没有剩余的所有者）时，`Rc` 及其包含的值都会被丢弃。"
 
 #: src/std/rc.md:7
 msgid ""
 "Cloning an `Rc` never performs a deep copy. Cloning creates just another "
 "pointer to the wrapped value, and increments the count."
 msgstr ""
-"克隆 `Rc` 从不执行深拷贝。克隆只是创建另一个指向包裹值的指针，并增加计数。"
+"克隆 `Rc` 从不执行深拷贝。克隆只是创建另一个指向被包裹值的指针，并增加计数。"
 
 #: src/std/rc.md:13
 msgid "\"Rc examples\""
@@ -13867,7 +13872,7 @@ msgstr "\"Rc 示例\""
 
 #: src/std/rc.md:15
 msgid "\"--- rc_a is created ---\""
-msgstr "\"--- rc_a 被创建 ---\""
+msgstr "\"--- rc_a 已创建 ---\""
 
 #: src/std/rc.md:18 src/std/rc.md:25 src/std/rc.md:37
 msgid "\"Reference Count of rc_a: {}\""
@@ -13875,7 +13880,7 @@ msgstr "\"rc_a 的引用计数：{}\""
 
 #: src/std/rc.md:21
 msgid "\"--- rc_a is cloned to rc_b ---\""
-msgstr "\"--- rc_a 被克隆到 rc_b ---\""
+msgstr "\"--- rc_a 被克隆为 rc_b ---\""
 
 #: src/std/rc.md:24
 msgid "\"Reference Count of rc_b: {}\""
@@ -13883,11 +13888,11 @@ msgstr "\"rc_b 的引用计数：{}\""
 
 #: src/std/rc.md:27
 msgid "// Two `Rc`s are equal if their inner values are equal\n"
-msgstr "// 如果两个 `Rc` 的内部值相等，则它们相等\n"
+msgstr "// 两个 `Rc` 如果内部值相等，则它们相等\n"
 
 #: src/std/rc.md:28
 msgid "\"rc_a and rc_b are equal: {}\""
-msgstr "\"rc_a 和 rc_b 相等：{}\""
+msgstr "\"rc_a 和 rc_b 是否相等：{}\""
 
 #: src/std/rc.md:30
 msgid "// We can use methods of a value directly\n"
@@ -13903,11 +13908,11 @@ msgstr "\"rc_b 的值：{}\""
 
 #: src/std/rc.md:34
 msgid "\"--- rc_b is dropped out of scope ---\""
-msgstr "\"--- rc_b 离开作用域 ---\""
+msgstr "\"--- rc_b 超出作用域被释放 ---\""
 
 #: src/std/rc.md:39
 msgid "\"--- rc_a is dropped out of scope ---\""
-msgstr "\"--- rc_a 离开作用域 ---\""
+msgstr "\"--- rc_a 超出作用域被释放 ---\""
 
 #: src/std/rc.md:42
 msgid ""
@@ -13917,21 +13922,21 @@ msgid ""
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
 "// 错误！`rc_examples` 已经被移动到 `rc_a` 中\n"
-"    // 当 `rc_a` 被丢弃时，`rc_examples` 也会一起被丢弃\n"
+"    // 当 `rc_a` 被释放时，`rc_examples` 也会一同被释放\n"
 "    // println!(\"rc_examples: {}\", rc_examples);\n"
-"    // TODO ^ 尝试取消注释这一行\n"
+"    // TODO：尝试取消注释上面这行\n"
 
 #: src/std/rc.md:51
 msgid ""
 "[std::rc](https://doc.rust-lang.org/std/rc/index.html) and [std::sync::arc]"
 "(https://doc.rust-lang.org/std/sync/struct.Arc.html)."
 msgstr ""
-"[std::rc](https://doc.rust-lang.org/std/rc/index.html) 和 [std::sync::arc]"
+"[`std::rc`](https://doc.rust-lang.org/std/rc/index.html) 和 [`std::sync::arc`]"
 "(https://doc.rust-lang.org/std/sync/struct.Arc.html)。"
 
 #: src/std/arc.md:1
 msgid "Arc"
-msgstr "Arc"
+msgstr "Arc（原子引用计数）"
 
 #: src/std/arc.md:3
 msgid ""
@@ -13942,11 +13947,14 @@ msgid ""
 "when the last reference pointer to a value is out of scope, the variable is "
 "dropped."
 msgstr ""
-"当需要在线程间共享所有权时，可以使用 `Arc`（Atomically Reference Counted，原子引用计数）。这个结构体通过 `Clone` 实现可以为内存堆中值的位置创建一个引用指针，同时增加引用计数。由于它在线程间共享所有权，当最后一个指向某个值的引用指针离开作用域时，该变量就会被释放。"
+"当需要在线程间共享所有权时，可以使用 `Arc`（原子引用计数，Atomically Reference "
+"Counted）。通过 `Clone` 实现，这个结构体可以为堆内存中值的位置创建一个引用指针，"
+"同时增加引用计数。由于它在线程间共享所有权，当指向某个值的最后一个引用指针超出"
+"作用域时，该变量就会被释放。"
 
 #: src/std/arc.md:15
 msgid "// This variable declaration is where its value is specified.\n"
-msgstr "// 这个变量声明指定了它的值。\n"
+msgstr "// 在这个变量声明中指定了它的值。\n"
 
 #: src/std/arc.md:16
 msgid "\"the same apple\""
@@ -13957,7 +13965,7 @@ msgid ""
 "// Here there is no value specification as it is a pointer to a\n"
 "        // reference in the memory heap.\n"
 msgstr ""
-"// 这里没有值的指定，因为它是指向内存堆中引用的指针。\n"
+"// 这里没有指定值，因为它是指向堆内存中引用的指针。\n"
 "        // \n"
 
 #: src/std/arc.md:24
@@ -13965,7 +13973,7 @@ msgid ""
 "// As Arc was used, threads can be spawned using the value allocated\n"
 "            // in the Arc variable pointer's location.\n"
 msgstr ""
-"// 由于使用了 Arc，可以使用 Arc 变量指针位置中分配的值来生成线程。\n"
+"// 由于使用了 Arc，可以使用 Arc 变量指针所指向的值来生成线程。\n"
 "            // \n"
 
 #: src/std/arc.md:30
@@ -13975,49 +13983,49 @@ msgstr "// 确保所有 Arc 实例都从生成的线程中打印出来。\n"
 #: src/std_misc.md:3
 msgid ""
 "Many other types are provided by the std library to support things such as:"
-msgstr "标准库提供了许多其他类型来支持诸如以下功能："
+msgstr "标准库提供了许多其他类型来支持各种功能，例如："
 
 #: src/std_misc.md:10
 msgid "These expand beyond what the [primitives](primitives.md) provide."
-msgstr "这些扩展了[原生类型](primitives.md)所提供的功能。"
+msgstr "这些类型扩展了[基本类型](primitives.md)所提供的功能。"
 
 #: src/std_misc/threads.md:3
 msgid ""
 "Rust provides a mechanism for spawning native OS threads via the `spawn` "
 "function, the argument of this function is a moving closure."
 msgstr ""
-"Rust 通过 `spawn` 函数提供了一种生成原生操作系统线程的机制，这个函数的参数是一个移动（moving）闭包。"
+"Rust 通过 `spawn` 函数提供了一种生成原生操作系统线程的机制，该函数的参数是一个移动闭包。"
 
 #: src/std_misc/threads.md:10 src/std_misc/threads/testcase_mapreduce.md:28
 msgid "// This is the `main` thread\n"
-msgstr "// 这是 `main` 线程\n"
+msgstr "// 这是主线程\n"
 
 #: src/std_misc/threads.md:13
 msgid "// Make a vector to hold the children which are spawned.\n"
-msgstr "// 创建一个动态数组来保存生成的子线程。\n"
+msgstr "// 创建一个向量来存储生成的子线程\n"
 
 #: src/std_misc/threads.md:17
 msgid "// Spin up another thread\n"
-msgstr "// 启动另一个线程\n"
+msgstr "// 启动一个新线程\n"
 
 #: src/std_misc/threads.md:19
 msgid "\"this is thread number {}\""
-msgstr "\"这是线程 {}\""
+msgstr "\"这是第 {} 号线程\""
 
 #: src/std_misc/threads.md:24
 msgid "// Wait for the thread to finish. Returns a result.\n"
-msgstr "// 等待线程结束。返回一个结果。\n"
+msgstr "// 等待线程完成，返回一个结果\n"
 
 #: src/std_misc/threads.md:30
 msgid "These threads will be scheduled by the OS."
-msgstr "这些线程将由操作系统调度。"
+msgstr "这些线程将由操作系统进行调度。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:3
 msgid ""
 "Rust makes it very easy to parallelise data processing, without many of the "
 "headaches traditionally associated with such an attempt."
 msgstr ""
-"Rust 使得并行化数据处理变得非常容易，避免了并行处理的很多传统难题。"
+"Rust 使并行数据处理变得非常简单，避免了传统并行处理中常见的诸多问题。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:5
 msgid ""
@@ -14025,7 +14033,7 @@ msgid ""
 "These, combined with Rust's concept of Ownership and aliasing rules, "
 "automatically prevent data races."
 msgstr ""
-"标准库提供了开箱即用的出色线程原语，它们与 Rust 的所有权概念和别名规则相结合，可以自动防止数据竞争。。"
+"标准库提供了开箱即用的优秀线程原语。这些原语结合 Rust 的所有权概念和别名规则，自动防止了数据竞争。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:9
 msgid ""
@@ -14034,7 +14042,7 @@ msgid ""
 "threads. (Where synchronisation is needed, there are synchronisation "
 "primitives like `Mutex`es or `Channel`s.)"
 msgstr ""
-"别名规则（一个可写引用或多个可读引用）自动防止你操作对其他线程可见的状态。（在需要同步处理时，有像 `Mutex` 或 `Channel` 这样的同步原语。）"
+"别名规则（一个可写引用或多个可读引用）自动防止你操作对其他线程可见的状态。（在需要同步的情况下，可以使用 `Mutex` 或 `Channel` 等同步原语。）"
 
 #: src/std_misc/threads/testcase_mapreduce.md:14
 msgid ""
@@ -14043,7 +14051,7 @@ msgid ""
 "threads. Each thread will sum its tiny block of digits, and subsequently we "
 "will sum the intermediate sums produced by each thread."
 msgstr ""
-"在这个例子中，我们将计算一个数字块中所有数字的总和。我们将通过将块的不同部分分配给不同的线程来完成这个任务。每个线程将计算其小块数字的总和，随后我们将汇总每个线程产生的中间总和。"
+"在这个例子中，我们将计算一个数字块中所有数字的总和。我们通过将数字块分成小块并分配给不同的线程来完成这个任务。每个线程将计算其小块数字的总和，随后我们将汇总每个线程产生的中间结果。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:19
 msgid ""
@@ -14055,7 +14063,7 @@ msgid ""
 "data between threads, you can use a smart pointer like `Arc` to keep the data "
 "alive and avoid non-`static` lifetimes.)"
 msgstr ""
-"注意，尽管我们在线程之间传递引用，但是 Rust 理解我们只是传递只读引用，因此不会造成不安全或数据竞争的情况。此外，因为我们传递的引用具有 `'static` 生命周期，Rust 会确保被引用的数据在这些线程仍在运行时不会被销毁。（当你需要在线程之间共享非 `static` 数据时，你可以使用像 `Arc` 这样的智能指针来确保数据的存活。）"
+"注意，尽管我们在线程间传递引用，但 Rust 理解我们只是传递只读引用，因此不会发生不安全操作或数据竞争。此外，由于我们传递的引用具有 `'static` 生命周期，Rust 确保这些线程运行时数据不会被销毁。（当需要在线程间共享非 `static` 数据时，可以使用 `Arc` 等智能指针来保持数据存活并避免非 `static` 生命周期。）"
 
 #: src/std_misc/threads/testcase_mapreduce.md:32
 msgid ""
@@ -14067,11 +14075,11 @@ msgid ""
 "    //\n"
 "    // TODO: see what happens to the output if you insert spaces!\n"
 msgstr ""
-"// 这是我们要处理的数据。\n"
-"    // 我们将通过一个线程化的 map-reduce 算法计算所有数字的总和。\n"
-"    // 每个由空格分隔的块将在不同的线程中处理。\n"
+"// 这是我们要处理的数据\n"
+"    // 我们将通过一个线程化的 map-reduce 算法计算所有数字的总和\n"
+"    // 每个由空格分隔的块将在不同的线程中处理\n"
 "    //\n"
-"    // TODO：看看如果你插入空格会发生什么！\n"
+"    // TODO：试试插入空格会对输出有什么影响！\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:37
 msgid ""
@@ -14095,7 +14103,7 @@ msgstr ""
 
 #: src/std_misc/threads/testcase_mapreduce.md:46
 msgid "// Make a vector to hold the child-threads which we will spawn.\n"
-msgstr "// 创建一个动态数组来保存我们将要生成的子线程。\n"
+msgstr "// 创建一个向量来存储我们将要生成的子线程。\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:49
 msgid ""
@@ -14106,9 +14114,9 @@ msgid ""
 "     ************************************************************************/"
 msgstr ""
 "/*************************************************************************\n"
-"     * \"Map\" 阶段\n"
+"     * "Map"阶段\n"
 "     *\n"
-"     * 将我们的数据分成段，并进行初始处理\n"
+"     * 将数据分割成多个段，并进行初步处理\n"
 "     ************************************************************************/"
 
 #: src/std_misc/threads/testcase_mapreduce.md:55
@@ -14116,8 +14124,8 @@ msgid ""
 "// split our data into segments for individual calculation\n"
 "    // each chunk will be a reference (&str) into the actual data\n"
 msgstr ""
-"// 将我们的数据分成段以进行单独计算\n"
-"    // 每个块将是对实际数据的引用 (&str)\n"
+"// 将数据分割成多个段以进行单独计算\n"
+"    // 每个数据块都是指向实际数据的引用（&str）\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:59
 msgid ""
@@ -14128,15 +14136,15 @@ msgid ""
 "a\n"
 "    // \"destructuring assignment\"\n"
 msgstr ""
-"// 遍历数据段。\n"
+"// 遍历数据段\n"
 "    // .enumerate() 为迭代的每个元素添加当前循环索引\n"
-"    // 结果元组 \"(index, element)\" 然后立即\n"
-"    // 通过 \"解构赋值\" 被 \"解构\" 为两个变量，\"i\" 和 \"data_segment\"\n"
+"    // 生成的元组"(索引, 元素)"随后立即通过\n"
+"    // "解构赋值"被"解构"为两个变量："i"和"data_segment"\n"
 "    // \n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:65
 msgid "\"data segment {} is \\\"{}\\\"\""
-msgstr "\"数据段 {} 是 \\\"{}\\\"\""
+msgstr "\"数据段 {} 是"{}"\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:67
 msgid ""
@@ -14158,28 +14166,29 @@ msgstr ""
 "// 在单独的线程中处理每个数据段\n"
 "        //\n"
 "        // spawn() 返回新线程的句柄，\n"
-"        // 我们必须保留它以访问返回值\n"
+"        // 我们必须保留该句柄以访问返回值\n"
 "        //\n"
 "        // 'move || -> u32' 是一个闭包的语法，它：\n"
 "        // * 不接受参数（'||'）\n"
-"        // * 获取其捕获变量的所有权（'move'）并\n"
+"        // * 获取其捕获变量的所有权（'move'）\n"
 "        // * 返回一个无符号 32 位整数（'-> u32'）\n"
 "        //\n"
-"        // Rust 足够聪明，能从闭包本身推断出 '-> u32'，\n"
+"        // Rust 足够智能，能从闭包本身推断出 '-> u32'，\n"
 "        // 所以我们可以省略它。\n"
 "        //\n"
+"        // TODO：尝试移除 'move' 并观察结果\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:82
 msgid "// Calculate the intermediate sum of this segment:\n"
-msgstr "// 计算这个段的中间和：\n"
+msgstr "// 计算此段的中间和：\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:84
 msgid "// iterate over the characters of our segment..\n"
-msgstr "// 遍历我们段中的字符..\n"
+msgstr "// 遍历此段中的字符...\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:86
 msgid "// .. convert text-characters to their number value..\n"
-msgstr "// .. 将文本字符转换为它们的数值..\n"
+msgstr "// ...将文本字符转换为对应的数值...\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:87
 msgid "\"should be a digit\""
@@ -14187,15 +14196,15 @@ msgstr "\"应该是一个数字\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:88
 msgid "// .. and sum the resulting iterator of numbers\n"
-msgstr "// .. 并对结果数字迭代器求和\n"
+msgstr "// ...并对结果数字迭代器求和\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:91
 msgid "// println! locks stdout, so no text-interleaving occurs\n"
-msgstr "// println! 锁定 stdout，所以不会发生文本交错\n"
+msgstr "// println! 会锁定标准输出，因此不会出现文本交错\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:92
 msgid "\"processed segment {}, result={}\""
-msgstr "\"处理段 {}，结果={}\""
+msgstr "\"已处理段 {}，结果={}\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:94
 msgid ""
@@ -14203,8 +14212,8 @@ msgid ""
 "            // last evaluated expression in each block is automatically its "
 "value.\n"
 msgstr ""
-"// 不需要 \"return\"，因为 Rust 是一种 \"表达式语言\"，\n"
-"            // 每个块中最后求值的表达式自动成为其值。\n"
+"// 不需要使用 \"return\"，因为 Rust 是一种"表达式语言"，\n"
+"// 每个代码块中最后求值的表达式会自动成为该块的返回值。\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:102
 msgid ""
@@ -14218,7 +14227,7 @@ msgstr ""
 "/*************************************************************************\n"
 "     * \"归约\"阶段\n"
 "     *\n"
-"     * 收集我们的中间结果，并将它们合并成最终结果\n"
+"     * 收集中间结果，并将它们合并成最终结果\n"
 "     ************************************************************************/"
 
 #: src/std_misc/threads/testcase_mapreduce.md:108
@@ -14253,7 +14262,7 @@ msgid ""
 "into a limited number of chunks, defined by a static constant at the "
 "beginning of the program."
 msgstr ""
-"让线程数量依赖于用户输入的数据并不明智。如果用户决定插入大量空格怎么办？我们真的想要生成 2,000 个线程吗？修改程序，使数据始终被分割成有限数量的块，这个数量由程序开头的静态常量定义。"
+"让线程数量依赖于用户输入的数据并不明智。如果用户决定插入大量空格，我们真的想要创建 2,000 个线程吗？修改程序，使数据始终被分割成固定数量的块，这个数量应由程序开头定义的静态常量来确定。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:129
 msgid "[Threads](../threads.md)"
@@ -14283,11 +14292,11 @@ msgid ""
 "[turbofish notation](https://doc.rust-lang.org/book/appendix-02-operators."
 "html?highlight=turbofish) to help type inference"
 msgstr ""
-"[turbofish 符号](https://doc.rust-lang.org/book/appendix-02-operators.html?highlight=turbofish)以帮助类型推断"
+"[涡轮鱼符号](https://doc.rust-lang.org/book/appendix-02-operators.html?highlight=turbofish)用于辅助类型推断"
 
 #: src/std_misc/threads/testcase_mapreduce.md:134
 msgid "[unwrap vs. expect](../../error/option_unwrap.md)"
-msgstr "[unwrap vs. expect](../../error/option_unwrap.md)"
+msgstr "[unwrap 与 expect](../../error/option_unwrap.md)"
 
 #: src/std_misc/threads/testcase_mapreduce.md:135
 msgid "[enumerate](https://doc.rust-lang.org/book/loops.html#enumerate)"
@@ -14299,7 +14308,7 @@ msgid ""
 "Channels allow a unidirectional flow of information between two end-points: "
 "the `Sender` and the `Receiver`."
 msgstr ""
-"Rust 提供异步 `channels`（信道）用于线程间通信。信道允许信息在两个端点之间单向流动：`Sender`（发送端）和 `Receiver`（接收端）。"
+"Rust 提供异步通道（`channels`）用于线程间通信。通道允许信息在两个端点之间单向流动：发送端（`Sender`）和接收端（`Receiver`）。"
 
 #: src/std_misc/channels.md:15
 msgid ""
@@ -14307,9 +14316,9 @@ msgid ""
 "    // where `T` is the type of the message to be transferred\n"
 "    // (type annotation is superfluous)\n"
 msgstr ""
-"// 信道有两个端点：`Sender<T>` 和 `Receiver<T>`，\n"
-"    // 其中 `T` 是要传输的消息的类型\n"
-"    // （类型标注是多余的）\n"
+"// 通道有两个端点：`Sender<T>` 和 `Receiver<T>`，\n"
+"    // 其中 `T` 是要传输的消息类型\n"
+"    // （此处的类型注解是多余的）\n"
 
 #: src/std_misc/channels.md:22
 msgid "// The sender endpoint can be copied\n"
@@ -14317,7 +14326,7 @@ msgstr "// 发送端可以被复制\n"
 
 #: src/std_misc/channels.md:25
 msgid "// Each thread will send its id via the channel\n"
-msgstr "// 每个线程将通过信道发送其 id\n"
+msgstr "// 每个线程将通过通道发送其 ID\n"
 
 #: src/std_misc/channels.md:27
 msgid ""
@@ -14325,23 +14334,23 @@ msgid ""
 "            // Each thread queues a message in the channel\n"
 msgstr ""
 "// 线程获取 `thread_tx` 的所有权\n"
-"            // 每个线程在信道中排队一条消息\n"
+"            // 每个线程在通道中排队一条消息\n"
 
 #: src/std_misc/channels.md:31
 msgid ""
 "// Sending is a non-blocking operation, the thread will continue\n"
 "            // immediately after sending its message\n"
 msgstr ""
-"// 发送是非阻塞操作，线程将在发送消息后\n"
-"            // 立即继续执行\n"
+"// 发送是非阻塞操作，线程在发送消息后\n"
+"            // 会立即继续执行\n"
 
 #: src/std_misc/channels.md:33
 msgid "\"thread {} finished\""
-msgstr "\"线程 {} 完成\""
+msgstr "\"线程 {} 已完成\""
 
 #: src/std_misc/channels.md:39
 msgid "// Here, all the messages are collected\n"
-msgstr "// 在这里，所有消息都被收集\n"
+msgstr "// 在这里收集所有消息\n"
 
 #: src/std_misc/channels.md:42
 msgid ""
@@ -14349,12 +14358,12 @@ msgid ""
 "        // `recv` will block the current thread if there are no messages "
 "available\n"
 msgstr ""
-"// `recv` 方法从信道中获取一条消息\n"
-"        // 如果没有可用的消息，`recv` 将阻塞当前线程\n"
+"// `recv` 方法从通道中获取一条消息\n"
+"        // 如果没有可用消息，`recv` 将阻塞当前线程\n"
 
 #: src/std_misc/channels.md:47
 msgid "// Wait for the threads to complete any remaining work\n"
-msgstr "// 等待线程完成任何剩余工作\n"
+msgstr "// 等待线程完成所有剩余工作\n"
 
 #: src/std_misc/channels.md:49
 msgid "\"oops! the child thread panicked\""
@@ -14371,14 +14380,14 @@ msgid ""
 "`windows::Path`, for Windows. The prelude exports the appropriate platform-"
 "specific `Path` variant."
 msgstr ""
-"`Path` 结构体表示底层文件系统中的文件路径。`Path` 有两种风格：用于类 UNIX 系统的 `posix::Path` 和用于 Windows 的 `windows::Path`。prelude 导出了适合特定平台的 `Path` 变体。"
+"`Path` 结构体表示底层文件系统中的文件路径。`Path` 有两种变体：用于类 UNIX 系统的 `posix::Path` 和用于 Windows 的 `windows::Path`。prelude 会导出适合特定平台的 `Path` 变体。"
 
 #: src/std_misc/path.md:8
 msgid ""
 "A `Path` can be created from an `OsStr`, and provides several methods to get "
 "information from the file/directory the path points to."
 msgstr ""
-"`Path` 可以从 `OsStr` 创建，并提供几种方法来获取路径指向的文件/目录的信息。"
+"`Path` 可以从 `OsStr` 创建，并提供多种方法来获取路径所指向的文件或目录的信息。"
 
 #: src/std_misc/path.md:11
 msgid ""
@@ -14386,7 +14395,7 @@ msgid ""
 "between `Path` and `PathBuf` is similar to that of `str` and `String`: a "
 "`PathBuf` can be mutated in-place, and can be dereferenced to a `Path`."
 msgstr ""
-"`Path` 是不可变的。`Path` 的所有权版本是 `PathBuf`。`Path` 和 `PathBuf` 之间的关系类似于 `str` 和 `String`：`PathBuf` 可以就地修改，并且可以解引用为 `Path`。"
+"`Path` 是不可变的。`Path` 的所有权版本是 `PathBuf`。`Path` 和 `PathBuf` 之间的关系类似于 `str` 和 `String`：`PathBuf` 可以原地修改，并且可以解引用为 `Path`。"
 
 #: src/std_misc/path.md:15
 msgid ""
@@ -14396,7 +14405,7 @@ msgid ""
 "`Path` can be freely converted to an `OsString` or `&OsStr` using "
 "`into_os_string` and `as_os_str`, respectively."
 msgstr ""
-"注意，`Path` 在内部**不是**表示为 UTF-8 字符串，而是存储为 `OsString`。因此，将 `Path` 转换为 `&str` **不是**零开销的，并且可能失败（返回一个 `Option`）。然而，`Path` 可以自由地转换为 `OsString` 或 `&OsStr`，分别使用 `into_os_string` 和 `as_os_str`。"
+"注意，`Path` 在内部**并非**表示为 UTF-8 字符串，而是存储为 `OsString`。因此，将 `Path` 转换为 `&str` **并非**零开销操作，且可能失败（返回一个 `Option`）。然而，`Path` 可以自由地转换为 `OsString` 或 `&OsStr`，分别使用 `into_os_string` 和 `as_os_str` 方法。"
 
 #: src/std_misc/path.md:25
 msgid "// Create a `Path` from an `&'static str`\n"
@@ -14408,7 +14417,7 @@ msgstr "\".\""
 
 #: src/std_misc/path.md:28
 msgid "// The `display` method returns a `Display`able structure\n"
-msgstr "// `display` 方法返回一个可 `Display` 的结构体\n"
+msgstr "// `display` 方法返回一个可用于显示的结构体\n"
 
 #: src/std_misc/path.md:31
 msgid ""
@@ -14451,7 +14460,7 @@ msgid ""
 "Be sure to check at other `Path` methods (`posix::Path` or `windows::Path`) "
 "and the `Metadata` struct."
 msgstr ""
-"记得看看其他 `Path` 方法（`posix::Path` 或 `windows::Path`）和 `Metadata` 结构体。"
+"请务必查看其他 `Path` 方法（`posix::Path` 或 `windows::Path`）以及 `Metadata` 结构体。"
 
 #: src/std_misc/path.md:56
 msgid ""
@@ -14466,14 +14475,14 @@ msgid ""
 "The `File` struct represents a file that has been opened (it wraps a file "
 "descriptor), and gives read and/or write access to the underlying file."
 msgstr ""
-"`File` 结构体表示一个已打开的文件（它包装了一个文件描述符），并提供对底层文件的读取和/或写入访问。"
+"`File` 结构体表示一个已打开的文件（它封装了一个文件描述符），并提供对底层文件的读取和/或写入访问。"
 
 #: src/std_misc/file.md:6
 msgid ""
 "Since many things can go wrong when doing file I/O, all the `File` methods "
 "return the `io::Result<T>` type, which is an alias for `Result<T, io::Error>`."
 msgstr ""
-"由于在进行文件 I/O 时可能会出现各种错误，因此所有的 `File` 方法都返回 `io::Result<T>` 类型，这是 `Result<T, io::Error>` 的别名。"
+"由于文件 I/O 操作可能会出现多种错误，所有 `File` 方法都返回 `io::Result<T>` 类型，这是 `Result<T, io::Error>` 的别名。"
 
 #: src/std_misc/file.md:9
 msgid ""
@@ -14481,7 +14490,7 @@ msgid ""
 "programmer can see all the failure paths, and is encouraged to handle them in "
 "a proactive manner."
 msgstr ""
-"这让所有 I/O 操作的失败都是**显性的**。得益于此，程序员可以看到所有的失败路径，并被鼓励主动处理它们。"
+"这使得所有 I/O 操作的失败都变得**显式**。得益于此，程序员可以看到所有可能的失败路径，并被鼓励主动处理这些情况。"
 
 #: src/std_misc/file/open.md:3
 msgid "The `open` function can be used to open a file in read-only mode."
@@ -14492,11 +14501,11 @@ msgid ""
 "A `File` owns a resource, the file descriptor and takes care of closing the "
 "file when it is `drop`ed."
 msgstr ""
-"`File` 拥有一个资源，即文件描述符，并在被 `drop` 时负责关闭文件。"
+"`File` 拥有一个资源（即文件描述符），并在被 `drop` 时负责关闭文件。"
 
 #: src/std_misc/file/open.md:14
 msgid "// Create a path to the desired file\n"
-msgstr "// 创建指向所需文件的路径\n"
+msgstr "// 创建指向目标文件的路径\n"
 
 #: src/std_misc/file/open.md:15
 msgid "\"hello.txt\""
@@ -14520,16 +14529,16 @@ msgstr "\"无法读取 {}: {}\""
 
 #: src/std_misc/file/open.md:28
 msgid "\"{} contains:\\n{}\""
-msgstr "\"{} 包含：\\n{}\""
+msgstr "\"{} 的内容：\\n{}\""
 
 #: src/std_misc/file/open.md:31
 msgid "// `file` goes out of scope, and the \"hello.txt\" file gets closed\n"
-msgstr "// `file` 超出作用域，\"hello.txt\" 文件被关闭\n"
+msgstr "// `file` 超出作用域，\"hello.txt\" 文件随之关闭\n"
 
 #: src/std_misc/file/open.md:35 src/std_misc/file/create.md:39
 #: src/std_misc/fs.md:109
 msgid "Here's the expected successful output:"
-msgstr "这是预期的成功输出："
+msgstr "以下是预期的成功输出："
 
 #: src/std_misc/file/open.md:37
 msgid ""
@@ -14543,7 +14552,7 @@ msgstr ""
 "```shell\n"
 "$ echo \"Hello World!\" > hello.txt\n"
 "$ rustc open.rs && ./open\n"
-"hello.txt 包含：\n"
+"hello.txt 的内容：\n"
 "Hello World!\n"
 "```"
 
@@ -14552,14 +14561,14 @@ msgid ""
 "(You are encouraged to test the previous example under different failure "
 "conditions: `hello.txt` doesn't exist, or `hello.txt` is not readable, etc.)"
 msgstr ""
-"（再试试在不同的失败条件下测试前面的例子：`hello.txt` 不存在，或 `hello.txt` 不可读等。）"
+"（建议您在不同的失败情况下测试上述示例：例如 `hello.txt` 不存在，或 `hello.txt` 不可读等。）"
 
 #: src/std_misc/file/create.md:3
 msgid ""
 "The `create` function opens a file in write-only mode. If the file already "
 "existed, the old content is destroyed. Otherwise, a new file is created."
 msgstr ""
-"`create` 函数以只写模式打开文件。如果文件已经存在，旧内容会被销毁。否则，会创建一个新文件。"
+"`create` 函数以只写模式打开文件。如果文件已存在，旧内容会被清除；否则，会创建一个新文件。"
 
 #: src/std_misc/file/create.md:9
 msgid ""
@@ -14591,7 +14600,7 @@ msgstr "// 以只写模式打开文件，返回 `io::Result<File>`\n"
 
 #: src/std_misc/file/create.md:27
 msgid "\"couldn't create {}: {}\""
-msgstr "\"couldn't create {}: {}\""
+msgstr "\"无法创建 {}: {}\""
 
 #: src/std_misc/file/create.md:31
 msgid "// Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`\n"
@@ -14599,18 +14608,18 @@ msgstr "// 将 `LOREM_IPSUM` 字符串写入 `file`，返回 `io::Result<()>`\n"
 
 #: src/std_misc/file/create.md:33
 msgid "\"couldn't write to {}: {}\""
-msgstr "\"couldn't write to {}: {}\""
+msgstr "\"无法写入 {}: {}\""
 
 #: src/std_misc/file/create.md:34
 msgid "\"successfully wrote to {}\""
-msgstr "\"successfully wrote to {}\""
+msgstr "\"成功写入 {}\""
 
 #: src/std_misc/file/create.md:53
 msgid ""
 "(As in the previous example, you are encouraged to test this example under "
 "failure conditions.)"
 msgstr ""
-"（和前面的例子一样，再试试在失败条件下测试这个例子。）"
+"（与前面的示例类似，建议您在失败情况下测试此示例。）"
 
 #: src/std_misc/file/create.md:56
 msgid ""
@@ -14618,7 +14627,7 @@ msgid ""
 "struct can be used to configure how a file is opened."
 msgstr ""
 "[`OpenOptions`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html) "
-"结构体可用于配置如何打开文件。"
+"结构体可用于配置文件的打开方式。"
 
 #: src/std_misc/file/read_lines.md:3
 msgid "A naive approach"
@@ -14629,7 +14638,7 @@ msgid ""
 "This might be a reasonable first attempt for a beginner's first "
 "implementation for reading lines from a file."
 msgstr ""
-"对于初学者来说，这可能是从文件中读取行的第一个尝试。"
+"对于初学者来说，这可能是从文件中读取行的一个合理的初步尝试。"
 
 #: src/std_misc/file/read_lines.md:22
 msgid ""
@@ -14637,11 +14646,11 @@ msgid ""
 "can also perform a map inline and collect the results, yielding a more "
 "concise and fluent expression."
 msgstr ""
-"由于 `lines()` 方法返回文件中各行的迭代器，我们也可以内联执行 map 并收集结果，从而得到一个更简洁流畅的表达式。"
+"由于 `lines()` 方法返回文件中各行的迭代器，我们可以内联执行 map 并收集结果，从而得到一个更简洁流畅的表达式。"
 
 #: src/std_misc/file/read_lines.md:31
 msgid "// panic on possible file-reading errors\n"
-msgstr "// 在可能的文件读取错误时 panic\n"
+msgstr "// 遇到可能的文件读取错误时 panic\n"
 
 #: src/std_misc/file/read_lines.md:32
 msgid "// split the string into an iterator of string slices\n"
@@ -14649,7 +14658,7 @@ msgstr "// 将字符串分割成字符串切片的迭代器\n"
 
 #: src/std_misc/file/read_lines.md:33
 msgid "// make each slice into a string\n"
-msgstr "// 将每个切片转换成字符串\n"
+msgstr "// 将每个切片转换为字符串\n"
 
 #: src/std_misc/file/read_lines.md:34
 msgid "// gather them together into a vector\n"
@@ -14661,7 +14670,7 @@ msgid ""
 "returned from `lines()` to the owned type `String`, using `.to_string()` and "
 "`String::from` respectively."
 msgstr ""
-"注意，在上面的两个例子中，我们都必须将 `lines()` 返回的 `&str` 引用转换为拥有所有权的 `String` 类型，分别使用 `.to_string()` 和 `String::from`。"
+"注意，在上述两个示例中，我们都必须将 `lines()` 返回的 `&str` 引用转换为拥有所有权的 `String` 类型，分别使用 `.to_string()` 和 `String::from`。"
 
 #: src/std_misc/file/read_lines.md:42
 msgid "A more efficient approach"
@@ -14672,18 +14681,18 @@ msgid ""
 "Here we pass ownership of the open `File` to a `BufReader` struct. "
 "`BufReader` uses an internal buffer to reduce intermediate allocations."
 msgstr ""
-"这里我们将打开的 `File` 的所有权传递给 `BufReader` 结构体。`BufReader` 使用内部缓冲区来减少中间分配。"
+"在这里，我们将打开的 `File` 的所有权传递给 `BufReader` 结构体。`BufReader` 使用内部缓冲区来减少中间分配。"
 
 #: src/std_misc/file/read_lines.md:47
 msgid ""
 "We also update `read_lines` to return an iterator instead of allocating new "
 "`String` objects in memory for each line."
 msgstr ""
-"我们还更新了 `read_lines` 函数，使其返回一个迭代器，而不是为每一行在内存中分配新的 `String` 对象。"
+"我们还对 `read_lines` 函数进行了改进，使其返回一个迭代器，而不是为每行内容在内存中分配新的 `String` 对象。"
 
 #: src/std_misc/file/read_lines.md:56
 msgid "// File hosts.txt must exist in the current path\n"
-msgstr "// 文件 hosts.txt 必须存在于当前路径\n"
+msgstr "// 文件 hosts.txt 必须存在于当前路径下\n"
 
 #: src/std_misc/file/read_lines.md:57
 msgid "\"./hosts.txt\""
@@ -14698,12 +14707,12 @@ msgid ""
 "// The output is wrapped in a Result to allow matching on errors.\n"
 "// Returns an Iterator to the Reader of the lines of the file.\n"
 msgstr ""
-"// 输出被包装在一个 Result 中以允许匹配错误。\n"
-"// 返回一个指向文件行的 Reader 的迭代器。\n"
+"// 输出被包装在 Result 中以便于错误匹配。\n"
+"// 返回一个指向文件行读取器的迭代器。\n"
 
 #: src/std_misc/file/read_lines.md:74
 msgid "Running this program simply prints the lines individually."
-msgstr "运行这个程序只是简单地逐行打印。"
+msgstr "运行此程序将逐行打印文件内容。"
 
 #: src/std_misc/file/read_lines.md:75
 msgid ""
@@ -14727,7 +14736,7 @@ msgid ""
 "define our generic `read_lines()` method with the same generic constraint, "
 "using the `where` keyword.)"
 msgstr ""
-"（注意，由于 `File::open` 期望一个泛型 `AsRef<Path>` 作为参数，我们使用 `where` 关键字定义了具有相同泛型约束的 `read_lines()` 方法。）"
+"（注意，由于 `File::open` 需要一个泛型 `AsRef<Path>` 作为参数，我们使用 `where` 关键字为 `read_lines()` 方法定义了相同的泛型约束。）"
 
 #: src/std_misc/file/read_lines.md:85
 msgid ""
@@ -14735,14 +14744,14 @@ msgid ""
 "the file's contents. This can especially cause performance issues when "
 "working with larger files."
 msgstr ""
-"这个过程比在内存中创建包含文件所有内容的 `String` 更高效。特别是在处理较大的文件时，这可以避免性能问题。"
+"这种方法比在内存中创建包含整个文件内容的 `String` 更加高效。特别是在处理大文件时，后者可能会导致性能问题。"
 
 #: src/std_misc/process.md:3
 msgid ""
 "The `process::Output` struct represents the output of a finished child "
 "process, and the `process::Command` struct is a process builder."
 msgstr ""
-"`process::Output` 结构体表示已完成的子进程的输出，而 `process::Command` 结构体是一个进程构建器。"
+"`process::Output` 结构体表示已完成子进程的输出，而 `process::Command` 结构体是一个进程构建器。"
 
 #: src/std_misc/process.md:10
 msgid "\"rustc\""
@@ -14758,18 +14767,18 @@ msgstr "\"执行进程失败：{}\""
 
 #: src/std_misc/process.md:19
 msgid "\"rustc succeeded and stdout was:\\n{}\""
-msgstr "\"rustc 成功执行，stdout 输出为：\\n{}\""
+msgstr "\"rustc 执行成功，标准输出为：\\n{}\""
 
 #: src/std_misc/process.md:23
 msgid "\"rustc failed and stderr was:\\n{}\""
-msgstr "\"rustc 执行失败，stderr 输出为：\\n{}\""
+msgstr "\"rustc 执行失败，标准错误输出为：\\n{}\""
 
 #: src/std_misc/process.md:28
 msgid ""
 "(You are encouraged to try the previous example with an incorrect flag passed "
 "to `rustc`)"
 msgstr ""
-"（试试在这个例子中向 `rustc` 传一个错误的参数）"
+"（建议您尝试在上述示例中向 `rustc` 传递一个错误的标志）"
 
 #: src/std_misc/process/pipe.md:3
 msgid ""
@@ -14777,7 +14786,7 @@ msgid ""
 "`stdin`, `stdout` and `stderr` handles for interaction with the underlying "
 "process via pipes."
 msgstr ""
-"`std::Child` 结构体表示一个正在运行的子进程，并暴露 `stdin`、`stdout` 和 `stderr` 句柄，从而通过管道与底层进程进行交互。"
+"`std::Child` 结构体代表一个正在运行的子进程，它暴露了 `stdin`、`stdout` 和 `stderr` 句柄，允许通过管道与底层进程进行交互。"
 
 #: src/std_misc/process/pipe.md:11
 msgid "\"the quick brown fox jumps over the lazy dog\\n\""
@@ -14785,7 +14794,7 @@ msgstr "\"the quick brown fox jumps over the lazy dog\\n\""
 
 #: src/std_misc/process/pipe.md:15
 msgid "// Spawn the `wc` command\n"
-msgstr "// 生成 `wc` 命令\n"
+msgstr "// 启动 `wc` 命令\n"
 
 #: src/std_misc/process/pipe.md:16 src/std_misc/fs.md:12 src/std_misc/fs.md:73
 #: src/std_misc/ffi.md:11
@@ -14810,7 +14819,7 @@ msgstr "\"wc\""
 
 #: src/std_misc/process/pipe.md:27
 msgid "\"couldn't spawn wc: {}\""
-msgstr "\"无法生成 wc：{}\""
+msgstr "\"无法启动 wc：{}\""
 
 #: src/std_misc/process/pipe.md:31
 msgid ""
@@ -14820,18 +14829,18 @@ msgid ""
 "instance\n"
 "    // must have one, we can directly `unwrap` it.\n"
 msgstr ""
-"// 向 `wc` 的 `stdin` 写入一个字符串。\n"
+"// 向 `wc` 的 `stdin` 写入字符串。\n"
 "    //\n"
-"    // `stdin` 的类型是 `Option<ChildStdin>`，不过我们已经知道这个实例不为空值\n"
-"    // 因此我们可以直接 `unwrap` 它。\n"
+"    // `stdin` 的类型是 `Option<ChildStdin>`，但我们知道这个实例\n"
+"    // 必定存在，所以可以直接 `unwrap` 它。\n"
 
 #: src/std_misc/process/pipe.md:36
 msgid "\"couldn't write to wc stdin: {}\""
-msgstr "\"无法写入 wc 的 stdin：{}\""
+msgstr "\"无法写入 wc 的标准输入：{}\""
 
 #: src/std_misc/process/pipe.md:37
 msgid "\"sent pangram to wc\""
-msgstr "\"已发送 pangram 到 wc\""
+msgstr "\"已将 pangram 发送给 wc\""
 
 #: src/std_misc/process/pipe.md:40
 msgid ""
@@ -14841,31 +14850,33 @@ msgid ""
 "    // This is very important, otherwise `wc` wouldn't start processing the\n"
 "    // input we just sent.\n"
 msgstr ""
-"// 因为 `stdin` 在上述调用后不再存活，被 `drop` 了，管道也被关闭。\n"
+"// 由于 `stdin` 在上述调用后不再存活，它会被 `drop`，\n"
+"    // 管道随之关闭。\n"
 "    //\n"
-"    // 这点非常重要，否则 `wc` 就不会开始处理我们刚刚发送的输入。\n"
+"    // 这一点非常重要，否则 `wc` 不会开始处理\n"
+"    // 我们刚刚发送的输入。\n"
 
 #: src/std_misc/process/pipe.md:46
 msgid ""
 "// The `stdout` field also has type `Option<ChildStdout>` so must be "
 "unwrapped.\n"
 msgstr ""
-"// `stdout` 字段的类型也是 `Option<ChildStdout>`，所以必须被解包。\n"
+"// `stdout` 字段的类型也是 `Option<ChildStdout>`，因此必须解包。\n"
 
 #: src/std_misc/process/pipe.md:49
 msgid "\"couldn't read wc stdout: {}\""
-msgstr "\"无法读取 wc 的 stdout：{}\""
+msgstr "\"无法读取 wc 的标准输出：{}\""
 
 #: src/std_misc/process/pipe.md:50
 msgid "\"wc responded with:\\n{}\""
-msgstr "\"wc 响应为：\\n{}\""
+msgstr "\"wc 的响应为：\\n{}\""
 
 #: src/std_misc/process/wait.md:3
 msgid ""
 "If you'd like to wait for a `process::Child` to finish, you must call `Child::"
 "wait`, which will return a `process::ExitStatus`."
 msgstr ""
-"如果你想等待一个 `process::Child` 完成，你必须调用 `Child::wait`，它将返回一个 `process::ExitStatus`。"
+"如果你想等待一个 `process::Child` 完成，你必须调用 `Child::wait`，它会返回一个 `process::ExitStatus`。"
 
 #: src/std_misc/process/wait.md:10
 msgid "\"sleep\""
@@ -14873,19 +14884,19 @@ msgstr "\"sleep\""
 
 #: src/std_misc/process/wait.md:13
 msgid "\"reached end of main\""
-msgid "\"reached end of main\""
+msgstr "\"到达 main 函数末尾\""
 
 #: src/std_misc/process/wait.md:18
 msgid ""
 "# `wait` keeps running for 5 seconds until the `sleep 5` command finishes\n"
 msgstr ""
-"# `wait` 持续运行 5 秒，直到 `sleep 5` 命令完成\n"
+"# `wait` 会持续运行 5 秒，直到 `sleep 5` 命令执行完毕\n"
 
 #: src/std_misc/fs.md:3
 msgid ""
 "The `std::fs` module contains several functions that deal with the filesystem."
 msgstr ""
-"`std::fs` 模块包含几个处理文件系统的函数。"
+"`std::fs` 模块包含多个用于处理文件系统的函数。"
 
 #: src/std_misc/fs.md:10 src/std_misc/fs.md:68 src/std_misc/ffi.md:20
 msgid "\"unix\""
@@ -14893,15 +14904,15 @@ msgstr "\"unix\""
 
 #: src/std_misc/fs.md:15
 msgid "// A simple implementation of `% cat path`\n"
-msgstr "// `% cat path` 的简单实现\n"
+msgstr "// `% cat path` 命令的简单实现\n"
 
 #: src/std_misc/fs.md:25
 msgid "// A simple implementation of `% echo s > path`\n"
-msgstr "// `% echo s > path` 的简单实现\n"
+msgstr "// `% echo s > path` 命令的简单实现\n"
 
 #: src/std_misc/fs.md:32
 msgid "// A simple implementation of `% touch path` (ignores existing files)\n"
-msgstr "// `% touch path` 的简单实现（忽略已存在的文件）\n"
+msgstr "// `% touch path` 命令的简单实现（忽略已存在的文件）\n"
 
 #: src/std_misc/fs.md:42
 msgid "\"`mkdir a`\""
@@ -14909,7 +14920,7 @@ msgstr "\"`mkdir a`\""
 
 #: src/std_misc/fs.md:43
 msgid "// Create a directory, returns `io::Result<()>`\n"
-msgstr "// 创建一个目录，返回 `io::Result<()>`\n"
+msgstr "// 创建目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:45 src/std_misc/fs.md:52 src/std_misc/fs.md:58
 #: src/std_misc/fs.md:63 src/std_misc/fs.md:70 src/std_misc/fs.md:75
@@ -14926,7 +14937,7 @@ msgstr "\"`echo hello > a/b.txt`\""
 msgid ""
 "// The previous match can be simplified using the `unwrap_or_else` method\n"
 msgstr ""
-"// 之前的匹配可以使用 `unwrap_or_else` 方法简化\n"
+"// 可以使用 `unwrap_or_else` 方法简化之前的匹配\n"
 
 #: src/std_misc/fs.md:51
 msgid "\"a/b.txt\""
@@ -14938,7 +14949,7 @@ msgstr "\"`mkdir -p a/c/d`\""
 
 #: src/std_misc/fs.md:56
 msgid "// Recursively create a directory, returns `io::Result<()>`\n"
-msgstr "// 逐层创建目录，返回 `io::Result<()>`\n"
+msgstr "// 递归创建目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:57 src/std_misc/fs.md:102
 msgid "\"a/c/d\""
@@ -14958,7 +14969,7 @@ msgstr "\"`ln -s ../b.txt a/c/b.txt`\""
 
 #: src/std_misc/fs.md:67
 msgid "// Create a symbolic link, returns `io::Result<()>`\n"
-msgstr "// 创建一个符号链接，返回 `io::Result<()>`\n"
+msgstr "// 创建符号链接，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:69 src/std_misc/fs.md:74
 msgid "\"../b.txt\""
@@ -14978,7 +14989,7 @@ msgstr "\"`ls a`\""
 
 #: src/std_misc/fs.md:86
 msgid "// Read the contents of a directory, returns `io::Result<Vec<Path>>`\n"
-msgstr "// 读取目录的内容，返回 `io::Result<Vec<Path>>`\n"
+msgstr "// 读取目录内容，返回 `io::Result<Vec<Path>>`\n"
 
 #: src/std_misc/fs.md:94
 msgid "\"`rm a/c/e.txt`\""
@@ -14986,7 +14997,7 @@ msgstr "\"`rm a/c/e.txt`\""
 
 #: src/std_misc/fs.md:95
 msgid "// Remove a file, returns `io::Result<()>`\n"
-msgstr "// 删除一个文件，返回 `io::Result<()>`\n"
+msgstr "// 删除文件，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:100
 msgid "\"`rmdir a/c/d`\""
@@ -14994,7 +15005,7 @@ msgstr "\"`rmdir a/c/d`\""
 
 #: src/std_misc/fs.md:101
 msgid "// Remove an empty directory, returns `io::Result<()>`\n"
-msgstr "// 删除一个空目录，返回 `io::Result<()>`\n"
+msgstr "// 删除空目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:111
 msgid ""
@@ -15032,11 +15043,11 @@ msgstr ""
 
 #: src/std_misc/fs.md:127
 msgid "And the final state of the `a` directory is:"
-msgstr "最终 `a` 目录的状态是："
+msgstr "最终 `a` 目录的状态如下："
 
 #: src/std_misc/fs.md:139
 msgid "An alternative way to define the function `cat` is with `?` notation:"
-msgstr "定义 `cat` 函数的另一种方式是使用 `?` 符号："
+msgstr "另一种定义 `cat` 函数的方法是使用 `?` 运算符："
 
 #: src/std_misc/fs.md:152
 msgid "[`cfg!`](../attribute/cfg.md)"
@@ -15051,11 +15062,11 @@ msgid ""
 "The command line arguments can be accessed using `std::env::args`, which "
 "returns an iterator that yields a `String` for each argument:"
 msgstr ""
-"命令行参数可以使用 `std::env::args` 访问，它返回一个迭代器，为每个参数生成一个 `String`："
+"可以使用 `std::env::args` 访问命令行参数，它返回一个迭代器，为每个参数生成一个 `String`："
 
 #: src/std_misc/arg.md:14
 msgid "// The first argument is the path that was used to call the program.\n"
-msgstr "// 第一个参数是用于调用程序的路径。\n"
+msgstr "// 第一个参数是用于调用程序的路径\n"
 
 #: src/std_misc/arg.md:15
 msgid "\"My path is {}.\""
@@ -15067,13 +15078,13 @@ msgid ""
 "    // Call the program like this:\n"
 "    //   $ ./args arg1 arg2\n"
 msgstr ""
-"// 剩余的参数是传递的命令行参数。\n"
+"// 其余参数是传递的命令行参数\n"
 "    // 像这样调用程序：\n"
 "    //   $ ./args arg1 arg2\n"
 
 #: src/std_misc/arg.md:20
 msgid "\"I got {:?} arguments: {:?}.\""
-msgstr "\"我得到了 {:?} 个参数：{:?}。\""
+msgstr "\"我获得了 {:?} 个参数：{:?}。\""
 
 #: src/std_misc/arg.md:24
 msgid ""
@@ -15085,8 +15096,8 @@ msgid ""
 msgstr ""
 "```shell\n"
 "$ ./args 1 2 3\n"
-"我的路径是 ./args。\n"
-"我得到了 3 个参数：[\"1\", \"2\", \"3\"]。\n"
+"程序路径：./args\n"
+"接收到 3 个参数：[\"1\"、\"2\"、\"3\"]\n"
 "```"
 
 #: src/std_misc/arg.md:32
@@ -15096,11 +15107,11 @@ msgid ""
 "argument crates being [`clap`](https://rust-cli.github.io/book/tutorial/cli-"
 "args.html#parsing-cli-arguments-with-clap)."
 msgstr ""
-"另外，在创建命令行应用程序时，有许多 crate 可以提供额外的功能。其中一个比较流行的命令行参数 crate 是 [`clap`](https://rust-cli.github.io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap)。"
+"此外，在开发命令行应用程序时，还有许多 crate 可以提供额外的功能。其中，[`clap`](https://rust-cli.github.io/book/tutorial/cli-args.html#parsing-cli-arguments-with-clap) 是一个广受欢迎的命令行参数处理 crate。"
 
 #: src/std_misc/arg/matching.md:3
 msgid "Matching can be used to parse simple arguments:"
-msgstr "可以用匹配来解析简单的参数："
+msgstr "可以使用模式匹配来解析简单的参数："
 
 #: src/std_misc/arg/matching.md:17
 msgid ""
@@ -15110,19 +15121,19 @@ msgid ""
 "match_args {{increase|decrease}} <integer>\n"
 "    Increase or decrease given integer by one.\""
 msgstr ""
-"\"usage:\n"
-"match_args <string>\n"
-"    Check whether given string is the answer.\n"
-"match_args {{increase|decrease}} <integer>\n"
-"    Increase or decrease given integer by one.\""
+"\"用法：\n"
+"match_args <字符串>\n"
+"    检查给定的字符串是否为正确答案。\n"
+"match_args {{increase|decrease}} <整数>\n"
+"    将给定的整数增加或减少 1。\""
 
 #: src/std_misc/arg/matching.md:28
 msgid "// no arguments passed\n"
-msgstr "// 没有传递参数\n"
+msgstr "// 未传递参数\n"
 
 #: src/std_misc/arg/matching.md:30
 msgid "\"My name is 'match_args'. Try passing some arguments!\""
-msgstr "\"My name is 'match_args'. Try passing some arguments!\""
+msgstr "\"我的名字是 'match_args'。试试传递一些参数吧！\""
 
 #: src/std_misc/arg/matching.md:32
 msgid "// one argument passed\n"
@@ -15130,11 +15141,11 @@ msgstr "// 传递了一个参数\n"
 
 #: src/std_misc/arg/matching.md:35
 msgid "\"This is the answer!\""
-msgstr "\"This is the answer!\""
+msgstr "\"这就是正确答案！\""
 
 #: src/std_misc/arg/matching.md:36
 msgid "\"This is not the answer.\""
-msgstr "\"This is not the answer.\""
+msgstr "\"这不是正确答案。\""
 
 #: src/std_misc/arg/matching.md:39
 msgid "// one command and one argument passed\n"
@@ -15146,7 +15157,7 @@ msgstr "// 解析数字\n"
 
 #: src/std_misc/arg/matching.md:49
 msgid "\"error: second argument not an integer\""
-msgstr "\"error: second argument not an integer\""
+msgstr "\"错误：第二个参数不是整数\""
 
 #: src/std_misc/arg/matching.md:54
 msgid "// parse the command\n"
@@ -15162,7 +15173,7 @@ msgstr "\"decrease\""
 
 #: src/std_misc/arg/matching.md:59
 msgid "\"error: invalid command\""
-msgstr "\"error: invalid command\""
+msgstr "\"错误：无效的命令\""
 
 #: src/std_misc/arg/matching.md:64
 msgid "// all the other cases\n"
@@ -15177,7 +15188,7 @@ msgid ""
 "If you named your program `match_args.rs` and compile it like this `rustc "
 "match_args.rs`, you can execute it as follows:"
 msgstr ""
-"如果你将程序命名为 `match_args.rs` 并像这样编译它 `rustc match_args.rs`，你可以按如下方式执行它："
+"如果你将程序命名为 `match_args.rs` 并使用 `rustc match_args.rs` 编译它，你可以按以下方式执行："
 
 #: src/std_misc/ffi.md:3
 msgid ""
@@ -15185,11 +15196,11 @@ msgid ""
 "functions must be declared inside an `extern` block annotated with a "
 "`#[link]` attribute containing the name of the foreign library."
 msgstr ""
-"Rust 为 C 库提供了外部函数接口（FFI）。外部函数必须在 `extern` 块内声明，并使用 `#[link]` 属性标注外部库的名称。"
+"Rust 提供了与 C 库交互的外部函数接口（FFI）。外部函数必须在 `extern` 块内声明，并使用 `#[link]` 属性标注外部库的名称。"
 
 #: src/std_misc/ffi.md:9
 msgid "// this extern block links to the libm library\n"
-msgstr "// 这个 extern 块链接到 libm 库\n"
+msgstr "// 此 extern 块链接到 libm 库\n"
 
 #: src/std_misc/ffi.md:12
 msgid "\"msvcrt\""
@@ -15212,7 +15223,8 @@ msgid ""
 "// Since calling foreign functions is considered unsafe,\n"
 "// it's common to write safe wrappers around them.\n"
 msgstr ""
-"// 由于调用外部函数被认为是不安全的，通常会封装一层安全的包装函数。\n"
+"// 由于调用外部函数被认为是不安全的，\n"
+"// 通常会为它们编写安全的包装函数。\n"
 
 #: src/std_misc/ffi.md:37
 msgid "// z = -1 + 0i\n"
@@ -15228,7 +15240,7 @@ msgstr "\"{:?} 的平方根是 {:?}\""
 
 #: src/std_misc/ffi.md:45
 msgid "// calling safe API wrapped around unsafe operation\n"
-msgstr "// 调用封装了不安全操作的安全 API \n"
+msgstr "// 调用封装了不安全操作的安全 API\n"
 
 #: src/std_misc/ffi.md:46
 msgid "\"cos({:?}) = {:?}\""
@@ -15251,45 +15263,45 @@ msgid ""
 "Rust is a programming language that cares a lot about correctness and it "
 "includes support for writing software tests within the language itself."
 msgstr ""
-"Rust 是一种非常注重正确性的编程语言，它支持在语言本身内编写软件测试。"
+"Rust 是一种非常注重正确性的编程语言，它内置了编写软件测试的支持。"
 
 #: src/testing.md:6
 msgid "Testing comes in three styles:"
-msgstr "测试有三种风格："
+msgstr "测试分为三种类型："
 
 #: src/testing.md:8
 msgid "[Unit](testing/unit_testing.md) testing."
-msgstr "[单元](testing/unit_testing.md)测试。"
+msgstr "[单元测试](testing/unit_testing.md)"
 
 #: src/testing.md:9
 msgid "[Doc](testing/doc_testing.md) testing."
-msgstr "[文档](testing/doc_testing.md)测试。"
+msgstr "[文档测试](testing/doc_testing.md)"
 
 #: src/testing.md:10
 msgid "[Integration](testing/integration_testing.md) testing."
-msgstr "[集成](testing/integration_testing.md)测试。"
+msgstr "[集成测试](testing/integration_testing.md)"
 
 #: src/testing.md:12
 msgid "Also Rust has support for specifying additional dependencies for tests:"
-msgstr "Rust 还支持为测试指定额外的依赖项："
+msgstr "此外，Rust 还支持为测试指定额外的依赖项："
 
 #: src/testing.md:14
 msgid "[Dev-dependencies](testing/dev_dependencies.md)"
-msgstr "[开发依赖（dev-dependencies）](testing/dev_dependencies.md)"
+msgstr "[开发依赖](testing/dev_dependencies.md)"
 
 #: src/testing.md:18
 msgid ""
 "[The Book](https://doc.rust-lang.org/book/ch11-00-testing.html) chapter on "
 "testing"
 msgstr ""
-"[《Rust 程序设计语言》](https://doc.rust-lang.org/book/ch11-00-testing.html)中关于测试的章节"
+"《Rust 程序设计语言》中[关于测试的章节](https://doc.rust-lang.org/book/ch11-00-testing.html)"
 
 #: src/testing.md:19
 msgid ""
 "[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
 "documentation.html) on doc-testing"
 msgstr ""
-"[API 指南](https://rust-lang-nursery.github.io/api-guidelines/documentation.html)中关于文档测试的内容"
+"API 指南中[关于文档测试的内容](https://rust-lang-nursery.github.io/api-guidelines/documentation.html)"
 
 #: src/testing/unit_testing.md:3
 msgid ""
@@ -15298,7 +15310,7 @@ msgid ""
 "setup, run the code we want to test, then assert whether the results are what "
 "we expect."
 msgstr ""
-"测试是用于验证非测试代码是否按预期方式运行的 Rust 函数。测试函数的主体通常执行一些设置，运行我们想要测试的代码，然后断言结果是否符合我们的预期。"
+"测试是 Rust 函数，用于验证非测试代码是否按预期方式运行。测试函数的主体通常包括一些准备工作，运行待测试的代码，然后断言结果是否符合预期。"
 
 #: src/testing/unit_testing.md:8
 msgid ""
@@ -15306,25 +15318,25 @@ msgid ""
 "[attribute](../attribute.md). Test functions are marked with the `#[test]` "
 "attribute."
 msgstr ""
-"大多数单元测试都放在带有 `#[cfg(test)]` [属性](../attribute.md)的 `tests` [mod](../mod.md) 中。测试函数用 `#[test]` 属性标记。"
+"大多数单元测试都放在带有 `#[cfg(test)]` [属性](../attribute.md)的 `tests` [模块](../mod.md)中。测试函数用 `#[test]` 属性标记。"
 
 #: src/testing/unit_testing.md:11
 msgid ""
 "Tests fail when something in the test function [panics](../std/panic.md). "
 "There are some helper [macros](../macros.md):"
 msgstr ""
-"当测试函数中的某些内容[panic](../std/panic.md)时，测试就会失败。这是一些辅助[宏](../macros.md)："
+"当测试函数中出现[恐慌（panic）](../std/panic.md)时，测试就会失败。以下是一些辅助[宏](../macros.md)："
 
 #: src/testing/unit_testing.md:14
 msgid "`assert!(expression)` - panics if expression evaluates to `false`."
-msgstr "`assert!(expression)` - 如果表达式计算结果为 `false`，则会 panic。"
+msgstr "`assert!(expression)` - 如果表达式求值为 `false`，则会触发 panic。"
 
 #: src/testing/unit_testing.md:15
 msgid ""
 "`assert_eq!(left, right)` and `assert_ne!(left, right)` - testing left and "
 "right expressions for equality and inequality respectively."
 msgstr ""
-"`assert_eq!(left, right)` 和 `assert_ne!(left, right)` - 分别测试左右表达式的相等性和不相等性。"
+"`assert_eq!(left, right)` 和 `assert_ne!(left, right)` - 分别用于测试左右表达式的相等性和不相等性。"
 
 #: src/testing/unit_testing.md:22
 msgid ""
@@ -15337,7 +15349,7 @@ msgstr ""
 msgid ""
 "// Note this useful idiom: importing names from outer (for mod tests) scope.\n"
 msgstr ""
-"// 注意这个惯用法：从外部（对于 mod tests 而言）作用域导入所有可用项名称。\n"
+"// 注意这个有用的惯用法：从外部作用域（对于 mod tests 而言）导入名称。\n"
 
 #: src/testing/unit_testing.md:42
 msgid ""
@@ -15349,11 +15361,11 @@ msgstr ""
 
 #: src/testing/unit_testing.md:49
 msgid "Tests can be run with `cargo test`."
-msgstr "可以使用 `cargo test` 运行测试。"
+msgstr "可以使用 `cargo test` 命令运行测试。"
 
 #: src/testing/unit_testing.md:73
 msgid "Tests and `?`"
-msgstr "测试和 `?`"
+msgstr "测试与 `?` 运算符"
 
 #: src/testing/unit_testing.md:74
 msgid ""
@@ -15361,7 +15373,7 @@ msgid ""
 "your unit tests can return `Result<()>`, which lets you use `?` in them! This "
 "can make them much more concise."
 msgstr ""
-"之前的单元测试示例都没有返回类型。但在 Rust 2018 中，单元测试可以返回 `Result<()>`，这让你可以在其中使用 `?`！这可以使它们变得更加简洁。"
+"之前的单元测试示例都没有返回类型。但在 Rust 2018 版本中，你的单元测试可以返回 `Result<()>`，这使得你可以在测试中使用 `?` 运算符！这可以使测试代码更加简洁。"
 
 #: src/testing/unit_testing.md:83
 msgid "\"negative floats don't have square roots\""
@@ -15373,7 +15385,7 @@ msgid ""
 "error-handling-and-panics/question-mark-in-main-and-tests.html) for more "
 "details."
 msgstr ""
-"更多详情可参考[《版本指南》](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)。"
+"更多详情请参阅[《版本指南》](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)。"
 
 #: src/testing/unit_testing.md:102
 msgid "Testing panics"
@@ -15386,19 +15398,19 @@ msgid ""
 "`expected = ` with the text of the panic message. If your function can panic "
 "in multiple ways, it helps make sure your test is testing the correct panic."
 msgstr ""
-"要测试在某些情况下应该 panic 的函数，可以使用 `#[should_panic]` 属性。这个属性接受可选参数 `expected = `，其中包含 panic 消息的文本。如果你的函数可能以多种方式 panic，这有助于确保正在测试对应的 panic。"
+"要检查在某些情况下应该触发恐慌的函数，可以使用 `#[should_panic]` 属性。这个属性接受可选参数 `expected = `，用于指定预期的恐慌消息文本。如果你的函数可能以多种方式触发 panic，这有助于确保你的测试正在检查正确的 panic 情况。"
 
 #: src/testing/unit_testing.md:112 src/testing/doc_testing.md:45
 msgid "\"Divide-by-zero error\""
-msgstr "\"Divide-by-zero error\""
+msgstr "\"除以零错误\""
 
 #: src/testing/unit_testing.md:114 src/testing/unit_testing.md:135
 msgid "\"Divide result is zero\""
-msgstr "\"Divide result is zero\""
+msgstr "\"除法结果为零\""
 
 #: src/testing/unit_testing.md:142
 msgid "Running these tests gives us:"
-msgstr "运行这些测试会得到："
+msgstr "运行这些测试会得到以下结果："
 
 #: src/testing/unit_testing.md:161
 msgid "Running specific tests"
@@ -15426,7 +15438,7 @@ msgid ""
 "Tests can be marked with the `#[ignore]` attribute to exclude some tests. Or "
 "to run them with command `cargo test -- --ignored`"
 msgstr ""
-"可以使用 `#[ignore]` 属性标记测试以排除某些测试。或者使用命令 `cargo test -- --ignored` 运行它们"
+"可以使用 `#[ignore]` 属性标记测试以排除某些测试。或者使用命令 `cargo test -- --ignored` 来运行这些被忽略的测试。"
 
 #: src/testing/doc_testing.md:3
 msgid ""
@@ -15436,7 +15448,7 @@ msgid ""
 "takes care about correctness, so these code blocks are compiled and used as "
 "documentation tests."
 msgstr ""
-"为 Rust 项目的编写文档的主要方式是通过在源代码中添加注释。文档注释使用 [CommonMark Markdown 规范](https://commonmark.org/)编写，并支持其中的代码块。Rust 注重正确性，因此这些代码块会被编译并用作文档测试。"
+"Rust 项目的主要文档编写方式是通过在源代码中添加注释。文档注释使用 [CommonMark Markdown 规范](https://commonmark.org/)编写，并支持其中的代码块。Rust 注重正确性，因此这些代码块会被编译并用作文档测试。"
 
 #: src/testing/doc_testing.md:10
 msgid ""
@@ -15452,10 +15464,10 @@ msgid ""
 "/// assert_eq!(result, 5);\n"
 "/// ```\n"
 msgstr ""
-"/// 第一行是描述函数的简短摘要。\n"
+"/// 第一行是函数的简要描述。\n"
 "///\n"
 "/// 接下来的几行是详细文档。代码块以三个反引号开始，\n"
-"/// 并且隐含了 `fn main()` 和 `extern crate <cratename>`。\n"
+"/// 并隐含了 `fn main()` 函数和 `extern crate <cratename>` 声明。\n"
 "/// 假设我们正在测试 `doccomments` crate：\n"
 "///\n"
 "/// ```\n"
@@ -15486,23 +15498,23 @@ msgid ""
 "/// doccomments::div(10, 0);\n"
 "/// ```\n"
 msgstr ""
-"/// 通常文档注释可能包括 \"Examples\"、\"Panics\" 和 \"Failures\" 部分。\n"
+"/// 文档注释通常包含"示例"、"异常"和"错误"等部分。\n"
 "///\n"
-"/// 下面的函数用于除法运算。\n"
+"/// 下面的函数用于两数相除。\n"
 "///\n"
-"/// # Examples\n"
+"/// # 示例\n"
 "///\n"
 "/// ```\n"
 "/// let result = doccomments::div(10, 2);\n"
 "/// assert_eq!(result, 5);\n"
 "/// ```\n"
 "///\n"
-"/// # Panics\n"
+"/// # 异常\n"
 "///\n"
-"/// 如果第二个参数为零，函数会 panic。\n"
+"/// 当第二个参数为零时，函数会触发异常。\n"
 "///\n"
 "/// ```rust,should_panic\n"
-"/// // 除以零会导致 panic\n"
+"/// // 除以零会触发异常\n"
 "/// doccomments::div(10, 0);\n"
 "/// ```\n"
 
@@ -15511,11 +15523,11 @@ msgid ""
 "Code blocks in documentation are automatically tested when running the "
 "regular `cargo test` command:"
 msgstr ""
-"在运行常规的 `cargo test` 命令时，文档中的代码块会自动进行测试："
+"运行常规的 `cargo test` 命令时，文档中的代码块会自动进行测试："
 
 #: src/testing/doc_testing.md:71
 msgid "Motivation behind documentation tests"
-msgstr "文档测试的目的"
+msgstr "文档测试的动机"
 
 #: src/testing/doc_testing.md:73
 msgid ""
@@ -15529,7 +15541,7 @@ msgid ""
 "hide it and `unwrap` it in hidden `main`. Sounds complicated? Here's an "
 "example:"
 msgstr ""
-"文档测试的主要目的是作为如何使用的示例，这是最重要的[指导原则](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark)之一。它允许将文档中的示例作为完整的代码片段使用。但是使用 `?` 会导致编译失败，因为 `main` 返回 `unit`。隐藏文档中的某些源代码行可以解决这个问题：可以编写 `fn try_main() -> Result<(), ErrorType>`，隐藏并在 `main` 中 `unwrap`。听起来很复杂？这里有一个例子："
+"文档测试的主要目的是提供功能演示的示例，这是最重要的[指导原则](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark)之一。它允许将文档中的示例作为完整的代码片段使用。但是使用 `?` 会导致编译失败，因为 `main` 函数返回 `unit` 类型。这时，隐藏文档中的某些源代码行就派上用场了：可以编写 `fn try_main() -> Result<(), ErrorType>`，将其隐藏，并在隐藏的 `main` 函数中 `unwrap` 它。听起来很复杂？这里有一个例子："
 
 #: src/testing/doc_testing.md:82
 msgid ""
@@ -15548,23 +15560,23 @@ msgid ""
 "/// # }\n"
 "/// ```\n"
 msgstr ""
-"/// 在文档测试中使用隐藏的 `try_main`。\n"
+"/// 在文档测试中使用隐藏的 `try_main` 函数。\n"
 "///\n"
 "/// ```\n"
-"/// # // 以 `#` 符号开头的行是隐藏的，但它们仍然可以编译！\n"
-"/// # fn try_main() -> Result<(), String> { // 文档中显示的包装函数体的行\n"
+"/// # // 以 `#` 开头的行在文档中是隐藏的，但它们仍然可以编译！\n"
+"/// # fn try_main() -> Result<(), String> { // 这行包装了文档中显示的函数体\n"
 "/// let res = doccomments::try_div(10, 2)?;\n"
 "/// # Ok(()) // 从 try_main 返回\n"
 "/// # }\n"
-"/// # fn main() { // 开始将要 unwrap() 的 main\n"
-"/// #    try_main().unwrap(); // 调用 try_main 并 unwrap\n"
-"/// #                         // 这样在出错时测试会 panic\n"
+"/// # fn main() { // 开始会调用 unwrap() 的 main 函数\n"
+"/// #    try_main().unwrap(); // 调用 try_main 并解包\n"
+"/// #                         // 这样在出错时测试会触发 panic\n"
 "/// # }\n"
 "/// ```\n"
 
 #: src/testing/doc_testing.md:97
 msgid "\"Divide-by-zero\""
-msgstr "\"除以零\""
+msgstr "\"除以零错误\""
 
 #: src/testing/doc_testing.md:106
 msgid ""
@@ -15588,11 +15600,11 @@ msgid ""
 "would. Their purpose is to test that many parts of your library work "
 "correctly together."
 msgstr ""
-"[单元测试](unit_testing.md)一次单独测试一个模块：它们很小，可以测试私有代码。集成测试位于 crate 外部，并且仅使用公开接口，就像其他使用该 crate 的代码一样。集成测试的目的是测试库的各个部分是否能正确地协同工作。"
+"[单元测试](unit_testing.md)每次只隔离测试一个模块：它们规模小，可以测试私有代码。集成测试则位于 crate 外部，仅使用其公共接口，就像其他代码一样。集成测试的目的是验证库的多个部分能否正确协同工作。"
 
 #: src/testing/integration_testing.md:8
 msgid "Cargo looks for integration tests in `tests` directory next to `src`."
-msgstr "Cargo 在 `src` 目录旁边的 `tests` 目录中寻找集成测试。"
+msgstr "Cargo 在 `src` 目录旁的 `tests` 目录中查找集成测试。"
 
 #: src/testing/integration_testing.md:10 src/testing/dev_dependencies.md:17
 msgid "File `src/lib.rs`:"
@@ -15600,7 +15612,7 @@ msgstr "文件 `src/lib.rs`："
 
 #: src/testing/integration_testing.md:13
 msgid "// Define this in a crate called `adder`.\n"
-msgstr "// 在一个名为 `adder` 的 crate 中定义这个。\n"
+msgstr "// 在名为 `adder` 的 crate 中定义此内容。\n"
 
 #: src/testing/integration_testing.md:19
 msgid "File with test: `tests/integration_test.rs`:"
@@ -15616,7 +15628,7 @@ msgid ""
 "crate. In order to share some code between integration tests we can make a "
 "module with public functions, importing and using it within tests."
 msgstr ""
-"`tests` 目录中的每个 Rust 源文件都被编译为一个单独的 crate。为了在集成测试之间共享一些代码，我们可以创建一个带有公共函数的模块，然后在测试中导入和使用它。"
+"`tests` 目录中的每个 Rust 源文件都被编译为独立的 crate。为了在集成测试之间共享代码，我们可以创建一个包含公共函数的模块，然后在测试中导入并使用它。"
 
 #: src/testing/integration_testing.md:54
 msgid "File `tests/common/mod.rs`:"
@@ -15627,7 +15639,7 @@ msgid ""
 "// some setup code, like creating required files/directories, starting\n"
 "    // servers, etc.\n"
 msgstr ""
-"// 一些设置代码，比如创建所需的文件/目录，启动\n"
+"// 一些设置代码，如创建必要的文件/目录，启动\n"
 "    // 服务器等。\n"
 
 #: src/testing/integration_testing.md:63
@@ -15648,7 +15660,7 @@ msgid ""
 "because the test runner will treat the file as a test crate and try to run "
 "tests inside it."
 msgstr ""
-"将模块创建为 `tests/common.rs` 也可以，但不推荐这样做，因为测试执行时会将该文件视为测试 crate 并尝试运行其中的测试。"
+"将模块创建为 `tests/common.rs` 也可行，但不推荐，因为测试运行器会将该文件视为测试 crate 并尝试运行其中的测试。"
 
 #: src/testing/dev_dependencies.md:1
 msgid "Development dependencies"
@@ -15661,7 +15673,7 @@ msgid ""
 "dependencies]` section. These dependencies are not propagated to other "
 "packages which depend on this package."
 msgstr ""
-"有时候我们需要仅用于测试（或示例、基准测试）的依赖项。这些依赖项被添加到 `Cargo.toml` 的 `[dev-dependencies]` 部分。这些依赖项不会被传播到依赖于这个包的其他包。"
+"有时我们需要仅用于测试（或示例、基准测试）的依赖项。这些依赖项添加在 `Cargo.toml` 的 `[dev-dependencies]` 部分。这些依赖项不会传递给依赖于本包的其他包。"
 
 #: src/testing/dev_dependencies.md:8
 msgid ""
@@ -15670,7 +15682,7 @@ msgid ""
 "`assert_eq!` and `assert_ne!` macros, to provide colorful diff.  \n"
 "File `Cargo.toml`:"
 msgstr ""
-"例如 [`pretty_assertions`](https://docs.rs/pretty_assertions/1.0.0/pretty_assertions/index.html)，它扩展了标准的 `assert_eq!` 和 `assert_ne!` 宏，提供彩色差异。  \n"
+"例如 [`pretty_assertions`](https://docs.rs/pretty_assertions/1.0.0/pretty_assertions/index.html)，它扩展了标准的 `assert_eq!` 和 `assert_ne!` 宏，提供彩色差异对比。  \n"
 "文件 `Cargo.toml`："
 
 #: src/testing/dev_dependencies.md:11
@@ -15682,7 +15694,7 @@ msgid ""
 "```"
 msgstr ""
 "```toml\n"
-"# 标准的 crate 数据省略\n"
+"# 省略标准的 crate 数据\n"
 "[dev-dependencies]\n"
 "pretty_assertions = \"1\"\n"
 "```"
@@ -15696,7 +15708,7 @@ msgid ""
 "[Cargo](http://doc.crates.io/specifying-dependencies.html) docs on specifying "
 "dependencies."
 msgstr ""
-"[Cargo](http://doc.crates.io/specifying-dependencies.html) 文档中关于指定依赖项的内容。"
+"[Cargo 文档](http://doc.crates.io/specifying-dependencies.html)中关于指定依赖项的说明。"
 
 #: src/unsafe.md:3
 msgid ""
@@ -15707,7 +15719,7 @@ msgid ""
 "put in place by the compiler; specifically, there are four primary things "
 "that unsafe is used for:"
 msgstr ""
-"作为本节的介绍，借用[官方文档](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)的话说，\"应该尽量减少代码库中不安全代码的数量。\" 记住这一点，让我们开始吧！Rust 中的不安全标注用于绕过编译器设置的保护；具体来说，不安全主要用于以下四个方面："
+"作为本节的引言，借用[官方文档](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)的话说："应该尽量减少代码库中不安全代码的数量。"牢记这一点，让我们开始吧！Rust 中的不安全标注用于绕过编译器设置的保护机制。具体来说，不安全主要用于以下四个方面："
 
 #: src/unsafe.md:9
 msgid "dereferencing raw pointers"
@@ -15718,7 +15730,7 @@ msgid ""
 "calling functions or methods which are `unsafe` (including calling a function "
 "over FFI, see [a previous chapter](std_misc/ffi.md) of the book)"
 msgstr ""
-"调用 `unsafe` 的函数或方法（包括通过 FFI 调用函数，参见本书的[前面的一章](std_misc/ffi.md)）"
+"调用被标记为 `unsafe` 的函数或方法（包括通过 FFI 调用函数，参见本书[前面的章节](std_misc/ffi.md)）"
 
 #: src/unsafe.md:12
 msgid "accessing or modifying static mutable variables"
@@ -15739,7 +15751,7 @@ msgid ""
 "borrow checker. Dereferencing a raw pointer can only be done through an "
 "unsafe block."
 msgstr ""
-"裸指针 `*` 和引用 `&T` 的功能类似，但引用总是安全的，因为借用检查器保证它们指向有效数据。解引用裸指针只能在不安全块中进行。"
+"裸指针 `*` 和引用 `&T` 的功能类似，但引用总是安全的，因为借用检查器保证它们指向有效数据。解引用裸指针只能在 unsafe 块中进行。"
 
 #: src/unsafe.md:31
 msgid "Calling Unsafe Functions"
@@ -15753,7 +15765,7 @@ msgid ""
 "fn.from_raw_parts.html) which will create a slice given a pointer to the "
 "first element and a length."
 msgstr ""
-"一些函数可以被声明为 `unsafe`，这意味着确保正确性是程序员的责任，而不再是编译器的责任。一个例子是 [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html)，它会根据指向第一个元素的指针和长度创建一个切片。"
+"某些函数可以被声明为 `unsafe`，这意味着确保其正确性是程序员的责任，而不是编译器的责任。一个例子是 [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html)，它根据指向第一个元素的指针和长度创建一个切片。"
 
 #: src/unsafe.md:54
 msgid ""
@@ -15762,7 +15774,7 @@ msgid ""
 "to is of the correct type. If these invariants aren't upheld then the "
 "program's behaviour is undefined and there is no knowing what will happen."
 msgstr ""
-"对于 `slice::from_raw_parts`，**必须**遵守的假设之一是传入的指针指向有效的内存，并且指向的内存类型正确。如果这些假设没有被遵守，那么程序的行为是未定义的，无法预知会发生什么。"
+"对于 `slice::from_raw_parts`，**必须**遵守的一个假设是：传入的指针指向有效内存，且指向的内存类型正确。如果这些不变量未被遵守，那么程序的行为将是未定义的，无法预知会发生什么。"
 
 #: src/unsafe/asm.md:3
 msgid ""
@@ -15773,18 +15785,18 @@ msgid ""
 "level hardware primitives, e.g. in kernel code, may also demand this "
 "functionality."
 msgstr ""
-"Rust 通过 `asm!` 宏提供了内联汇编支持。它可以用于在编译器生成的汇编输出中嵌入手写的汇编代码。通常这不是必需的，但在需要特定的性能或时序且无法通过其他方式实现时可能会用到。访问低级硬件原语，例如在内核代码中，也可能需要这个功能。"
+"Rust 通过 `asm!` 宏提供了内联汇编支持。它可以用于在编译器生成的汇编输出中嵌入手写的汇编代码。通常这不是必需的，但在无法通过其他方式实现所需性能或时序要求时可能会用到。访问底层硬件原语（例如在内核代码中）也可能需要这个功能。"
 
 #: src/unsafe/asm.md:8
 msgid ""
 "**Note**: the examples here are given in x86/x86-64 assembly, but other "
 "architectures are also supported."
 msgstr ""
-"**注意**：这里的例子使用的是 x86/x86-64 汇编，但也支持其他架构。"
+"**注意**：这里的示例使用 x86/x86-64 汇编，但也支持其他架构。"
 
 #: src/unsafe/asm.md:10
 msgid "Inline assembly is currently supported on the following architectures:"
-msgstr "内联汇编目前支持以下架构："
+msgstr "目前支持内联汇编的架构包括："
 
 #: src/unsafe/asm.md:11
 msgid "x86 and x86-64"
@@ -15831,7 +15843,7 @@ msgid ""
 "invariants. The instructions to be inserted are listed in the first argument "
 "of the `asm!` macro as a string literal."
 msgstr ""
-"这将在编译器生成的汇编中插入一条 NOP（无操作）指令。注意，所有 `asm!` 调用都必须在 `unsafe` 块内，因为它们可能插入任意指令并破坏各种假设。要插入的指令作为字符串字面量列在 `asm!` 宏的第一个参数中。"
+"这将在编译器生成的汇编代码中插入一条 NOP（无操作）指令。请注意，所有 `asm!` 调用都必须放在 `unsafe` 块内，因为它们可能插入任意指令并破坏各种不变量。要插入的指令以字符串字面量的形式列在 `asm!` 宏的第一个参数中。"
 
 #: src/unsafe/asm.md:35
 msgid "Inputs and outputs"
@@ -15842,7 +15854,7 @@ msgid ""
 "Now inserting an instruction that does nothing is rather boring. Let us do "
 "something that actually acts on data:"
 msgstr ""
-"插入一个什么都不做的指令相当无聊。现在让我们做一些实际操作数据的事情："
+"插入一个什么都不做的指令相当无聊。让我们来做些实际操作数据的事情："
 
 #: src/unsafe/asm.md:46
 msgid "\"mov {}, 5\""
@@ -15863,11 +15875,11 @@ msgid ""
 "into the template and will read the variable from there after the inline "
 "assembly finishes executing."
 msgstr ""
-"这将把值 `5` 写入 `u64` 变量 `x`。你可以看到，我们用来指定指令的字符串字面量实际上是一个模板字符串。它遵循与 Rust [格式化字符串](https://doc.rust-lang.org/std/fmt/#syntax)相同的规则。然而，插入到模板中的参数看起来可能与你熟悉的有些不同。首先，我们需要指定变量是内联汇编的输入还是输出。在这种情况下，它是一个输出。我们通过写 `out` 来声明这一点。我们还需要指定汇编期望变量在什么类型的寄存器中。在这种情况下，我们通过指定 `reg` 将其放在任意通用寄存器中。编译器将选择一个适当的寄存器插入到模板中，并在内联汇编执行完成后从那里读取变量。"
+"这将把值 `5` 写入 `u64` 类型的变量 `x`。你可以看到，我们用来指定指令的字符串字面量实际上是一个模板字符串。它遵循与 Rust [格式化字符串](https://doc.rust-lang.org/std/fmt/#syntax)相同的规则。然而，插入到模板中的参数看起来可能与你熟悉的有些不同。首先，我们需要指定变量是内联汇编的输入还是输出。在这个例子中，它是一个输出。我们通过写 `out` 来声明这一点。我们还需要指定汇编期望变量在什么类型的寄存器中。这里我们通过指定 `reg` 将其放在任意通用寄存器中。编译器将选择一个合适的寄存器插入到模板中，并在内联汇编执行完成后从该寄存器读取变量的值。"
 
 #: src/unsafe/asm.md:65
 msgid "Let us see another example that also uses an input:"
-msgstr "让我们看另一个也使用输入的例子："
+msgstr "让我们再看一个使用输入的例子："
 
 #: src/unsafe/asm.md:75
 msgid "\"mov {0}, {1}\""
@@ -15883,11 +15895,11 @@ msgid ""
 "variable `o`. The particular way this assembly does this is first copying the "
 "value from `i` to the output, and then adding `5` to it."
 msgstr ""
-"这将把 `5` 加到变量 `i` 的输入上，并将结果写入变量 `o`。这段汇编的具体做法是先将 `i` 的值复制到输出，然后加上 `5`。"
+"这段代码会将 `5` 加到变量 `i` 的值上，然后将结果写入变量 `o`。具体的汇编实现是先将 `i` 的值复制到输出寄存器，然后再加上 `5`。"
 
 #: src/unsafe/asm.md:89
 msgid "The example shows a few things:"
-msgstr "这个例子展示了几点："
+msgstr "这个例子展示了几个要点："
 
 #: src/unsafe/asm.md:91
 msgid ""
@@ -15896,13 +15908,13 @@ msgid ""
 "joined together with newlines between them. This makes it easy to format "
 "assembly code."
 msgstr ""
-"首先，我们可以看到 `asm!` 允许多个模板字符串参数；每个参数都被视为单独的一行汇编代码，就好像它们都用换行符连接在一起。这使得格式化汇编代码变得容易。"
+"`asm!` 宏支持多个模板字符串参数，每个参数都被视为独立的汇编代码行，就像它们之间用换行符连接一样。这使得格式化汇编代码变得简单。"
 
 #: src/unsafe/asm.md:96
 msgid ""
 "Second, we can see that inputs are declared by writing `in` instead of `out`."
 msgstr ""
-"其次，我们可以看到输入是通过写 `in` 而不是 `out` 来声明的。"
+"其次，我们可以看到输入参数使用 `in` 声明，而不是 `out`。"
 
 #: src/unsafe/asm.md:98
 msgid ""
@@ -15912,11 +15924,11 @@ msgid ""
 "using this facility is generally recommended, as it improves readability, and "
 "allows reordering instructions without changing the argument order."
 msgstr ""
-"第三，我们可以看到我们可以指定参数编号或名称，就像在任何格式字符串中一样。对于内联汇编模板，这特别有用，因为参数经常被多次使用。对于更复杂的内联汇编，通常建议使用这种方式，因为它提高了可读性，并允许在不改变参数顺序的情况下重新排序指令。"
+"第三，我们可以像在任何格式字符串中一样指定参数编号或名称。这在内联汇编模板中特别有用，因为参数通常会被多次使用。对于更复杂的内联汇编，建议使用这种方式，因为它提高了可读性，并且允许在不改变参数顺序的情况下重新排列指令。"
 
 #: src/unsafe/asm.md:103
 msgid "We can further refine the above example to avoid the `mov` instruction:"
-msgstr "我们可以进一步优化上面的例子以避免 `mov` 指令："
+msgstr "我们可以进一步优化上面的例子，避免使用 `mov` 指令："
 
 #: src/unsafe/asm.md:117
 msgid ""
@@ -15924,7 +15936,7 @@ msgid ""
 "output. This is different from specifying an input and output separately in "
 "that it is guaranteed to assign both to the same register."
 msgstr ""
-"我们可以看到 `inout` 用于指定既是输入又是输出的参数。这与分别指定输入和输出不同，它保证将两者分配到同一个寄存器。"
+"我们可以看到 `inout` 用于指定既作为输入又作为输出的参数。这与分别指定输入和输出不同，它保证将两者分配到同一个寄存器。"
 
 #: src/unsafe/asm.md:120
 msgid ""
@@ -15948,14 +15960,14 @@ msgid ""
 "output that is written only after all inputs have been consumed. There is "
 "also an `inlateout` variant of this specifier."
 msgstr ""
-"Rust 编译器在分配操作数时比较保守。它假设 `out` 可以在任何时候被写入，因此不能与任何其他参数共享其位置。然而，为了保证最佳性能，使用尽可能少的寄存器很重要，这样它们就不必在内联汇编块周围保存和重新加载。为了实现这一点，Rust 提供了一个 `lateout` 说明符。这可以用于任何只在所有输入被消耗后才写入的输出。这个说明符还有一个 `inlateout` 变体。"
+"Rust 编译器在分配操作数时采取保守策略。它假设 `out` 可以在任何时候被写入，因此不能与其他参数共享位置。然而，为了保证最佳性能，使用尽可能少的寄存器很重要，这样就不必在内联汇编块前后保存和重新加载寄存器。为此，Rust 提供了 `lateout` 说明符。这可以用于任何在所有输入被消耗后才写入的输出。此外还有一个 `inlateout` 变体。"
 
 #: src/unsafe/asm.md:145
 msgid ""
 "Here is an example where `inlateout` _cannot_ be used in `release` mode or "
 "other optimized cases:"
 msgstr ""
-"这里有一个例子，在 `release` 模式或其他优化情况下 _不能_ 使用 `inlateout`："
+"以下是一个在 `release` 模式或其他优化情况下 _不能_ 使用 `inlateout` 的例子："
 
 #: src/unsafe/asm.md:156 src/unsafe/asm.md:180 src/unsafe/asm.md:463
 msgid "\"add {0}, {1}\""
@@ -15973,7 +15985,7 @@ msgid ""
 "`inlateout(reg) a` can instead lead to the final value `a = 16`, causing the "
 "assertion to fail."
 msgstr ""
-"在未优化的情况下（例如 `Debug` 模式），在上面的例子中将 `inout(reg) a` 替换为 `inlateout(reg) a` 可以继续给出预期的结果。然而，在 `release` 模式或其他优化情况下，使用 `inlateout(reg) a` 可能会导致最终值 `a = 16`，使断言失败。"
+"在未优化的情况下（如 `Debug` 模式），将上述例子中的 `inout(reg) a` 替换为 `inlateout(reg) a` 仍能得到预期结果。但在 `release` 模式或其他优化情况下，使用 `inlateout(reg) a` 可能导致最终值 `a = 16`，使断言失败。"
 
 #: src/unsafe/asm.md:169
 msgid ""
@@ -15984,21 +15996,21 @@ msgid ""
 "initial load from variable `c`. This is in contrast to how using `inout(reg) "
 "a` ensures a separate register is allocated for `a`."
 msgstr ""
-"这是因为在优化情况下，编译器可以自由地为输入 `b` 和 `c` 分配相同的寄存器，因为它知道它们具有相同的值。此外，当使用 `inlateout` 时，`a` 和 `c` 可能被分配到同一个寄存器，在这种情况下，第一条 `add` 指令会覆盖从变量 `c` 初始加载的值。这与使用 `inout(reg) a` 确保为 `a` 分配单独的寄存器形成对比。"
+"这是因为在优化情况下，编译器可以为输入 `b` 和 `c` 分配相同的寄存器，因为它知道它们具有相同的值。此外，当使用 `inlateout` 时，`a` 和 `c` 可能被分配到同一个寄存器，这种情况下，第一条 `add` 指令会覆盖从变量 `c` 初始加载的值。相比之下，使用 `inout(reg) a` 可以确保为 `a` 分配一个单独的寄存器。"
 
 #: src/unsafe/asm.md:171
 msgid ""
 "However, the following example can use `inlateout` since the output is only "
 "modified after all input registers have been read:"
 msgstr ""
-"然而，以下示例可以使用 `inlateout`，因为输出仅在所有输入寄存器被读取后才被修改："
+"然而，以下示例可以使用 `inlateout`，因为输出仅在读取所有输入寄存器后才被修改："
 
 #: src/unsafe/asm.md:186
 msgid ""
 "As you can see, this assembly fragment will still work correctly if `a` and "
 "`b` are assigned to the same register."
 msgstr ""
-"如你所见，即使 `a` 和 `b` 被分配到同一个寄存器，这段汇编代码片段仍然能正确工作。"
+"如你所见，即使 `a` 和 `b` 被分配到同一个寄存器，这段汇编代码片段仍能正确运行。"
 
 #: src/unsafe/asm.md:188
 msgid "Explicit register operands"
@@ -16013,7 +16025,7 @@ msgid ""
 "registers `eax`, `ebx`, `ecx`, `edx`, `ebp`, `esi`, and `edi` among others "
 "can be addressed by their name."
 msgstr ""
-"某些指令要求操作数必须在特定的寄存器中。因此，Rust 内联汇编提供了一些更具体的约束说明符。虽然 `reg` 通常在任何架构上都可用，但显式寄存器是高度特定于架构的。例如，对于 x86，通用寄存器 `eax`、`ebx`、`ecx`、`edx`、`ebp`、`esi` 和 `edi` 等可以通过它们的名称来寻址。"
+"某些指令要求操作数必须位于特定寄存器中。因此，Rust 内联汇编提供了一些更具体的约束说明符。虽然 `reg` 通常适用于任何架构，但显式寄存器高度依赖于特定架构。例如，对于 x86 架构，通用寄存器如 `eax`、`ebx`、`ecx`、`edx`、`ebp`、`esi` 和 `edi` 等可以直接通过名称进行寻址。"
 
 #: src/unsafe/asm.md:200
 msgid "\"out 0x64, eax\""
@@ -16039,11 +16051,11 @@ msgid ""
 "name directly instead. Also, they must appear at the end of the operand list "
 "after all other operand types."
 msgstr ""
-"**注意**：与其他操作数类型不同，显式寄存器操作数不能在模板字符串中使用：你不能使用 `{}`，而应该直接写寄存器名称。此外，它们必须出现在操作数列表的末尾，在所有其他操作数类型之后。"
+"**注意**：与其他操作数类型不同，显式寄存器操作数不能在模板字符串中使用。你不能使用 `{}`，而应直接写入寄存器名称。此外，它们必须出现在操作数列表的末尾，位于所有其他操作数类型之后。"
 
 #: src/unsafe/asm.md:209
 msgid "Consider this example which uses the x86 `mul` instruction:"
-msgstr "考虑这个使用 x86 `mul` 指令的例子："
+msgstr "考虑以下使用 x86 `mul` 指令的例子："
 
 #: src/unsafe/asm.md:221
 msgid ""
@@ -16051,8 +16063,8 @@ msgid ""
 "            // the 128-bit result of the multiplication to rax:rdx.\n"
 "            \"mul {}\""
 msgstr ""
-"// x86 mul 指令将 rax 作为隐式输入，并将\n"
-"            // 乘法的 128 位结果写入 rax:rdx。\n"
+"// x86 的 mul 指令将 rax 作为隐式输入，\n"
+"            // 并将乘法的 128 位结果写入 rax:rdx。\n"
 "            \"mul {}\""
 
 #: src/unsafe/asm.md:225 src/unsafe/asm.md:347
@@ -16072,7 +16084,7 @@ msgid ""
 "stored in `rax` from which we fill the variable `lo`. The higher 64 bits are "
 "stored in `rdx` from which we fill the variable `hi`."
 msgstr ""
-"这里使用 `mul` 指令将两个 64 位输入相乘，得到一个 128 位的结果。唯一的显式操作数是一个寄存器，我们用变量 `a` 填充它。第二个操作数是隐式的，必须是 `rax` 寄存器，我们用变量 `b` 填充它。结果的低 64 位存储在 `rax` 中，我们用它填充变量 `lo`。高 64 位存储在 `rdx` 中，我们用它填充变量 `hi`。"
+"这里使用 `mul` 指令将两个 64 位输入相乘，得到一个 128 位的结果。唯一的显式操作数是一个寄存器，我们用变量 `a` 填充它。第二个操作数是隐式的，必须是 `rax` 寄存器，我们用变量 `b` 填充它。结果的低 64 位存储在 `rax` 中，用于填充变量 `lo`。高 64 位存储在 `rdx` 中，用于填充变量 `hi`。"
 
 #: src/unsafe/asm.md:241
 msgid "Clobbered registers"
@@ -16087,7 +16099,7 @@ msgid ""
 "We need to tell the compiler about this since it may need to save and restore "
 "this state around the inline assembly block."
 msgstr ""
-"在许多情况下，内联汇编会修改不需要作为输出的状态。通常这是因为我们必须在汇编中使用临时寄存器，或者因为指令修改了我们不需要进一步检查的状态。这种状态通常被称为"被破坏"。我们需要告诉编译器这一点，因为它可能需要在内联汇编块周围保存和恢复这种状态。"
+"在许多情况下，内联汇编会修改不需要作为输出的状态。这通常是因为我们必须在汇编中使用临时寄存器，或者因为指令修改了我们不需要进一步检查的状态。这种状态通常被称为"被破坏"。我们需要告知编译器这一点，因为它可能需要在内联汇编块前后保存和恢复这种状态。"
 
 #: src/unsafe/asm.md:253
 msgid "// three entries of four bytes each\n"
@@ -16103,10 +16115,10 @@ msgid ""
 "register instead.\n"
 msgstr ""
 "// 字符串按顺序以 ASCII 格式存储在 ebx、edx、ecx 中\n"
-"    // 因为 ebx 是保留的，汇编需要保留它的值。\n"
-"    // 所以我们在主要汇编代码前后进行 push 和 pop 操作。\n"
-"    // 64 位处理器的 64 位模式不允许推入/弹出 32 位寄存器（如 ebx），\n"
-"    // 所以我们必须使用扩展的 rbx 寄存器。\n"
+"    // 由于 ebx 是保留寄存器，汇编需要保留其值\n"
+"    // 因此我们在主要汇编代码前后执行 push 和 pop 操作\n"
+"    // 64 位处理器的 64 位模式不允许对 32 位寄存器（如 ebx）进行 push/pop 操作\n"
+"    // 所以我们必须使用扩展的 rbx 寄存器\n"
 
 #: src/unsafe/asm.md:263
 msgid "\"push rbx\""
@@ -16142,10 +16154,9 @@ msgid ""
 "            // The *pointer itself* is only an input even though it's written "
 "behind\n"
 msgstr ""
-"// 我们使用指向数组的指针来存储值，以简化\n"
-"            // Rust 代码，代价是多了几条汇编指令\n"
-"            // 然而，这更明确地展示了汇编的工作方式，与\n"
-"            // 显式寄存器输出（如 `out(\"ecx\") val`）相比\n"
+"// 我们使用指向数组的指针来存储值，以简化 Rust 代码\n"
+"            // 虽然这会增加几条汇编指令，但更清晰地展示了汇编的工作方式\n"
+"            // 相比于使用显式寄存器输出（如 `out(\"ecx\") val`）\n"
 "            // *指针本身*只是一个输入，尽管它在背后被写入\n"
 
 #: src/unsafe/asm.md:274 src/unsafe/asm.md:345
@@ -16154,11 +16165,11 @@ msgstr "\"rdi\""
 
 #: src/unsafe/asm.md:275
 msgid "// select cpuid 0, also specify eax as clobbered\n"
-msgstr "// 选择 cpuid 0，同时指定 eax 为被破坏\n"
+msgstr "// 选择 cpuid 0，同时指定 eax 为被修改寄存器\n"
 
 #: src/unsafe/asm.md:277
 msgid "// cpuid clobbers these registers too\n"
-msgstr "// cpuid 也破坏这些寄存器\n"
+msgstr "// cpuid 也会修改这些寄存器\n"
 
 #: src/unsafe/asm.md:278
 msgid "\"ecx\""
@@ -16179,7 +16190,7 @@ msgid ""
 "`cpuid` argument and `ebx`, `edx`, and `ecx` with the CPU manufacturer ID as "
 "ASCII bytes in that order."
 msgstr ""
-"在上面的例子中，我们使用 `cpuid` 指令来读取 CPU 制造商 ID。这条指令将最大支持的 `cpuid` 参数写入 `eax`，并按顺序将 CPU 制造商 ID 作为 ASCII 字节写入 `ebx`、`edx` 和 `ecx`。"
+"在上面的示例中，我们使用 `cpuid` 指令读取 CPU 制造商 ID。该指令将最大支持的 `cpuid` 参数写入 `eax`，并按顺序将 CPU 制造商 ID 的 ASCII 字节写入 `ebx`、`edx` 和 `ecx`。"
 
 #: src/unsafe/asm.md:294
 msgid ""
@@ -16189,7 +16200,7 @@ msgid ""
 "but with `_` instead of a variable name, which indicates that the output "
 "value is to be discarded."
 msgstr ""
-"尽管 `eax` 从未被读取，我们仍然需要告诉编译器该寄存器已被修改，这样编译器就可以保存在汇编之前这些寄存器中的任何值。这是通过将其声明为输出来完成的，但使用 `_` 而不是变量名，这表示输出值将被丢弃。"
+"尽管 `eax` 从未被读取，我们仍需要告知编译器该寄存器已被修改，这样编译器就可以保存汇编前这些寄存器中的任何值。我们通过将其声明为输出来实现这一点，但使用 `_` 而非变量名，表示输出值将被丢弃。"
 
 #: src/unsafe/asm.md:296
 msgid ""
@@ -16201,7 +16212,7 @@ msgid ""
 "`reg` operands dangerous when using reserved registers as we could "
 "unknowingly corrupt our input or output because they share the same register."
 msgstr ""
-"这段代码还解决了 `ebx` 是 LLVM 保留寄存器的限制。这意味着 LLVM 假定它对该寄存器有完全控制权，并且必须在退出汇编块之前将其恢复到原始状态，所以它不能用作输入或输出，**除非**编译器使用它来满足通用寄存器类（例如 `in(reg)`）。这使得在使用保留寄存器时，`reg` 操作数变得危险，因为我们可能会在不知情的情况下破坏我们的输入或输出，因为它们共享同一个寄存器。"
+"这段代码还解决了 LLVM 将 `ebx` 视为保留寄存器的限制。这意味着 LLVM 假定它对该寄存器拥有完全控制权，并且必须在退出汇编块之前将其恢复到原始状态。因此，`ebx` 不能用作输入或输出，**除非**编译器将其用于满足通用寄存器类（如 `in(reg)`）。这使得在使用保留寄存器时，`reg` 操作数变得危险，因为我们可能会在不知情的情况下破坏输入或输出，原因是它们共享同一个寄存器。"
 
 #: src/unsafe/asm.md:298
 msgid ""
@@ -16212,14 +16223,14 @@ msgid ""
 "register is saved. On 32 bit targets the code would instead use `ebx` in the "
 "`push`/`pop`."
 msgstr ""
-"为了解决这个问题，我们使用 `rdi` 来存储输出数组的指针，通过 `push` 保存 `ebx`，在汇编块内从 `ebx` 读取到数组中，然后通过 `pop` 将 `ebx` 恢复到原始状态。`push` 和 `pop` 使用完整的 64 位 `rbx` 版本的寄存器，以确保整个寄存器被保存。在 32 位目标上，代码会在 `push`/`pop` 中使用 `ebx`。"
+"为了解决这个问题，我们采用以下策略：使用 `rdi` 存储输出数组的指针；通过 `push` 保存 `ebx`；在汇编块内从 `ebx` 读取数据到数组中；然后通过 `pop` 将 `ebx` 恢复到原始状态。`push` 和 `pop` 操作使用完整的 64 位 `rbx` 寄存器版本，以确保整个寄存器被保存。在 32 位目标上，代码会在 `push`/`pop` 操作中使用 `ebx`。"
 
 #: src/unsafe/asm.md:300
 msgid ""
 "This can also be used with a general register class to obtain a scratch "
 "register for use inside the asm code:"
 msgstr ""
-"这也可以与通用寄存器类一起使用，以获得一个临时寄存器在汇编代码内使用："
+"这种技术还可以与通用寄存器类一起使用，以获得一个临时寄存器在汇编代码内使用："
 
 #: src/unsafe/asm.md:305
 msgid "// Multiply x by 6 using shifts and adds\n"
@@ -16256,7 +16267,7 @@ msgid ""
 "Multiple `clobber_abi` arguments may be provided and all clobbers from all "
 "specified ABIs will be inserted."
 msgstr ""
-"默认情况下，`asm!` 假定任何未指定为输出的寄存器的内容都将被汇编代码保留。`asm!` 的 [`clobber_abi`](https://doc.rust-lang.org/stable/reference/inline-assembly.html#abi-clobbers) 参数告诉编译器根据给定的调用约定 ABI 自动插入必要的破坏操作数：任何在该 ABI 中未完全保留的寄存器都将被视为被破坏。可以提供多个 `clobber_abi` 参数，所有指定 ABI 的所有破坏都将被插入。"
+"默认情况下，`asm!` 假定汇编代码会保留所有未指定为输出的寄存器的内容。`asm!` 的 [`clobber_abi`](https://doc.rust-lang.org/stable/reference/inline-assembly.html#abi-clobbers) 参数告诉编译器根据给定的调用约定 ABI 自动插入必要的破坏操作数：任何在该 ABI 中未完全保留的寄存器都将被视为被破坏。可以提供多个 `clobber_abi` 参数，所有指定 ABI 的破坏都将被插入。"
 
 #: src/unsafe/asm.md:332 src/unsafe/asm.md:350
 msgid "\"C\""
@@ -16288,7 +16299,7 @@ msgid ""
 "            // convention as clobbered.\n"
 msgstr ""
 "// 将所有不被 \"C\" 调用约定保留的寄存器\n"
-"            // 标记为被破坏。\n"
+"            // 标记为被破坏\n"
 
 #: src/unsafe/asm.md:358
 msgid "Register template modifiers"
@@ -16302,7 +16313,7 @@ msgid ""
 "each typically being a \"view\" over a subset of the register (e.g. the low "
 "32 bits of a 64-bit register)."
 msgstr ""
-"在某些情况下，需要对寄存器名称插入模板字符串时的格式进行精细控制。当一个架构的汇编语言对同一个寄存器有几个名称时，这是必要的，每个名称通常是寄存器子集的一个"视图"（例如，64 位寄存器的低 32 位）。"
+"在某些情况下，需要对寄存器名称插入模板字符串时的格式进行精细控制。当一个架构的汇编语言对同一个寄存器有多个名称时，这种控制尤为必要。每个名称通常代表寄存器的一个子集"视图"（例如，64 位寄存器的低 32 位）。"
 
 #: src/unsafe/asm.md:362
 msgid ""
@@ -16316,7 +16327,7 @@ msgid ""
 "This default can be overridden by using modifiers on the template string "
 "operands, just like you would with format strings:"
 msgstr ""
-"这个默认设置可以通过在模板字符串操作数上使用修饰符来覆盖，就像你在格式字符串中使用的那样："
+"可以通过在模板字符串操作数上使用修饰符来覆盖这个默认设置，类似于格式字符串的用法："
 
 #: src/unsafe/asm.md:373
 msgid "\"mov {0:h}, {0:l}\""
@@ -16328,7 +16339,7 @@ msgid ""
 "register allocator to the 4 legacy x86 registers (`ax`, `bx`, `cx`, `dx`) of "
 "which the first two bytes can be addressed independently."
 msgstr ""
-"在这个例子中，我们使用 `reg_abcd` 寄存器类来限制寄存器分配器使用 4 个传统的 x86 寄存器（`ax`、`bx`、`cx`、`dx`），其中前两个字节可以独立寻址。"
+"在这个例子中，我们使用 `reg_abcd` 寄存器类来限制寄存器分配器只使用 4 个传统的 x86 寄存器（`ax`、`bx`、`cx`、`dx`）。这些寄存器的前两个字节可以独立寻址。"
 
 #: src/unsafe/asm.md:382
 msgid ""
@@ -16338,7 +16349,7 @@ msgid ""
 "byte. The asm code will therefore be expanded as `mov ah, al` which copies "
 "the low byte of the value into the high byte."
 msgstr ""
-"假设寄存器分配器选择将 `x` 分配在 `ax` 寄存器中。`h` 修饰符将发出该寄存器高字节的寄存器名称，而 `l` 修饰符将发出低字节的寄存器名称。因此，汇编代码将被展开为 `mov ah, al`，这将值的低字节复制到高字节。"
+"假设寄存器分配器选择将 `x` 分配到 `ax` 寄存器。`h` 修饰符将生成该寄存器高字节的名称，而 `l` 修饰符将生成低字节的名称。因此，汇编代码将被展开为 `mov ah, al`，这条指令将值的低字节复制到高字节。"
 
 #: src/unsafe/asm.md:385
 msgid ""
@@ -16360,7 +16371,7 @@ msgid ""
 "assembly syntax, you should wrap inputs/outputs in `[]` to indicate they are "
 "memory operands:"
 msgstr ""
-"有时汇编指令需要通过内存地址/内存位置传递操作数。你必须手动使用目标架构指定的内存地址语法。例如，在使用 Intel 汇编语法的 x86/x86_64 上，你应该将输入/输出用 `[]` 包裹，以表明它们是内存操作数："
+"有时汇编指令需要通过内存地址或内存位置传递操作数。你必须手动使用目标架构指定的内存地址语法。例如，在使用 Intel 汇编语法的 x86/x86_64 架构上，你应该用 `[]` 包裹输入/输出，以表明它们是内存操作数："
 
 #: src/unsafe/asm.md:399
 msgid "\"fldcw [{}]\""
@@ -16376,14 +16387,14 @@ msgid ""
 "linker error or may cause other strange behavior. Reuse of a named label can "
 "happen in a variety of ways including:"
 msgstr ""
-"任何命名标签的重用，无论是局部的还是其他的，都可能导致汇编器或链接器错误，或可能引起其他奇怪的行为。命名标签的重用可能以多种方式发生，包括："
+"重复使用命名标签（无论是局部的还是其他类型的）可能导致汇编器或链接器错误，或引起其他异常行为。命名标签的重用可能以多种方式发生，包括："
 
 #: src/unsafe/asm.md:409
 msgid ""
 "explicitly: using a label more than once in one `asm!` block, or multiple "
 "times across blocks."
 msgstr ""
-"显式：在一个 `asm!` 块中多次使用一个标签，或在多个块之间多次使用。"
+"显式重用：在一个 `asm!` 块中多次使用同一标签，或在多个块之间重复使用。"
 
 #: src/unsafe/asm.md:410
 msgid ""
@@ -16391,14 +16402,14 @@ msgid ""
 "copies of an `asm!` block, for example when the function containing it is "
 "inlined in multiple places."
 msgstr ""
-"通过内联隐式：编译器允许实例化 `asm!` 块的多个副本，例如当包含它的函数在多个地方内联时。"
+"通过内联隐式重用：编译器可能会创建 `asm!` 块的多个副本，例如当包含该块的函数在多处被内联时。"
 
 #: src/unsafe/asm.md:411
 msgid ""
 "implicitly via LTO: LTO can cause code from _other crates_ to be placed in "
 "the same codegen unit, and so could bring in arbitrary labels."
 msgstr ""
-"通过 LTO 隐式：LTO 可能导致**其他 crate** 的代码被放置在同一个代码生成单元中，因此可能引入任意标签。"
+"通过 LTO 隐式重用：链接时优化（LTO）可能导致**其他 crate** 的代码被放置在同一代码生成单元中，从而可能引入任意标签。"
 
 #: src/unsafe/asm.md:413
 msgid ""
@@ -16407,7 +16418,9 @@ msgid ""
 "inside inline assembly code. Defining symbols in assembly code may lead to "
 "assembler and/or linker errors due to duplicate symbol definitions."
 msgstr ""
-"因此，你应该只在内联汇编代码中使用 GNU 汇编器的**数字**[局部标签](https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-Labels)。在汇编代码中定义符号可能会由于重复的符号定义导致汇编器和/或链接器错误。"
+"因此，你应该只在内联汇编代码中使用 GNU 汇编器的**数字**[局部标签]"
+"(https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-Labels)。"
+"在汇编代码中定义符号可能会由于重复的符号定义而导致汇编器和/或链接器错误。"
 
 #: src/unsafe/asm.md:415
 msgid ""
@@ -16418,7 +16431,11 @@ msgid ""
 "will avoid any ambiguity, but that affects the syntax of the _entire_ `asm!` "
 "block. (See [Options](#options), below, for more on `options`.)"
 msgstr ""
-"此外，在 x86 上使用默认的 Intel 语法时，由于[一个 LLVM 的 bug](https://bugs.llvm.org/show_bug.cgi?id=36144)，你不应该使用仅由 `0` 和 `1` 数字组成的标签，例如 `0`、`11` 或 `101010`，因为它们可能最终被解释为二进制值。使用 `options(att_syntax)` 可以避免任何歧义，但这会影响**整个** `asm!` 块的语法。（有关 `options` 的更多信息，请参见下面的[选项](#options)。）"
+"此外，在 x86 架构上使用默认的 Intel 语法时，由于[一个 LLVM 的 bug]"
+"(https://bugs.llvm.org/show_bug.cgi?id=36144)，你不应使用仅由 `0` 和 `1` 组成的标签，"
+"如 `0`、`11` 或 `101010`，因为它们可能被误解为二进制值。使用 `options(att_syntax)` "
+"可以避免这种歧义，但这会影响*整个* `asm!` 块的语法。（关于 `options` 的更多信息，"
+"请参见下文的[选项](#options)。）"
 
 #: src/unsafe/asm.md:424
 msgid "\"mov {0}, 10\""
@@ -16453,11 +16470,11 @@ msgid ""
 "This will decrement the `{0}` register value from 10 to 3, then add 2 and "
 "store it in `a`."
 msgstr ""
-"这将把 `{0}` 寄存器的值从 10 递减到 3，然后加 2 并存储在 `a` 中。"
+"这段代码会将 `{0}` 寄存器的值从 10 递减到 3，然后加 2 并将结果存储在 `a` 中。"
 
 #: src/unsafe/asm.md:441
 msgid "This example shows a few things:"
-msgstr "这个例子展示了几点："
+msgstr "这个例子展示了几个要点："
 
 #: src/unsafe/asm.md:443
 msgid ""
@@ -16468,12 +16485,12 @@ msgstr "首先，同一个数字可以在同一个内联块中多次用作标签
 #: src/unsafe/asm.md:444
 msgid ""
 "Second, that when a numeric label is used as a reference (as an instruction "
-"operand, for example), the suffixes “b” (“backward”) or ”f” (“forward”) "
+"operand, for example), the suffixes "b" ("backward") or "f" ("forward") "
 "should be added to the numeric label. It will then refer to the nearest label "
 "defined by this number in this direction."
 msgstr ""
-"其次，当数字标签被用作引用（例如作为指令操作数）时，应该在数字标签后添加后缀 "b"（"backward"，向后）或 "f"（"forward"，向前）。"
-"它将引用该方向上由这个数字定义的最近的标签。"
+"其次，当数字标签被用作引用（例如作为指令操作数）时，应在数字标签后添加后缀 "b"（"backward"，向后）"
+"或 "f"（"forward"，向前）。这样它将引用该方向上由这个数字定义的最近的标签。"
 
 #: src/unsafe/asm.md:449
 msgid "Options"
@@ -16487,18 +16504,20 @@ msgid ""
 "give the compiler more information about what the assembly code is actually "
 "doing so that it can optimize better."
 msgstr ""
-"默认情况下，内联汇编块的处理方式与具有自定义调用约定的外部 FFI 函数调用相同：它可能读/写内存，有可观察的副作用等。"
-"然而，在许多情况下，我们希望给编译器提供更多关于汇编代码实际在做什么的信息，以便它可以更好地优化。"
+"默认情况下，内联汇编块的处理方式与具有自定义调用约定的外部 FFI 函数调用相同：它可能读写内存，"
+"产生可观察的副作用等。然而，在许多情况下，我们希望向编译器提供更多关于汇编代码实际行为的信息，"
+"以便编译器能够进行更好的优化。"
 
 #: src/unsafe/asm.md:453
 msgid "Let's take our previous example of an `add` instruction:"
-msgstr "让我们看看之前 `add` 指令的例子："
+msgstr "让我们回顾一下之前 `add` 指令的例子："
 
 #: src/unsafe/asm.md:472
 msgid ""
 "Options can be provided as an optional final argument to the `asm!` macro. We "
 "specified three options here:"
-msgstr "选项可以作为 `asm!` 宏的可选最终参数提供。我们在这里指定了三个选项："
+msgstr ""
+"可以将选项作为可选的最后一个参数传递给 `asm!` 宏。在这个例子中，我们指定了三个选项："
 
 #: src/unsafe/asm.md:473
 msgid ""
@@ -16506,7 +16525,7 @@ msgid ""
 "output depends only on its inputs. This allows the compiler optimizer to call "
 "the inline asm fewer times or even eliminate it entirely."
 msgstr ""
-"`pure` 表示汇编代码没有可观察的副作用，其输出仅依赖于其输入。这允许编译器优化器减少调用内联汇编的次数，甚至完全消除它。"
+"`pure`：表示汇编代码没有可观察的副作用，其输出仅依赖于输入。这使得编译器优化器能够减少内联汇编的调用次数，甚至完全消除它。"
 
 #: src/unsafe/asm.md:474
 msgid ""
@@ -16515,7 +16534,7 @@ msgid ""
 "address that is accessible to it (e.g. through a pointer passed as an "
 "operand, or a global)."
 msgstr ""
-"`nomem` 表示汇编代码不读取或写入内存。默认情况下，编译器会假设内联汇编可以读取或写入任何它可以访问的内存地址（例如，通过作为操作数传递的指针，或全局变量）。"
+"`nomem`：表示汇编代码不读取或写入内存。默认情况下，编译器会假设内联汇编可以读写任何它可访问的内存地址（例如通过作为操作数传递的指针或全局变量）。"
 
 #: src/unsafe/asm.md:475
 msgid ""
@@ -16523,21 +16542,21 @@ msgid ""
 "allows the compiler to use optimizations such as the stack red zone on x86-64 "
 "to avoid stack pointer adjustments."
 msgstr ""
-"`nostack` 表示汇编代码不会将任何数据压入栈中。这允许编译器使用诸如 x86-64 上的栈红区等优化来避免栈指针调整。"
+"`nostack`：表示汇编代码不会向栈中压入任何数据。这允许编译器使用诸如 x86-64 上的栈红区等优化技术，以避免栈指针调整。"
 
 #: src/unsafe/asm.md:477
 msgid ""
 "These allow the compiler to better optimize code using `asm!`, for example by "
 "eliminating pure `asm!` blocks whose outputs are not needed."
 msgstr ""
-"这些选项允许编译器更好地优化使用 `asm!` 的代码，例如通过消除那些输出不被需要的纯 `asm!` 块。"
+"这些选项使编译器能够更好地优化使用 `asm!` 的代码，例如消除那些输出未被使用的纯 `asm!` 块。"
 
 #: src/unsafe/asm.md:479
 msgid ""
 "See the [reference](https://doc.rust-lang.org/stable/reference/inline-"
 "assembly.html) for the full list of available options and their effects."
 msgstr ""
-"查看[参考文档](https://doc.rust-lang.org/stable/reference/inline-assembly.html)以获取可用选项的完整列表及其效果。"
+"有关可用选项的完整列表及其效果，请参阅[参考文档]（https://doc.rust-lang.org/stable/reference/inline-assembly.html）。"
 
 #: src/compatibility.md:3
 msgid ""
@@ -16545,7 +16564,7 @@ msgid ""
 "compatibility issues can arise, despite efforts to ensure forwards-"
 "compatibility wherever possible."
 msgstr ""
-"Rust 语言正在快速发展，因此尽管努力确保尽可能的向前兼容性，某些兼容性问题仍可能出现。"
+"Rust 语言正在快速发展。尽管我们努力确保尽可能的向前兼容，但某些兼容性问题仍可能出现。"
 
 #: src/compatibility.md:7
 msgid "[Raw identifiers](compatibility/raw_identifiers.md)"
@@ -16561,8 +16580,7 @@ msgid ""
 "older edition of Rust has a variable or function with the same name as a "
 "keyword introduced in a newer edition."
 msgstr ""
-"Rust，像许多编程语言一样，有"关键字"的概念。这些标识符对语言来说有特殊含义，因此你不能在变量名、函数名和其他地方使用它们。"
-"原始标识符允许你在通常不允许使用关键字的地方使用它们。这在 Rust 引入新关键字，而使用旧版本 Rust 的库有一个与新版本中引入的关键字同名的变量或函数时特别有用。"
+"Rust 和许多编程语言一样，有"关键字"的概念。这些标识符在语言中具有特殊含义，因此你不能在变量名、函数名等地方使用它们。原始标识符允许你在通常不允许使用关键字的地方使用它们。这在 Rust 引入新关键字，而使用旧版本 Rust 的库中有与新版本引入的关键字同名的变量或函数时特别有用。"
 
 #: src/compatibility/raw_identifiers.md:11
 msgid ""
@@ -16571,16 +16589,15 @@ msgid ""
 "feature in the 2018 edition, so without raw identifiers, we would have no way "
 "to name the function."
 msgstr ""
-"例如，设想一个使用 2015 版 Rust 编译的 crate `foo`，它导出了一个名为 `try` 的函数。这个关键字在 2018 版中被保留用于新特性，"
-"所以如果没有原始标识符，我们就无法命名这个函数。"
+"例如，假设有一个使用 Rust 2015 版编译的 crate `foo`，它导出了一个名为 `try` 的函数。这个关键字在 2018 版中被保留用于新特性，如果没有原始标识符，我们就无法命名这个函数。"
 
 #: src/compatibility/raw_identifiers.md:24
 msgid "You'll get this error:"
-msgstr "得到这个错误："
+msgstr "你会得到这个错误："
 
 #: src/compatibility/raw_identifiers.md:34
 msgid "You can write this with a raw identifier:"
-msgstr "可以使用原始标识符这样写："
+msgstr "你可以使用原始标识符这样写："
 
 #: src/meta.md:3
 msgid ""
@@ -16588,41 +16605,41 @@ msgid ""
 "tooling or infrastructure support which just makes things better for "
 "everyone. These topics include:"
 msgstr ""
-"有些主题与程序本身如何运行并不直接相关，但它们提供了工具或基础设施支持，使得整个软件生态都变得更好。这些主题包括："
+"有些主题虽然与程序如何运行不直接相关，但它们提供了工具或基础设施支持，使得整个开发生态变得更好。这些主题包括："
 
 #: src/meta.md:7
 msgid ""
 "[Documentation](meta/doc.md): Generate library documentation for users via "
 "the included `rustdoc`."
 msgstr ""
-"[文档](meta/doc.md)：通过包含的 `rustdoc` 为用户生成库文档。"
+"[文档](meta/doc.md)：使用内置的 `rustdoc` 为用户生成库文档。"
 
 #: src/meta.md:9
 msgid ""
 "[Playground](meta/playground.md): Integrate the Rust Playground in your "
 "documentation."
 msgstr ""
-"[Playground](meta/playground.md)：在你的文档中集成 Rust Playground。"
+"[Playground](meta/playground.md)：在文档中集成 Rust Playground。"
 
 #: src/meta/doc.md:3
 msgid ""
 "Use `cargo doc` to build documentation in `target/doc`, `cargo doc --open` "
 "will automatically open it in your web browser."
 msgstr ""
-"使用 `cargo doc` 在 `target/doc` 中构建文档，`cargo doc --open` 将在浏览器中自动打开。"
+"使用 `cargo doc` 在 `target/doc` 目录下构建文档。运行 `cargo doc --open` 将自动在浏览器中打开文档。"
 
 #: src/meta/doc.md:6
 msgid ""
 "Use `cargo test` to run all tests (including documentation tests), and `cargo "
 "test --doc` to only run documentation tests."
 msgstr ""
-"使用 `cargo test` 运行所有测试（包括文档测试），使用 `cargo test --doc` 只运行文档测试。"
+"使用 `cargo test` 运行所有测试（包括文档测试）。如果只想运行文档测试，请使用 `cargo test --doc`。"
 
 #: src/meta/doc.md:9
 msgid ""
 "These commands will appropriately invoke `rustdoc` (and `rustc`) as required."
 msgstr ""
-"这些命令将根据需要适当地调用 `rustdoc`（和 `rustc`）。"
+"这些命令会根据需要适当地调用 `rustdoc`（和 `rustc`）。"
 
 #: src/meta/doc.md:11
 msgid "Doc comments"
@@ -16635,7 +16652,7 @@ msgid ""
 "documentation. They are denoted by a `///`, and support [Markdown](https://en."
 "wikipedia.org/wiki/Markdown)."
 msgstr ""
-"文档注释对于需要文档的大型项目非常有用。当运行 `rustdoc` 时，这些注释会被编译成文档。它们由 `///` 表示，并支持 [Markdown](https://en.wikipedia.org/wiki/Markdown)。"
+"文档注释对需要文档的大型项目非常有用。运行 `rustdoc` 时，这些注释会被编译成文档。文档注释以 `///` 开头，并支持 [Markdown](https://zh.wikipedia.org/wiki/Markdown) 语法。"
 
 #: src/meta/doc.md:18
 msgid "\"doc\""
@@ -16647,7 +16664,7 @@ msgstr "/// 这里表示一个人类\n"
 
 #: src/meta/doc.md:22
 msgid "/// A person must have a name, no matter how much Juliet may hate it\n"
-msgstr "/// 一个人必须有一个名字，不管朱丽叶有多讨厌它\n"
+msgstr "/// 一个人必须有名字，不管朱丽叶有多么讨厌这一点\n"
 
 #: src/meta/doc.md:27
 msgid ""
@@ -16667,8 +16684,8 @@ msgstr ""
 "    /// # 示例\n"
 "    ///\n"
 "    /// ```\n"
-"    /// // 你可以在注释中的围栏之间放置 rust 代码\n"
-"    /// // 如果你向 `rustdoc` 传递 --test 参数，它甚至会为你测试这段代码！\n"
+"    /// // 你可以在注释中的代码块里编写 Rust 代码\n"
+"    /// // 如果向 `rustdoc` 传递 --test 参数，它甚至会为你测试这段代码！\n"
 "    /// use doc::Person;\n"
 "    /// let person = Person::new(\"name\");\n"
 "    /// ```\n"
@@ -16680,9 +16697,9 @@ msgid ""
 "    /// Says \"Hello, [name](Person::name)\" to the `Person` it is called "
 "on.\n"
 msgstr ""
-"/// 给出一个友好的问候！\n"
+"/// 给出友好的问候！\n"
 "    ///\n"
-"    /// 对调用它的 `Person` 说 \"Hello, [name](Person::name)\"。\n"
+"    /// 对调用此方法的 `Person` 说 "Hello, [name](Person::name)"。\n"
 
 #: src/meta/doc.md:47
 msgid "\"Hello, {}!\""
@@ -16697,7 +16714,7 @@ msgid ""
 "To run the tests, first build the code as a library, then tell `rustdoc` "
 "where to find the library so it can link it into each doctest program:"
 msgstr ""
-"要运行测试，首先将代码构建为库，然后告诉 `rustdoc` 在哪里找到库，以便它可以将其链接到每个文档测试程序中："
+"要运行测试，首先将代码构建为库，然后告诉 `rustdoc` 库的位置，以便它可以将库链接到每个文档测试程序中："
 
 #: src/meta/doc.md:61
 msgid ""
@@ -16719,7 +16736,7 @@ msgstr "文档属性"
 msgid ""
 "Below are a few examples of the most common `#[doc]` attributes used with "
 "`rustdoc`."
-msgstr "以下是与 `rustdoc` 一起使用的最常见的 `#[doc]` 属性的几个例子。"
+msgstr "以下是几个与 `rustdoc` 配合使用的最常见 `#[doc]` 属性示例。"
 
 #: src/meta/doc.md:71
 msgid "`inline`"
@@ -16727,11 +16744,11 @@ msgstr "`inline`"
 
 #: src/meta/doc.md:73
 msgid "Used to inline docs, instead of linking out to separate page."
-msgstr "用于内联文档，而不是链接到单独的页面。"
+msgstr "用于内联文档，而非链接到单独的页面。"
 
 #: src/meta/doc.md:78
 msgid "/// bar docs\n"
-msgstr "/// bar 文档\n"
+msgstr "/// bar 的文档\n"
 
 #: src/meta/doc.md:81
 msgid "/// the docs for Bar\n"
@@ -16743,7 +16760,7 @@ msgstr "`no_inline`"
 
 #: src/meta/doc.md:88
 msgid "Used to prevent linking out to separate page or anywhere."
-msgstr "用于防止链接到单独的页面或任何地方。"
+msgstr "用于防止链接到单独页面或其他任何地方。"
 
 #: src/meta/doc.md:91
 msgid "// Example from libcore/prelude\n"
@@ -16755,7 +16772,7 @@ msgstr "`hidden`"
 
 #: src/meta/doc.md:98
 msgid "Using this tells `rustdoc` not to include this in documentation:"
-msgstr "使用这个属性告诉 `rustdoc` 不要包含在文档中："
+msgstr "使用此属性告诉 `rustdoc` 不要在文档中包含此内容："
 
 #: src/meta/doc.md:101
 msgid "// Example from the futures-rs library\n"
@@ -16766,7 +16783,7 @@ msgid ""
 "For documentation, `rustdoc` is widely used by the community. It's what is "
 "used to generate the [std library docs](https://doc.rust-lang.org/std/)."
 msgstr ""
-"针对文档，`rustdoc` 被社区广泛使用。[标准库文档](https://doc.rust-lang.org/std/)就是用它来生成的。"
+"在文档生成方面，`rustdoc` 被社区广泛使用。它是用来生成 [标准库文档](https://doc.rust-lang.org/std/) 的工具。"
 
 #: src/meta/doc.md:111
 msgid ""
@@ -16774,7 +16791,7 @@ msgid ""
 "org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-"
 "comments)"
 msgstr ""
-"[Rust 程序设计语言: 编写有用的文档注释](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments)"
+"[《Rust 程序设计语言》：编写有用的文档注释](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments)"
 
 #: src/meta/doc.md:112
 msgid "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/index.html)"
@@ -16785,7 +16802,7 @@ msgid ""
 "[The Reference: Doc comments](https://doc.rust-lang.org/stable/reference/"
 "comments.html#doc-comments)"
 msgstr ""
-"[参考手册: 文档注释](https://doc.rust-lang.org/stable/reference/comments.html#doc-comments)"
+"[Rust 参考手册：文档注释](https://doc.rust-lang.org/stable/reference/comments.html#doc-comments)"
 
 #: src/meta/doc.md:114
 msgid ""
@@ -16793,39 +16810,40 @@ msgid ""
 "rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-"
 "text)"
 msgstr ""
-"[RFC 1574: API 文档约定](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text)"
+"[RFC 1574：API 文档约定](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text)"
 
 #: src/meta/doc.md:115
 msgid ""
 "[RFC 1946: Relative links to other items from doc comments (intra-rustdoc "
 "links)](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
 msgstr ""
-"[RFC 1946: 从文档注释到其他项目的相对链接（rustdoc 内部链接）](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
+"[RFC 1946：文档注释中的相对链接（rustdoc 内部链接）](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
 
 #: src/meta/doc.md:116
 msgid ""
 "[Is there any documentation style guide for comments? (reddit)](https://www."
 "reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
 msgstr ""
-"[有没有关于注释的文档风格指南？（reddit）](https://www.reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
+"[有关注释的文档风格指南？（Reddit 讨论）](https://www."
+"reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
 
 #: src/meta/playground.md:3
 msgid ""
 "The [Rust Playground](https://play.rust-lang.org/) is a way to experiment "
 "with Rust code through a web interface."
 msgstr ""
-"[Rust Playground](https://play.rust-lang.org/) 是一种在线运行验证 Rust 代码的方式。"
+"[Rust Playground](https://play.rust-lang.org/) 是一个通过网页界面体验 Rust 代码的平台。"
 
 #: src/meta/playground.md:6
 msgid "Using it with `mdbook`"
-msgstr "在 `mdbook` 中使用"
+msgstr "在 `mdbook` 中使用 Playground"
 
 #: src/meta/playground.md:8
 msgid ""
 "In [`mdbook`](https://github.com/rust-lang/mdBook), you can make code "
 "examples playable and editable."
 msgstr ""
-"在 [`mdbook`](https://github.com/rust-lang/mdBook) 中，你可以使代码示例可运行和可编辑。"
+"在 [`mdbook`](https://github.com/rust-lang/mdBook) 中，你可以让代码示例变得可运行和可编辑。"
 
 #: src/meta/playground.md:16
 msgid ""
@@ -16833,18 +16851,18 @@ msgid ""
 "tweak it. The key here is the adding of the word `editable` to your codefence "
 "block separated by a comma."
 msgstr ""
-"这允许读者既可以运行你的代码示例，也可以修改和调整它。这里的关键是在你的代码块标注中添加 `editable` 这个词，用逗号分隔。"
+"这不仅允许读者运行你的代码示例，还能修改和调整它。关键是在代码块标记中添加 `editable` 关键字，用逗号分隔。"
 
 #: src/meta/playground.md:26
 msgid ""
 "Additionally, you can add `ignore` if you want `mdbook` to skip your code "
 "when it builds and tests."
 msgstr ""
-"此外，如果你希望 `mdbook` 在构建和测试时跳过你的代码，你可以添加 `ignore`。"
+"此外，如果你希望 `mdbook` 在构建和测试时跳过某段代码，可以添加 `ignore` 关键字。"
 
 #: src/meta/playground.md:35
 msgid "Using it with docs"
-msgstr "在文档中使用"
+msgstr "在文档中使用 Playground"
 
 #: src/meta/playground.md:37
 msgid ""
@@ -16854,7 +16872,9 @@ msgid ""
 "attribute called [`html_playground_url`](https://doc.rust-lang.org/rustdoc/"
 "write-documentation/the-doc-attribute.html#html_playground_url)."
 msgstr ""
-"你可能已经注意到在一些 [官方 Rust 文档](https://doc.rust-lang.org/core/) 中有一个写着 \"Run\" 的按钮，它会在 Rust Playground 的新标签页中打开代码示例。使用名为 [`html_playground_url`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_playground_url) 的 `#[doc]` 属性，就可以启用这个功能。"
+"你可能注意到在一些[官方 Rust 文档](https://doc.rust-lang.org/core/)中有一个"运行"按钮，"
+"点击后会在 Rust Playground 的新标签页中打开代码示例。要启用此功能，需要使用 `#[doc]` 属性中的 "
+"[`html_playground_url`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_playground_url)。"
 
 #: src/meta/playground.md:42
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -49,7 +49,7 @@ msgstr "格式化"
 
 #: src/SUMMARY.md:13 src/primitives.md:1
 msgid "Primitives"
-msgstr "原始类型"
+msgstr "原生类型"
 
 #: src/SUMMARY.md:14 src/primitives/literals.md:1
 msgid "Literals and operators"
@@ -671,7 +671,7 @@ msgstr "测试实例：map-reduce"
 
 #: src/SUMMARY.md:195 src/std_misc.md:7 src/std_misc/channels.md:1
 msgid "Channels"
-msgstr "通道"
+msgstr "信道"
 
 #: src/SUMMARY.md:196 src/std_misc/path.md:1
 msgid "Path"
@@ -804,7 +804,7 @@ msgstr "[Hello World](hello.md) - 从一个传统的 Hello World 程序开始。
 msgid ""
 "[Primitives](primitives.md) - Learn about signed integers, unsigned integers "
 "and other primitives."
-msgstr "[Primitives](primitives.md) - 学习有关有符号整数、无符号整数和其他原始类型的信息。"
+msgstr "[Primitives](primitives.md) - 学习有关有符号整数、无符号整数和其他原生类型的信息。"
 
 #: src/index.md:18
 msgid "[Custom Types](custom_types.md) - `struct` and `enum`."
@@ -3312,11 +3312,11 @@ msgid ""
 "Rust provides several mechanisms to change or define the type of primitive "
 "and user defined types. The following sections cover:"
 msgstr ""
-"Rust 提供了几种机制来更改或定义原始类型和用户定义类型。以下部分涵盖了："
+"Rust 提供了几种机制来更改或定义原生类型和用户定义类型。以下部分涵盖了："
 
 #: src/types.md:5
 msgid "[Casting](types/cast.md) between primitive types"
-msgstr "原始类型之间的[转换](types/cast.md)"
+msgstr "原生类型之间的[转换](types/cast.md)"
 
 #: src/types.md:6
 msgid "Specifying the desired type of [literals](types/literals.md)"
@@ -3336,7 +3336,7 @@ msgid ""
 "But, explicit type conversion (casting) can be performed using the `as` "
 "keyword."
 msgstr ""
-"Rust 不提供原始类型之间的隐式类型转换（coercion, 强制转换）。但是，可以使用 `as` 关键字执行显式类型转换（casting）。"
+"Rust 不提供原生类型之间的隐式类型转换（coercion, 强制转换）。但是，可以使用 `as` 关键字执行显式类型转换（casting）。"
 
 #: src/types/cast.md:6
 msgid ""
@@ -3633,7 +3633,7 @@ msgid ""
 "Types must have `UpperCamelCase` names, or the compiler will raise a warning. "
 "The exception to this rule are the primitive types: `usize`, `f32`, etc."
 msgstr ""
-"`type` 语句可以用来给一个已存在的类型起一个新名字。类型必须有 `UpperCamelCase`（大驼峰）的名字，否则编译器会发出警告。这个规则的例外是原始类型：`usize`、`f32` 等。"
+"`type` 语句可以用来给一个已存在的类型起一个新名字。类型必须有 `UpperCamelCase`（大驼峰）的名字，否则编译器会发出警告。这个规则的例外是原生类型：`usize`、`f32` 等。"
 
 #: src/types/alias.md:8
 msgid "// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.\n"
@@ -3670,7 +3670,7 @@ msgid ""
 "Primitive types can be converted to each other through [casting](types/cast."
 "md)."
 msgstr ""
-"原始类型可以通过[类型转换](types/cast.md)相互转换。"
+"原生类型可以通过[类型转换](types/cast.md)相互转换。"
 
 #: src/conversion.md:5
 msgid ""
@@ -3705,7 +3705,7 @@ msgid ""
 "are numerous implementations of this trait within the standard library for "
 "conversion of primitive and common types."
 msgstr ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 特质允许一个类型定义如何从另一个类型创建自己，从而提供了一种非常简单的机制来在几种类型之间进行转换。标准库中有许多这个特质的实现，用于原始类型和常见类型的转换。"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 特质允许一个类型定义如何从另一个类型创建自己，从而提供了一种非常简单的机制来在几种类型之间进行转换。标准库中有许多这个特质的实现，用于原生类型和常见类型的转换。"
 
 #: src/conversion/from_into.md:14
 msgid "For example we can easily convert a `str` into a `String`"
@@ -12437,7 +12437,7 @@ msgid ""
 "The `std` library provides many custom types which expands drastically on the "
 "`primitives`. Some of these include:"
 msgstr ""
-"`std` 库提供了许多自定义类型，这些类型大大扩展了`原始类型`。其中包括："
+"`std` 库提供了许多自定义类型，这些类型大大扩展了`原生类型`。其中包括："
 
 #: src/std.md:6
 msgid "growable `String`s like: `\"hello world\"`"
@@ -12464,7 +12464,7 @@ msgid ""
 "[primitives](primitives.md) and [the std library](https://doc.rust-lang.org/"
 "std/)"
 msgstr ""
-"[原始类型](primitives.md) 和 [std 库](https://doc.rust-lang.org/std/)"
+"[原生类型](primitives.md) 和 [标准库](https://doc.rust-lang.org/std/)"
 
 #: src/std/box.md:3
 msgid ""
@@ -13749,7 +13749,7 @@ msgid ""
 "Rust provides a mechanism for spawning native OS threads via the `spawn` "
 "function, the argument of this function is a moving closure."
 msgstr ""
-"Rust 通过 `spawn` 函数提供了一种生成本地操作系统线程的机制，这个函数的参数是一个移动（moving）闭包。"
+"Rust 通过 `spawn` 函数提供了一种生成原生操作系统线程的机制，这个函数的参数是一个移动（moving）闭包。"
 
 #: src/std_misc/threads.md:10 src/std_misc/threads/testcase_mapreduce.md:28
 msgid "// This is the `main` thread\n"
@@ -13780,7 +13780,7 @@ msgid ""
 "Rust makes it very easy to parallelise data processing, without many of the "
 "headaches traditionally associated with such an attempt."
 msgstr ""
-"Rust 使得并行化数据处理变得非常容易，避免了传统上与此类尝试相关的许多麻烦。"
+"Rust 使得并行化数据处理变得非常容易，避免了并行处理的很多传统难题。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:5
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -3632,11 +3632,11 @@ msgid ""
 "Types must have `UpperCamelCase` names, or the compiler will raise a warning. "
 "The exception to this rule are the primitive types: `usize`, `f32`, etc."
 msgstr ""
-"`type` 语句可以用来给一个已存在的类型起一个新名字。类型必须有 `UpperCamelCase`（大驼峰）的名字，否则编译器会发出警告。这个规则的例外是原生类型：`usize`、`f32` 等。"
+"`type` 语句用于为现有类型创建新名称。类型名必须使用 `UpperCamelCase`（大驼峰）命名，否则编译器会发出警告。此规则的例外是原始类型，如 `usize`、`f32` 等。"
 
 #: src/types/alias.md:8
 msgid "// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.\n"
-msgstr "// `NanoSecond`、`Inch` 和 `U64` 都是 `u64` 的新名字。\n"
+msgstr "// `NanoSecond`、`Inch` 和 `U64` 都是 `u64` 的新名称。\n"
 
 #: src/types/alias.md:14
 msgid "// `NanoSecond` = `Inch` = `U64` = `u64`.\n"
@@ -3647,7 +3647,7 @@ msgid ""
 "// Note that type aliases *don't* provide any extra type safety, because\n"
 "    // aliases are *not* new types\n"
 msgstr ""
-"// 注意类型别名**不**提供任何额外的类型安全性，因为别名**不是**新的类型\n"
+"// 注意，类型别名*不会*提供额外的类型安全性，因为别名*不是*新类型\n"
 
 #: src/types/alias.md:20
 msgid "\"{} nanoseconds + {} inches = {} unit?\""
@@ -3658,7 +3658,7 @@ msgid ""
 "The main use of aliases is to reduce boilerplate; for example the `io::"
 "Result<T>` type is an alias for the `Result<T, io::Error>` type."
 msgstr ""
-"别名的主要用途是减少样板代码；例如，`io::Result<T>` 类型是 `Result<T, io::Error>` 类型的别名。"
+"别名的主要用途是减少重复代码。例如，`io::Result<T>` 类型是 `Result<T, io::Error>` 类型的别名。"
 
 #: src/types/alias.md:32
 msgid "[Attributes](../attribute.md)"
@@ -3669,7 +3669,7 @@ msgid ""
 "Primitive types can be converted to each other through [casting](types/cast."
 "md)."
 msgstr ""
-"原生类型可以通过[类型转换](types/cast.md)相互转换。"
+"原始类型可以通过[类型转换](types/cast.md)相互转换。"
 
 #: src/conversion.md:5
 msgid ""
@@ -3680,7 +3680,7 @@ msgid ""
 "specific ones for the more common cases, in particular when converting to and "
 "from `String`s."
 msgstr ""
-"Rust 通过使用[特质](trait.md)来处理自定义类型（即 `struct` 和 `enum`）之间的转换。通用转换将使用 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质。然而，对于更常见的情况，特别是在与 `String` 相互转换时，还有一些更具体的特质。"
+"Rust 通过使用[特质](trait.md)来处理自定义类型（如 `struct` 和 `enum`）之间的转换。通用转换使用 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质。然而，对于更常见的情况，特别是与 `String` 相互转换时，还有一些更具体的特质。"
 
 #: src/conversion/from_into.md:3
 msgid ""
@@ -3690,7 +3690,7 @@ msgid ""
 "are able to convert type A from type B, then it should be easy to believe "
 "that we should be able to convert type B to type A."
 msgstr ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质本质上是相互关联的，这实际上是其实现的一部分。如果你能够将类型 A 从类型 B 转换，那么我们应该很容易相信我们也能够将类型 B 转换为类型 A。"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质本质上是相互关联的，这实际上是其实现的一部分。如果你能将类型 A 从类型 B 转换，那么我们也应该能够将类型 B 转换为类型 A。"
 
 #: src/conversion/from_into.md:7
 msgid "`From`"
@@ -3704,7 +3704,7 @@ msgid ""
 "are numerous implementations of this trait within the standard library for "
 "conversion of primitive and common types."
 msgstr ""
-"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 特质允许一个类型定义如何从另一个类型创建自己，从而提供了一种非常简单的机制来在几种类型之间进行转换。标准库中有许多这个特质的实现，用于原生类型和常见类型的转换。"
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 特质允许一个类型定义如何从另一个类型创建自身，从而提供了一种非常简单的机制来在多种类型之间进行转换。标准库中有许多这个特质的实现，用于原始类型和常见类型的转换。"
 
 #: src/conversion/from_into.md:14
 msgid "For example we can easily convert a `str` into a `String`"
@@ -3717,7 +3717,7 @@ msgstr "我们可以为自己的类型定义类似的转换。"
 #: src/conversion/from_into.md:39 src/conversion/from_into.md:68
 #: src/conversion/from_into.md:98
 msgid "\"My number is {:?}\""
-msgstr "\"My number is {:?}\""
+msgstr "\"我的数字是 {:?}\""
 
 #: src/conversion/from_into.md:43
 msgid "`Into`"
@@ -3754,7 +3754,7 @@ msgid ""
 "converse is not true: implementing `Into` for your type will not "
 "automatically provide it with an implementation of `From`."
 msgstr ""
-"`From` 和 `Into` 被设计为互补的。我们不需要为两个特质都提供实现。如果你为你的类型实现了 `From` 特质，`Into` 会在必要时调用它。但是请注意，反过来并不成立：为你的类型实现 `Into` 不会自动为它提供 `From` 的实现。"
+"`From` 和 `Into` 被设计为互补的。我们不需要为两个特质都提供实现。如果你为你的类型实现了 `From` 特质，`Into` 会在必要时调用它。但请注意，反过来并不成立：为你的类型实现 `Into` 不会自动为它提供 `From` 的实现。"
 
 #: src/conversion/from_into.md:86
 msgid "// Define `From`\n"
@@ -3773,7 +3773,11 @@ msgid ""
 "for fallible conversions, and as such, return [`Result`](https://doc.rust-"
 "lang.org/std/result/enum.Result.html)s."
 msgstr ""
-"与 [`From` 和 `Into`](from_into.html) 类似，[`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) 和 [`TryInto`](https://doc.rust-lang.org/std/convert/trait.TryInto.html) 是用于类型之间转换的泛型特质。与 `From`/`Into` 不同，`TryFrom`/`TryInto` 特质用于可能失败的转换，因此返回 [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)。"
+"与 [`From` 和 `Into`](from_into.html) 类似，[`TryFrom`] 和 [`TryInto`] 是用于类型转换的泛型特质。与 `From`/`Into` 不同，`TryFrom`/`TryInto` 特质用于可能失败的转换，因此返回 [`Result`]。\n"
+"\n"
+"[`TryFrom`]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html\n"
+"[`TryInto`]: https://doc.rust-lang.org/std/convert/trait.TryInto.html\n"
+"[`Result`]: https://doc.rust-lang.org/std/result/enum.Result.html"
 
 #: src/conversion/try_from_try_into.md:33
 msgid "// TryFrom\n"
@@ -3785,7 +3789,7 @@ msgstr "// TryInto\n"
 
 #: src/conversion/string.md:1
 msgid "To and from Strings"
-msgstr "字符串的相互转换"
+msgstr "字符串的转换"
 
 #: src/conversion/string.md:3
 msgid "Converting to String"
@@ -3801,11 +3805,15 @@ msgid ""
 "trait.ToString.html) and also allows printing the type as discussed in the "
 "section on [`print!`](../hello/print.md)."
 msgstr ""
-"将任何类型转换为 `String` 就像为该类型实现 [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) 特质一样简单。但是，你应该实现 [`fmt::Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) 特质，而不是直接实现 `ToString`。`fmt::Display` 会自动提供 [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)，并且还允许打印类型，就像在 [`print!`](../hello/print.md) 部分讨论的那样。"
+"要将任何类型转换为 `String`，只需为该类型实现 [`ToString`] 特质即可。但更好的做法是实现 [`fmt::Display`] 特质，它不仅会自动提供 [`ToString`]，还允许打印该类型，就像在 [`print!`] 部分讨论的那样。\n"
+"\n"
+"[`ToString`]: https://doc.rust-lang.org/std/string/trait.ToString.html\n"
+"[`fmt::Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html\n"
+"[`print!`]: ../hello/print.md"
 
 #: src/conversion/string.md:19
 msgid "\"Circle of radius {}\""
-msgstr "\"Circle of radius {}\""
+msgstr "\"半径为 {} 的圆\""
 
 #: src/conversion/string.md:29
 msgid "Parsing a String"
@@ -3820,7 +3828,9 @@ msgid ""
 "inference or to specify the type to parse using the 'turbofish' syntax. Both "
 "alternatives are shown in the following example."
 msgstr ""
-"将字符串转换为许多类型是很有用的，但最常见的字符串操作之一是将它们从字符串转换为数字。惯用的方法是使用 [`parse`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) 函数，并通过类型推断或使用 'turbofish' 语法指定要解析的类型。以下示例展示了这两种方法。"
+"将字符串转换为其他类型很有用，其中最常见的操作之一是将字符串转换为数字。惯用的方法是使用 [`parse`] 函数，可以通过类型推断或使用"涡轮鱼"语法指定要解析的类型。以下示例展示了这两种方法。\n"
+"\n"
+"[`parse`]: https://doc.rust-lang.org/std/primitive.str.html#method.parse"
 
 #: src/conversion/string.md:37
 msgid ""
@@ -3829,7 +3839,9 @@ msgid ""
 "implemented for that type. This is implemented for numerous types within the "
 "standard library."
 msgstr ""
-"只要为该类型实现了 [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) 特质，这就会将字符串转换为指定的类型。标准库中为许多类型实现了这个特质。"
+"只要为目标类型实现了 [`FromStr`] 特质，就可以将字符串转换为指定的类型。标准库中为许多类型实现了这个特质。\n"
+"\n"
+"[`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html"
 
 #: src/conversion/string.md:43 src/std_misc/process/wait.md:10
 msgid "\"5\""
@@ -3845,7 +3857,7 @@ msgstr "\"10\""
 
 #: src/conversion/string.md:47
 msgid "\"Sum: {:?}\""
-msgstr "\"Sum: {:?}\""
+msgstr "\"总和：{:?}\""
 
 #: src/conversion/string.md:51
 msgid ""
@@ -3853,7 +3865,9 @@ msgid ""
 "[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
 "that type."
 msgstr ""
-"要在用户定义的类型上获得这个功能，只需为该类型实现 [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) 特质。"
+"要在自定义类型上获得这个功能，只需为该类型实现 [`FromStr`] 特质。\n"
+"\n"
+"[`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html"
 
 #: src/conversion/string.md:74
 msgid "\"    3 \""
@@ -3861,7 +3875,7 @@ msgstr "\"    3 \""
 
 #: src/expression.md:3
 msgid "A Rust program is (mostly) made up of a series of statements:"
-msgstr "Rust 程序（大部分）由一系列语句组成:"
+msgstr "Rust 程序（主要）由一系列语句组成："
 
 #: src/expression.md:7
 msgid ""
@@ -3877,7 +3891,7 @@ msgstr ""
 msgid ""
 "There are a few kinds of statements in Rust. The most common two are "
 "declaring a variable binding, and using a `;` with an expression:"
-msgstr "Rust 中有几种语句。最常见的两种是声明变量绑定，以及在表达式后使用 `;`:"
+msgstr "Rust 中有几种语句。最常见的两种是声明变量绑定，以及在表达式后使用分号 `;`："
 
 #: src/expression.md:18
 msgid "// variable binding\n"
@@ -3893,7 +3907,9 @@ msgid ""
 "last expression in the block will be assigned to the place expression such as "
 "a local variable. However, if the last expression of the block ends with a "
 "semicolon, the return value will be `()`."
-msgstr "代码块也是表达式，所以它们可以用作赋值中的值。代码块中的最后一个表达式将被赋值给左值表达式，比如局部变量。但是，如果代码块的最后一个表达式以分号结尾，返回值将是 `()`。"
+msgstr ""
+"代码块也是表达式，因此可以在赋值中作为值使用。代码块中的最后一个表达式会被赋值给左值表达式（如局部变量）。"
+"但是，如果代码块的最后一个表达式以分号结尾，返回值将是 `()`。"
 
 #: src/expression.md:41
 msgid "// This expression will be assigned to `y`\n"
@@ -3920,7 +3936,8 @@ msgstr "\"z 是 {:?}\""
 msgid ""
 "An integral part of any programming language are ways to modify control flow: "
 "`if`/`else`, `for`, and others. Let's talk about them in Rust."
-msgstr "任何编程语言的一个重要部分是修改控制流的方法：`if`/`else`、`for` 等。让我们来讨论 Rust 中的这些内容。"
+msgstr ""
+"控制流是任何编程语言的重要组成部分，如 `if`/`else`、`for` 等。让我们来讨论 Rust 中的这些内容。"
 
 #: src/flow_control/if_else.md:3
 msgid ""
@@ -3928,7 +3945,9 @@ msgid ""
 "them, the boolean condition doesn't need to be surrounded by parentheses, and "
 "each condition is followed by a block. `if`\\-`else` conditionals are "
 "expressions, and, all branches must return the same type."
-msgstr "使用 `if`\\-`else` 分支和其他语言类似。与许多语言不同的是，布尔条件不需要用括号括起来，每个条件后面都跟着一个代码块。`if`\\-`else` 条件是表达式，并且所有分支必须返回相同的类型。"
+msgstr ""
+"`if`-`else` 分支结构与其他语言类似。不同之处在于，布尔条件不需要用括号括起来，每个条件后面都跟着一个代码块。"
+"`if`-`else` 条件是表达式，所有分支必须返回相同的类型。"
 
 #: src/flow_control/if_else.md:13
 msgid "\"{} is negative\""
@@ -3948,7 +3967,7 @@ msgstr "\"，是一个小数字，扩大十倍\""
 
 #: src/flow_control/if_else.md:24
 msgid "// This expression returns an `i32`.\n"
-msgstr "// 这个表达式返回一个 `i32`。\n"
+msgstr "// 这个表达式返回 `i32` 类型。\n"
 
 #: src/flow_control/if_else.md:27
 msgid "\", and is a big number, halve the number\""
@@ -3956,7 +3975,7 @@ msgstr "\"，是一个大数字，将数字减半\""
 
 #: src/flow_control/if_else.md:29
 msgid "// This expression must return an `i32` as well.\n"
-msgstr "// 这个表达式也必须返回一个 `i32`。\n"
+msgstr "// 这个表达式也必须返回 `i32` 类型。\n"
 
 #: src/flow_control/if_else.md:31
 msgid "// TODO ^ Try suppressing this expression with a semicolon.\n"
@@ -3965,7 +3984,7 @@ msgstr "// TODO ^ 尝试用分号结束这个表达式。\n"
 #: src/flow_control/if_else.md:33
 msgid ""
 "//   ^ Don't forget to put a semicolon here! All `let` bindings need it.\n"
-msgstr "//   ^ 别忘了在这里加分号！所有的 `let` 绑定都需要它。\n"
+msgstr "//   ^ 别忘了在这里加分号！所有 `let` 绑定都需要它。\n"
 
 #: src/flow_control/if_else.md:35 src/flow_control/match.md:35
 msgid "\"{} -> {}\""
@@ -3973,14 +3992,15 @@ msgstr "\"{} -> {}\""
 
 #: src/flow_control/loop.md:3
 msgid "Rust provides a `loop` keyword to indicate an infinite loop."
-msgstr "Rust 提供了 `loop` 关键字来表示一个无限循环。"
+msgstr "Rust 提供 `loop` 关键字来表示无限循环。"
 
 #: src/flow_control/loop.md:5
 msgid ""
 "The `break` statement can be used to exit a loop at anytime, whereas the "
 "`continue` statement can be used to skip the rest of the iteration and start "
 "a new one."
-msgstr "`break` 语句可以随时退出循环，而 `continue` 语句可以用来跳过本次迭代的剩余部分并开始新的迭代。"
+msgstr ""
+"`break` 语句可以随时退出循环，而 `continue` 语句可以跳过当前迭代的剩余部分并开始下一次迭代。"
 
 #: src/flow_control/loop.md:13
 msgid "\"Let's count until infinity!\""
@@ -4011,7 +4031,9 @@ msgid ""
 "It's possible to `break` or `continue` outer loops when dealing with nested "
 "loops. In these cases, the loops must be annotated with some `'label`, and "
 "the label must be passed to the `break`/`continue` statement."
-msgstr "在处理嵌套循环时，可以 `break` 或 `continue` 外层循环。在这些情况下，循环必须用某个 `'label` 标记，并且必须将标签传递给 `break`/`continue` 语句。"
+msgstr ""
+"在处理嵌套循环时，可以 `break` 或 `continue` 外层循环。这种情况下，循环必须用 `'label` 标记，"
+"并且必须将标签传递给 `break`/`continue` 语句。"
 
 #: src/flow_control/loop/nested.md:12
 msgid "\"Entered the outer loop\""
@@ -4035,7 +4057,7 @@ msgstr "// 这会中断外层循环\n"
 
 #: src/flow_control/loop/nested.md:24
 msgid "\"This point will never be reached\""
-msgstr "\"永远不会到达这一点\""
+msgstr "\"这一点永远不会到达\""
 
 #: src/flow_control/loop/nested.md:27
 msgid "\"Exited the outer loop\""
@@ -4047,25 +4069,27 @@ msgid ""
 "the operation returns a value though, you might need to pass it to the rest "
 "of the code: put it after the `break`, and it will be returned by the `loop` "
 "expression."
-msgstr "`loop` 的一个用途是重试一个操作，直到它成功。如果操作返回一个值，你可能需要将它传递给代码的其余部分：将它放在 `break` 之后，它将被 `loop` 表达式返回。"
+msgstr ""
+"`loop` 的一个用途是重试操作直到成功。如果操作返回一个值，你可能需要将它传递给代码的其余部分："
+"将它放在 `break` 之后，它将被 `loop` 表达式返回。"
 
 #: src/flow_control/while.md:3
 msgid "The `while` keyword can be used to run a loop while a condition is true."
-msgstr "`while` 关键字可以用来在条件为真时运行循环。"
+msgstr "`while` 关键字用于在条件为真时运行循环。"
 
 #: src/flow_control/while.md:5
 msgid ""
 "Let's write the infamous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) "
 "using a `while` loop."
-msgstr "让我们使用 `while` 循环来编写著名的 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 程序。"
+msgstr "让我们用 `while` 循环来编写著名的 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 程序。"
 
 #: src/flow_control/while.md:9
 msgid "// A counter variable\n"
-msgstr "// 一个计数器变量\n"
+msgstr "// 计数器变量\n"
 
 #: src/flow_control/while.md:12
 msgid "// Loop while `n` is less than 101\n"
-msgstr "// 当 `n` 小于 101 时循环\n"
+msgstr "// 当 `n` 小于 101 时继续循环\n"
 
 #: src/flow_control/while.md:15 src/flow_control/for.md:17
 #: src/flow_control/for.md:37 src/fn.md:34
@@ -4084,7 +4108,7 @@ msgstr "\"buzz\""
 
 #: src/flow_control/while.md:24
 msgid "// Increment counter\n"
-msgstr "// 增加计数器\n"
+msgstr "// 计数器递增\n"
 
 #: src/flow_control/for.md:1
 msgid "for loops"
@@ -4095,11 +4119,13 @@ msgid ""
 "The `for in` construct can be used to iterate through an `Iterator`. One of "
 "the easiest ways to create an iterator is to use the range notation `a..b`. "
 "This yields values from `a` (inclusive) to `b` (exclusive) in steps of one."
-msgstr "`for in` 结构可以用来遍历 `Iterator`。创建迭代器最简单的方法之一是使用区间表示法 `a..b`。这会生成从 `a`（包含）到 `b`（不包含）的值，步长为一。"
+msgstr ""
+"`for in` 结构可用于遍历 `Iterator`。创建迭代器最简单的方法之一是使用区间表示法 `a..b`。"
+"这会生成从 `a`（包含）到 `b`（不包含）的值，步长为 1。"
 
 #: src/flow_control/for.md:10
 msgid "Let's write FizzBuzz using `for` instead of `while`."
-msgstr "让我们使用 `for` 而不是 `while` 来编写 FizzBuzz。"
+msgstr "让我们用 `for` 而不是 `while` 来编写 FizzBuzz。"
 
 #: src/flow_control/for.md:14 src/flow_control/for.md:34
 msgid "// `n` will take the values: 1, 2, ..., 100 in each iteration\n"
@@ -4109,11 +4135,11 @@ msgstr "// `n` 在每次迭代中将取值：1, 2, ..., 100\n"
 msgid ""
 "Alternatively, `a..=b` can be used for a range that is inclusive on both "
 "ends. The above can be written as:"
-msgstr "或者，可以使用 `a..=b` 来表示两端都包含的范围。上面的代码可以写成："
+msgstr "另外，可以使用 `a..=b` 表示两端都包含的范围。上面的代码可以改写为："
 
 #: src/flow_control/for.md:49
 msgid "for and iterators"
-msgstr "for 和迭代器"
+msgstr "for 与迭代器"
 
 #: src/flow_control/for.md:51
 msgid ""
@@ -4122,20 +4148,27 @@ msgid ""
 "by default the `for` loop will apply the `into_iter` function to the "
 "collection. However, this is not the only means of converting collections "
 "into iterators."
-msgstr "`for in` 结构能够以多种方式与 `Iterator` 交互。正如在[迭代器](../trait/iter.md)特质一节中讨论的那样，默认情况下 `for` 循环会对集合应用 `into_iter` 函数。然而，这并不是将集合转换为迭代器的唯一方法。"
+msgstr ""
+"`for in` 结构能以多种方式与 `Iterator` 交互。正如在 [Iterator](../trait/iter.md) "
+"特质一节中讨论的那样，默认情况下 `for` 循环会对集合应用 `into_iter` 函数。"
+"然而，这并不是将集合转换为迭代器的唯一方法。"
 
 #: src/flow_control/for.md:56
 msgid ""
 "`into_iter`, `iter` and `iter_mut` all handle the conversion of a collection "
 "into an iterator in different ways, by providing different views on the data "
 "within."
-msgstr "`into_iter`、`iter` 和 `iter_mut` 都以不同的方式处理集合到迭代器的转换，通过提供对数据的不同视图。"
+msgstr ""
+"`into_iter`、`iter` 和 `iter_mut` 都以不同的方式处理集合到迭代器的转换，"
+"通过提供对数据的不同视图。"
 
 #: src/flow_control/for.md:60
 msgid ""
 "`iter` - This borrows each element of the collection through each iteration. "
 "Thus leaving the collection untouched and available for reuse after the loop."
-msgstr "`iter` - 这在每次迭代中借用集合的每个元素。因此，集合保持不变，并且在循环之后可以重复使用。"
+msgstr ""
+"`iter` - 在每次迭代中借用集合的每个元素。"
+"因此，集合保持不变，并且在循环之后可以重复使用。"
 
 #: src/flow_control/for.md:65 src/flow_control/for.md:85
 #: src/flow_control/for.md:104
@@ -4171,13 +4204,16 @@ msgid ""
 "`into_iter` - This consumes the collection so that on each iteration the "
 "exact data is provided. Once the collection has been consumed it is no longer "
 "available for reuse as it has been 'moved' within the loop."
-msgstr "`into_iter` - 这会消耗集合，使得在每次迭代中提供确切的数据。一旦集合被消耗，它就不再可用于重复使用，因为它已经在循环中被'移动'了。"
+msgstr ""
+"`into_iter` - 这会消耗集合，使得在每次迭代中提供确切的数据。"
+"一旦集合被消耗，它就不再可用于重复使用，因为它已经在循环中被"移动"了。"
 
 #: src/flow_control/for.md:99
 msgid ""
 "`iter_mut` - This mutably borrows each element of the collection, allowing "
 "for the collection to be modified in place."
-msgstr "`iter_mut` - 这会可变地借用集合的每个元素，允许在原地修改集合。"
+msgstr ""
+"`iter_mut` - 这会可变地借用集合的每个元素，允许在原地修改集合。"
 
 #: src/flow_control/for.md:109
 msgid "\"Hello\""
@@ -4188,7 +4224,9 @@ msgid ""
 "In the above snippets note the type of `match` branch, that is the key "
 "difference in the types of iteration. The difference in type then of course "
 "implies differing actions that are able to be performed."
-msgstr "在上面的代码片段中，注意 `match` 分支的类型，这是迭代类型的关键区别。类型的差异意味着可以执行的操作不同。"
+msgstr ""
+"在上面的代码片段中，注意 `match` 分支的类型，这是迭代类型的关键区别。"
+"类型的差异意味着可以执行不同的操作。"
 
 #: src/flow_control/for.md:123
 msgid "[Iterator](../trait/iter.md)"
@@ -4199,11 +4237,13 @@ msgid ""
 "Rust provides pattern matching via the `match` keyword, which can be used "
 "like a C `switch`. The first matching arm is evaluated and all possible "
 "values must be covered."
-msgstr "Rust 通过 `match` 关键字提供模式匹配，它可以像 C 语言的 `switch` 一样使用。第一个匹配的分支会被求值，并且必须覆盖所有可能的值。"
+msgstr ""
+"Rust 通过 `match` 关键字提供模式匹配，类似于 C 语言的 `switch`。"
+"第一个匹配的分支会被求值，并且必须覆盖所有可能的值。"
 
 #: src/flow_control/match.md:10
 msgid "// TODO ^ Try different values for `number`\n"
-msgstr "// TODO ^ 尝试为 `number` 赋予不同的值\n"
+msgstr "// TODO ^ 尝试为 `number` 赋不同的值\n"
 
 #: src/flow_control/match.md:12
 msgid "\"Tell me about {}\""
@@ -4223,7 +4263,7 @@ msgstr "// 匹配多个值\n"
 
 #: src/flow_control/match.md:17
 msgid "\"This is a prime\""
-msgstr "\"这是一个质数\""
+msgstr "\"这是个质数\""
 
 #: src/flow_control/match.md:18
 msgid ""
@@ -4231,7 +4271,7 @@ msgid ""
 "        // Match an inclusive range\n"
 msgstr ""
 "// TODO ^ 尝试将 13 添加到质数列表中\n"
-"        // 匹配一个包含的范围\n"
+"        // 匹配一个闭区间范围\n"
 
 #: src/flow_control/match.md:20
 msgid "\"A teen\""
@@ -4239,7 +4279,7 @@ msgstr "\"一个青少年\""
 
 #: src/flow_control/match.md:21
 msgid "// Handle the rest of cases\n"
-msgstr "// 处理剩余的情况\n"
+msgstr "// 处理其余情况\n"
 
 #: src/flow_control/match.md:22
 msgid "\"Ain't special\""
@@ -4247,7 +4287,7 @@ msgstr "\"没什么特别的\""
 
 #: src/flow_control/match.md:23
 msgid "// TODO ^ Try commenting out this catch-all arm\n"
-msgstr "// TODO ^ 尝试注释掉这个捕获所有情况的分支\n"
+msgstr "// TODO ^ 尝试注释掉这个匹配所有情况的分支\n"
 
 #: src/flow_control/match.md:27
 msgid "// Match is an expression too\n"
@@ -4291,15 +4331,15 @@ msgstr "元组可以在 `match` 中按如下方式解构："
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:8
 msgid "// TODO ^ Try different values for `triple`\n"
-msgstr "// TODO ^ 尝试为 `triple` 赋予不同的值\n"
+msgstr "// TODO ^ 尝试为 `triple` 赋不同的值\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:10
 msgid "\"Tell me about {:?}\""
-msgstr "\"Tell me about {:?}\""
+msgstr "\"告诉我关于 {:?} 的信息\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:11
 msgid "// Match can be used to destructure a tuple\n"
-msgstr "// match 可以用来解构一个元组\n"
+msgstr "// match 可用于解构元组\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:13
 msgid "// Destructure the second and third elements\n"
@@ -4307,27 +4347,27 @@ msgstr "// 解构第二和第三个元素\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:14
 msgid "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
-msgstr "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
+msgstr "\"第一个是 `0`，`y` 是 {:?}，`z` 是 {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:15
 msgid "\"First is `1` and the rest doesn't matter\""
-msgstr "\"First is `1` and the rest doesn't matter\""
+msgstr "\"第一个是 `1`，其余的不重要\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:16
 msgid "\"last is `2` and the rest doesn't matter\""
-msgstr "\"last is `2` and the rest doesn't matter\""
+msgstr "\"最后一个是 `2`，其余的不重要\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:17
 msgid "\"First is `3`, last is `4`, and the rest doesn't matter\""
-msgstr "\"First is `3`, last is `4`, and the rest doesn't matter\""
+msgstr "\"第一个是 `3`，最后一个是 `4`，其余的不重要\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:18
 msgid "// `..` can be used to ignore the rest of the tuple\n"
-msgstr "// `..` 可以用来忽略元组中的其余部分\n"
+msgstr "// `..` 可用于忽略元组中的其余部分\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:19
 msgid "\"It doesn't matter what they are\""
-msgstr "\"It doesn't matter what they are\""
+msgstr "\"它们是什么并不重要\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:20
 msgid "// `_` means don't bind the value to a variable\n"
@@ -4339,11 +4379,11 @@ msgstr "[元组](../../../primitives/tuples.md)"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:3
 msgid "Like tuples, arrays and slices can be destructured this way:"
-msgstr "像元组一样，数组和切片也可以用这种方式解构："
+msgstr "与元组类似，数组和切片也可以用这种方式解构："
 
 #: src/flow_control/match/destructuring/destructure_slice.md:7
 msgid "// Try changing the values in the array, or make it a slice!\n"
-msgstr "// 尝试改变数组中的值，或者将其变成一个切片！\n"
+msgstr "// 尝试改变数组中的值，或将其变成切片！\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:11
 msgid "// Binds the second and the third elements to the respective variables\n"
@@ -4351,7 +4391,7 @@ msgstr "// 将第二个和第三个元素分别绑定到相应的变量\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:13
 msgid "\"array[0] = 0, array[1] = {}, array[2] = {}\""
-msgstr "\"array[0] = 0, array[1] = {}, array[2] = {}\""
+msgstr "\"array[0] = 0，array[1] = {}，array[2] = {}\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:15
 msgid "// Single values can be ignored with _\n"
@@ -4359,15 +4399,15 @@ msgstr "// 单个值可以用 _ 忽略\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:17
 msgid "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
-msgstr "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
+msgstr "\"array[0] = 1，array[2] = {}，array[1] 被忽略了\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:21
 msgid "// You can also bind some and ignore the rest\n"
-msgstr "// 你也可以绑定一些值并忽略其余的\n"
+msgstr "// 你也可以绑定一部分值并忽略其余的\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:23
 msgid "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
-msgstr "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
+msgstr "\"array[0] = -1，array[1] = {}，其他所有的都被忽略了\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:26
 msgid ""
@@ -4387,7 +4427,7 @@ msgstr ""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:32
 msgid "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
-msgstr "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
+msgstr "\"array[0] = 3，array[1] = {}，其他元素是 {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:36
 msgid ""
@@ -4399,15 +4439,14 @@ msgstr ""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:39
 msgid "\"array[0] = {}, middle = {:?}, array[2] = {}\""
-msgstr "\"array[0] = {}, middle = {:?}, array[2] = {}\""
+msgstr "\"array[0] = {}，中间部分 = {:?}，array[2] = {}\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:48
 msgid ""
 "[Arrays and Slices](../../../primitives/array.md) and [Binding](../binding."
 "md) for `@` sigil"
 msgstr ""
-"[数组和切片](../../../primitives/array.md) 和 [绑定](../binding."
-"md) 中的 `@` 符号"
+"关于 `@` 符号的更多信息，请参阅[数组和切片](../../../primitives/array.md)和[绑定](../binding.md)"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:3
 msgid "An `enum` is destructured similarly:"
@@ -4418,16 +4457,15 @@ msgid ""
 "// `allow` required to silence warnings because only\n"
 "// one variant is used.\n"
 msgstr ""
-"// 需要 `allow` 来消除警告，因为只使用了\n"
-"// 一个变体。\n"
+"// 使用 `allow` 来抑制警告，因为只使用了一个变体。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:10
 msgid "// These 3 are specified solely by their name.\n"
-msgstr "// 这 3 个仅由它们的名称指定。\n"
+msgstr "// 这 3 个仅通过名称指定。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:14
 msgid "// These likewise tie `u32` tuples to different names: color models.\n"
-msgstr "// 这些同样将 `u32` 元组绑定到不同的名称：颜色模型。\n"
+msgstr "// 这些同样将 `u32` 元组与不同的名称（颜色模型）关联。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:24
 msgid "// TODO ^ Try different variants for `color`\n"
@@ -4435,7 +4473,7 @@ msgstr "// TODO ^ 尝试为 `color` 使用不同的变体\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:26
 msgid "\"What color is it?\""
-msgstr "\"What color is it?\""
+msgstr "\"这是什么颜色？\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:27
 msgid "// An `enum` can be destructured using a `match`.\n"
@@ -4443,47 +4481,47 @@ msgstr "// 可以使用 `match` 来解构 `enum`。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:29
 msgid "\"The color is Red!\""
-msgstr "\"The color is Red!\""
+msgstr "\"颜色是红色！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:30
 msgid "\"The color is Blue!\""
-msgstr "\"The color is Blue!\""
+msgstr "\"颜色是蓝色！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:31
 msgid "\"The color is Green!\""
-msgstr "\"The color is Green!\""
+msgstr "\"颜色是绿色！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:33
 msgid "\"Red: {}, green: {}, and blue: {}!\""
-msgstr "\"Red: {}, green: {}, and blue: {}!\""
+msgstr "\"红：{}，绿：{}，蓝：{}！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:35
 msgid "\"Hue: {}, saturation: {}, value: {}!\""
-msgstr "\"Hue: {}, saturation: {}, value: {}!\""
+msgstr "\"色相：{}，饱和度：{}，明度：{}！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:37
 msgid "\"Hue: {}, saturation: {}, lightness: {}!\""
-msgstr "\"Hue: {}, saturation: {}, lightness: {}!\""
+msgstr "\"色相：{}，饱和度：{}，亮度：{}！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:39
 msgid "\"Cyan: {}, magenta: {}, yellow: {}!\""
-msgstr "\"Cyan: {}, magenta: {}, yellow: {}!\""
+msgstr "\"青：{}，品红：{}，黄：{}！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:41
 msgid "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
-msgstr "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
+msgstr "\"青：{}，品红：{}，黄：{}，黑（K）：{}！\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:43
 msgid "// Don't need another arm because all variants have been examined\n"
-msgstr "// 不需要另一个分支，因为所有变体都已经被检查过了\n"
+msgstr "// 不需要其他分支，因为所有变体都已检查\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:50
 msgid ""
 "[`#[allow(...)]`](../../../attribute/unused.md), [color models](https://en."
 "wikipedia.org/wiki/Color_model) and [`enum`](../../../custom_types/enum.md)"
 msgstr ""
-"[`#[allow(...)]`](../../../attribute/unused.md)，[颜色模型](https://en."
-"wikipedia.org/wiki/Color_model) 和 [`enum`](../../../custom_types/enum.md)"
+"[`#[allow(...)]`](../../../attribute/unused.md)、[颜色模型](https://en."
+"wikipedia.org/wiki/Color_model)和[`enum`](../../../custom_types/enum.md)"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:3
 msgid ""
@@ -4491,7 +4529,7 @@ msgid ""
 "dereferencing as they are different concepts which are used differently from "
 "languages like C/C++."
 msgstr ""
-"对于指针，需要区分解构（destructure）和解引用（dereference），因为它们是不同的概念，其使用方式与 C/C++ 等语言不同。"
+"对于指针，需要区分解构和解引用，因为它们是不同的概念，其用法与 C/C++ 等语言不同。"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:7
 msgid "Dereferencing uses `*`"
@@ -4522,20 +4560,20 @@ msgstr ""
 "        // 就像这样的比较：\n"
 "        // `&i32`\n"
 "        // `&val`\n"
-"        // ^ 我们看到如果匹配的 `&` 被去掉，那么 `i32`\n"
+"        // ^ 我们可以看到，如果去掉匹配的 `&`，那么 `i32`\n"
 "        // 应该被赋值给 `val`。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:23
 msgid "\"Got a value via destructuring: {:?}\""
-msgstr "\"通过解构获得一个值：{:?}\""
+msgstr "\"通过解构获得的值：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:26
 msgid "// To avoid the `&`, you dereference before matching.\n"
-msgstr "// 为了避免 `&`，你可以在匹配之前解引用。\n"
+msgstr "// 为了避免 `&`，你可以在匹配前解引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:28
 msgid "\"Got a value via dereferencing: {:?}\""
-msgstr "\"通过解引用获得一个值：{:?}\""
+msgstr "\"通过解引用获得的值：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:31
 msgid ""
@@ -4554,24 +4592,24 @@ msgid ""
 "    // reference is assigned.\n"
 msgstr ""
 "// Rust 提供 `ref` 正是为了这个目的。它修改了\n"
-"    // 赋值，使得为元素创建一个引用；这个\n"
-"    // 引用被赋值。\n"
+"    // 赋值，为元素创建一个引用；\n"
+"    // 这个引用被赋值。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:41
 msgid ""
 "// Accordingly, by defining 2 values without references, references\n"
 "    // can be retrieved via `ref` and `ref mut`.\n"
 msgstr ""
-"// 相应地，通过定义两个没有引用的值，可以\n"
-"    // 通过 `ref` 和 `ref mut` 获取引用。\n"
+"// 相应地，通过定义两个没有引用的值，\n"
+"    // 可以通过 `ref` 和 `ref mut` 获取引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:46
 msgid "// Use `ref` keyword to create a reference.\n"
-msgstr "// 使用 `ref` 关键字创建一个引用。\n"
+msgstr "// 使用 `ref` 关键字创建引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:48
 msgid "\"Got a reference to a value: {:?}\""
-msgstr "\"获得一个值的引用：{:?}\""
+msgstr "\"获得了一个值的引用：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:51
 msgid "// Use `ref mut` similarly.\n"
@@ -4582,7 +4620,7 @@ msgid ""
 "// Got a reference. Gotta dereference it before we can\n"
 "            // add anything to it.\n"
 msgstr ""
-"// 获得一个引用。在我们能够\n"
+"// 获得了一个引用。在我们能够\n"
 "            // 对其进行任何添加操作之前，必须先解引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:57
@@ -4595,15 +4633,15 @@ msgstr "[ref 模式](../../../scope/borrow/ref.md)"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:3
 msgid "Similarly, a `struct` can be destructured as shown:"
-msgstr "类似地，`struct` 可以按如下方式解构："
+msgstr "同样，`struct` 可以按如下方式解构："
 
 #: src/flow_control/match/destructuring/destructure_structures.md:12
 msgid "// Try changing the values in the struct to see what happens\n"
-msgstr "// 尝试改变结构体中的值，看看会发生什么\n"
+msgstr "// 尝试更改结构体中的值，看看会发生什么\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:16
 msgid "\"First of x is 1, b = {},  y = {} \""
-msgstr "\"x 的第一个元素是 1，b = {}，y = {} \""
+msgstr "\"x 的第一个元素是 1，b = {}，y = {}\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:18
 msgid ""
@@ -4615,27 +4653,27 @@ msgstr ""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:20
 msgid "\"y is 2, i = {:?}\""
-msgstr "\"y 是 2，i = {:?}\""
+msgstr "\"y 为 2，i = {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:22
 msgid "// and you can also ignore some variables:\n"
-msgstr "// 你也可以忽略一些变量：\n"
+msgstr "// 你也可以忽略某些变量：\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:23
 msgid "\"y = {}, we don't care about x\""
-msgstr "\"y = {}，我们不关心 x\""
+msgstr "\"y = {}，我们不关心 x 的值\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:24
 msgid ""
 "// this will give an error: pattern does not mention field `x`\n"
 "        //Foo { y } => println!(\"y = {}\", y),\n"
 msgstr ""
-"// 这会产生一个错误：模式没有提到字段 `x`\n"
+"// 这会导致错误：模式中未提及字段 `x`\n"
 "        //Foo { y } => println!(\"y = {}\", y),\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:30
 msgid "// You do not need a match block to destructure structs:\n"
-msgstr "// 你不需要 match 块来解构结构体：\n"
+msgstr "// 解构结构体不一定需要 match 块：\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:32
 msgid "\"Outside: x0 = {x0:?}, y0 = {y0}\""
@@ -4643,7 +4681,7 @@ msgstr "\"外部：x0 = {x0:?}，y0 = {y0}\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:34
 msgid "// Destructuring works with nested structs as well:\n"
-msgstr "// 解构也适用于嵌套的结构体：\n"
+msgstr "// 解构也适用于嵌套结构体：\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:41
 msgid "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
@@ -4655,37 +4693,38 @@ msgstr "[结构体](../../../custom_types/structs.md)"
 
 #: src/flow_control/match/guard.md:3
 msgid "A `match` _guard_ can be added to filter the arm."
-msgstr "可以添加 `match` **守卫**来过滤分支。"
+msgstr "`match` 分支可以使用**守卫**进行额外的筛选。"
 
 #: src/flow_control/match/guard.md:14
 msgid "// ^ TODO try different values for `temperature`\n"
-msgstr "// ^ TODO 尝试不同的 `temperature` 值\n"
+msgstr "// ^ TODO：尝试为 `temperature` 赋予不同的值\n"
 
 #: src/flow_control/match/guard.md:17
 msgid "\"{}C is above 30 Celsius\""
-msgstr "\"{}摄氏度高于 30 摄氏度\""
+msgstr "\"{}°C 高于 30°C\""
 
 #: src/flow_control/match/guard.md:18
 msgid "// The `if condition` part ^ is a guard\n"
-msgstr "// `if condition` 部分 ^ 是一个守卫\n"
+msgstr "// `if condition` 部分 ^ 就是守卫\n"
 
 #: src/flow_control/match/guard.md:19
 msgid "\"{}C is equal to or below 30 Celsius\""
-msgstr "\"{}摄氏度等于或低于 30 摄氏度\""
+msgstr "\"{}°C 不高于 30°C\""
 
 #: src/flow_control/match/guard.md:21
 msgid "\"{}F is above 86 Fahrenheit\""
-msgstr "\"{}华氏度高于 86 华氏度\""
+msgstr "\"{}°F 高于 86°F\""
 
 #: src/flow_control/match/guard.md:22
 msgid "\"{}F is equal to or below 86 Fahrenheit\""
-msgstr "\"{}华氏度等于或低于 86 华氏度\""
+msgstr "\"{}°F 不高于 86°F\""
 
 #: src/flow_control/match/guard.md:27
 msgid ""
 "Note that the compiler won't take guard conditions into account when checking "
 "if all patterns are covered by the match expression."
-msgstr "注意，编译器在检查 match 表达式是否覆盖了所有模式时，不会考虑守卫条件。"
+msgstr ""
+"注意，编译器在检查 match 表达式是否涵盖了所有模式时，不会考虑守卫条件。"
 
 #: src/flow_control/match/guard.md:35
 msgid "\"Zero\""
@@ -4700,8 +4739,8 @@ msgid ""
 "// _ => unreachable!(\"Should never happen.\"),\n"
 "        // TODO ^ uncomment to fix compilation\n"
 msgstr ""
-"// _ => unreachable!(\"永远不应该发生。\"),\n"
-"        // TODO ^ 取消注释以修复编译\n"
+"// _ => unreachable!(\"不应该发生。\"),\n"
+"        // TODO ^ 取消注释以修复编译错误\n"
 
 #: src/flow_control/match/guard.md:45
 msgid "[Tuples](../../primitives/tuples.md) [Enums](../../custom_types/enum.md)"
@@ -4713,7 +4752,7 @@ msgid ""
 "variable without re-binding. `match` provides the `@` sigil for binding "
 "values to names:"
 msgstr ""
-"间接访问变量使得无法在分支中使用该变量而不重新绑定。`match` 提供了 `@` 符号用于将值绑定到名称："
+"间接访问变量时，无法在分支中使用该变量而不重新绑定。`match` 提供了 `@` 符号，用于将值绑定到名称："
 
 #: src/flow_control/match/binding.md:8
 msgid "// A function `age` which returns a `u32`.\n"
@@ -4721,11 +4760,11 @@ msgstr "// 一个返回 `u32` 的 `age` 函数。\n"
 
 #: src/flow_control/match/binding.md:14
 msgid "\"Tell me what type of person you are\""
-msgstr "\"告诉我你是什么样的人\""
+msgstr "\"告诉我你是什么类型的人\""
 
 #: src/flow_control/match/binding.md:17
 msgid "\"I haven't celebrated my first birthday yet\""
-msgstr "\"我还没有庆祝过我的第一个生日\""
+msgstr "\"我还没有过第一个生日\""
 
 #: src/flow_control/match/binding.md:18
 msgid ""
@@ -4733,36 +4772,37 @@ msgid ""
 "        // would the child be? Instead, bind to `n` for the\n"
 "        // sequence of 1 ..= 12. Now the age can be reported.\n"
 msgstr ""
-"// 可以直接 `match` 1 ..= 12，但那样孩子的年龄是多少呢？\n"
-"        // 相反，将 1 ..= 12 的序列绑定到 `n`。现在可以报告年龄了。\n"
+"// 可以直接匹配 1 ..= 12，但那样无法知道具体年龄\n"
+"        // 相反，我们将 1 ..= 12 的序列绑定到 `n`\n"
+"        // 现在就可以报告具体年龄了\n"
 
 #: src/flow_control/match/binding.md:21
 msgid "\"I'm a child of age {:?}\""
-msgstr "\"我是一个 {:?} 岁的孩子\""
+msgstr "\"我是 {:?} 岁的儿童\""
 
 #: src/flow_control/match/binding.md:22
 msgid "\"I'm a teen of age {:?}\""
-msgstr "\"我是一个 {:?} 岁的青少年\""
+msgstr "\"我是 {:?} 岁的青少年\""
 
 #: src/flow_control/match/binding.md:23
 msgid "// Nothing bound. Return the result.\n"
-msgstr "// 没有绑定。返回结果。\n"
+msgstr "// 没有绑定。直接返回结果。\n"
 
 #: src/flow_control/match/binding.md:24
 msgid "\"I'm an old person of age {:?}\""
-msgstr "\"我是一个 {:?} 岁的老年人\""
+msgstr "\"我是 {:?} 岁的老年人\""
 
 #: src/flow_control/match/binding.md:29
 msgid ""
 "You can also use binding to \"destructure\" `enum` variants, such as `Option`:"
-msgstr "你也可以使用绑定来"解构" `enum` 变体，比如 `Option`："
+msgstr "你也可以使用绑定来"解构" `enum` 变体，例如 `Option`："
 
 #: src/flow_control/match/binding.md:38
 msgid ""
 "// Got `Some` variant, match if its value, bound to `n`,\n"
 "        // is equal to 42.\n"
 msgstr ""
-"// 得到 `Some` 变体，匹配如果它的值等于 42，绑定到 `n`，\n"
+"// 获得 `Some` 变体，检查其值（绑定到 `n`）是否等于 42\n"
 
 #: src/flow_control/match/binding.md:40
 msgid "\"The Answer: {}!\""
@@ -4770,7 +4810,7 @@ msgstr "\"答案是：{}！\""
 
 #: src/flow_control/match/binding.md:41
 msgid "// Match any other number.\n"
-msgstr "// 匹配任何其他数字。\n"
+msgstr "// 匹配任何其他数字\n"
 
 #: src/flow_control/match/binding.md:42
 msgid "\"Not interesting... {}\""
@@ -4778,21 +4818,21 @@ msgstr "\"不感兴趣... {}\""
 
 #: src/flow_control/match/binding.md:43
 msgid "// Match anything else (`None` variant).\n"
-msgstr "// 匹配其他任何情况（`None` 变体）。\n"
+msgstr "// 匹配其他任何情况（`None` 变体）\n"
 
 #: src/flow_control/match/binding.md:50
 msgid ""
 "[`functions`](../../fn.md), [`enums`](../../custom_types/enum.md) and "
 "[`Option`](../../std/option.md)"
 msgstr ""
-"[`函数`](../../fn.md)，[`枚举`](../../custom_types/enum.md) 和 "
+"[`函数`](../../fn.md)、[`枚举`](../../custom_types/enum.md) 和 "
 "[`Option`](../../std/option.md)"
 
 #: src/flow_control/if_let.md:3
 msgid ""
 "For some use cases, when matching enums, `match` is awkward. For example:"
 msgstr ""
-"在某些场景中，当匹配枚举时，使用 `match` 会显得很奇怪。例如："
+"在某些情况下，使用 `match` 匹配枚举可能会显得繁琐。例如："
 
 #: src/flow_control/if_let.md:6 src/flow_control/while_let.md:7
 #: src/flow_control/while_let.md:35
@@ -4801,62 +4841,62 @@ msgstr "// 创建 `Option<i32>` 类型的 `optional`\n"
 
 #: src/flow_control/if_let.md:10
 msgid "\"This is a really long string and `{:?}`\""
-msgstr "\"这是一个非常长的字符串和 `{:?}`\""
+msgstr "\"这是一个很长的字符串，其中包含 `{:?}`\""
 
 #: src/flow_control/if_let.md:12
 msgid ""
 "// ^ Required because `match` is exhaustive. Doesn't it seem\n"
 "    // like wasted space?\n"
 msgstr ""
-"// ^ 这是必要的，因为 `match` 需要穷举。不觉得这行很多余吗？\n"
+"// ^ 这是必需的，因为 `match` 要求穷举所有情况。\n"
+"    // 是不是觉得有些浪费空间？\n"
 
 #: src/flow_control/if_let.md:18
 msgid ""
 "`if let` is cleaner for this use case and in addition allows various failure "
 "options to be specified:"
 msgstr ""
-"`if let` 对于这种场景更加简洁，而且还允许指定各种失败的选项："
+"对于这种情况，`if let` 更加简洁，而且还允许指定各种失败时的处理选项："
 
 #: src/flow_control/if_let.md:23
 msgid "// All have type `Option<i32>`\n"
-msgstr "// 全都是 `Option<i32>` 类型\n"
+msgstr "// 以下都是 `Option<i32>` 类型\n"
 
 #: src/flow_control/if_let.md:28
 msgid ""
 "// The `if let` construct reads: \"if `let` destructures `number` into\n"
 "    // `Some(i)`, evaluate the block (`{}`).\n"
 msgstr ""
-"// `if let` 结构读作：如果 `let` 将 `number` 解构成 `Some(i)`，\n"
-"    // 则执行语句块（`{}`）。\n"
+"// `if let` 结构的含义是：如果 `let` 能将 `number` 解构为\n"
+"    // `Some(i)`，则执行代码块（`{}`）。\n"
 
 #: src/flow_control/if_let.md:31 src/flow_control/if_let.md:36
 #: src/flow_control/if_let.md:46
 msgid "\"Matched {:?}!\""
-msgstr "\"匹配 {:?}！\""
+msgstr "\"匹配到 {:?}！\""
 
 #: src/flow_control/if_let.md:34
 msgid "// If you need to specify a failure, use an else:\n"
-msgstr "// 如果需要指定一个失败的情况，使用 else：\n"
+msgstr "// 如果需要指定匹配失败的情况，可以使用 else：\n"
 
 #: src/flow_control/if_let.md:38
 msgid "// Destructure failed. Change to the failure case.\n"
-msgstr "// 解构失败。切换到失败情况。\n"
+msgstr "// 解构失败。转到失败处理的情况。\n"
 
 #: src/flow_control/if_let.md:39 src/flow_control/if_let.md:50
 msgid "\"Didn't match a number. Let's go with a letter!\""
-msgstr "\"没有匹配到数字。我们用一个字母吧！\""
+msgstr "\"没有匹配到数字。那就用一个字母吧！\""
 
 #: src/flow_control/if_let.md:42
 msgid "// Provide an altered failing condition.\n"
-msgstr "// 提供一个改变的失败条件。\n"
+msgstr "// 提供一个修改后的失败条件。\n"
 
 #: src/flow_control/if_let.md:47
 msgid ""
 "// Destructure failed. Evaluate an `else if` condition to see if the\n"
 "    // alternate failure branch should be taken:\n"
 msgstr ""
-"// 解构失败。评估 `else if` 条件，看看是否应该执行\n"
-"    // 替代的失败分支：\n"
+"// 解构失败。评估 `else if` 条件，看是否应该执行替代的失败分支：\n"
 
 #: src/flow_control/if_let.md:52
 msgid "// The condition evaluated false. This branch is the default:\n"
@@ -4864,7 +4904,7 @@ msgstr "// 条件判断为假。这个分支是默认情况：\n"
 
 #: src/flow_control/if_let.md:53
 msgid "\"I don't like letters. Let's go with an emoticon :)!\""
-msgstr "\"我不喜欢字母。我们用个表情符号吧 :)！\""
+msgstr "\"我不喜欢字母。那就用个表情符号吧 :)！\""
 
 #: src/flow_control/if_let.md:58
 msgid "In the same way, `if let` can be used to match any enum value:"
@@ -4892,7 +4932,7 @@ msgid ""
 "    // So this will print nothing\n"
 msgstr ""
 "// 变量 b 不匹配 Foo::Bar\n"
-"    // 所以这里不会打印任何东西\n"
+"    // 所以这里不会打印任何内容\n"
 
 #: src/flow_control/if_let.md:82
 msgid "\"b is foobar\""
@@ -4903,7 +4943,7 @@ msgid ""
 "// Variable c matches Foo::Qux which has a value\n"
 "    // Similar to Some() in the previous example\n"
 msgstr ""
-"// 变量 c 匹配 Foo::Qux，它有一个值\n"
+"// 变量 c 匹配 Foo::Qux，它包含一个值\n"
 "    // 类似于前面例子中的 Some()\n"
 
 #: src/flow_control/if_let.md:88
@@ -4912,7 +4952,7 @@ msgstr "\"c 是 {}\""
 
 #: src/flow_control/if_let.md:91
 msgid "// Binding also works with `if let`\n"
-msgstr "// 绑定也可以用于 `if let`\n"
+msgstr "// `if let` 也可以进行绑定\n"
 
 #: src/flow_control/if_let.md:93
 msgid "\"c is one hundred\""
@@ -4926,11 +4966,11 @@ msgid ""
 "because instances of the enum cannot be equated, however `if let` will "
 "continue to work."
 msgstr ""
-"`if let` 的另一个好处是它允许我们匹配非参数化的枚举变体。即使在枚举没有实现或派生 `PartialEq` 的情况下也是如此。在这种情况下，`if Foo::Bar == a` 将无法编译，因为枚举的实例无法进行相等比较，但 `if let` 仍然可以正常工作。"
+"`if let` 的另一个优点是它允许我们匹配非参数化的枚举变体。即使在枚举没有实现或派生 `PartialEq` 的情况下也是如此。在这种情况下，`if Foo::Bar == a` 将无法编译，因为枚举的实例无法进行相等比较，但 `if let` 仍然可以正常工作。"
 
 #: src/flow_control/if_let.md:100
 msgid "Would you like a challenge? Fix the following example to use `if let`:"
-msgstr "想要一个挑战吗？修复下面的例子，使用 `if let`："
+msgstr "想要挑战一下吗？请修改以下示例，使用 `if let`："
 
 #: src/flow_control/if_let.md:103
 msgid ""
@@ -4942,14 +4982,14 @@ msgstr ""
 
 #: src/flow_control/if_let.md:112
 msgid "// ^-- this causes a compile-time error. Use `if let` instead.\n"
-msgstr "// ^-- 这会导致编译时错误。使用 `if let` 来替代。\n"
+msgstr "// ^-- 这会导致编译时错误。请改用 `if let`。\n"
 
 #: src/flow_control/if_let.md:120
 msgid ""
 "[`enum`](../custom_types/enum.md), [`Option`](../std/option.md), and the [RFC]"
 "(https://github.com/rust-lang/rfcs/pull/160)"
 msgstr ""
-"[`枚举`](../custom_types/enum.md)，[`Option`](../std/option.md)，以及 [RFC]"
+"[`枚举`](../custom_types/enum.md)、[`Option`](../std/option.md) 和 [RFC]"
 "(https://github.com/rust-lang/rfcs/pull/160)"
 
 #: src/flow_control/let_else.md:4

--- a/po/zh.po
+++ b/po/zh.po
@@ -3430,21 +3430,21 @@ msgstr ""
 
 #: src/types/cast.md:53
 msgid "// Unless it already fits, of course.\n"
-msgstr "// 当然，除非它已经适合。\n"
+msgstr "// 当然，如果已经适合的话就不需要转换。\n"
 
 #: src/types/cast.md:54
 msgid "\" 128 as a i16 is: {}\""
-msgstr "\" 128 作为 i16 是：{}\""
+msgstr "\" 128 转换为 i16 是：{}\""
 
 #: src/types/cast.md:56
 msgid ""
 "// In boundary case 128 value in 8-bit two's complement representation is "
 "-128\n"
-msgstr "// 在边界情况下，128 在 8 位二进制补码表示中是 -128\n"
+msgstr "// 边界情况：128 在 8 位二进制补码表示中为 -128\n"
 
 #: src/types/cast.md:57
 msgid "\" 128 as a i8 is : {}\""
-msgstr "\" 128 作为 i8 是：{}\""
+msgstr "\" 128 转换为 i8 是：{}\""
 
 #: src/types/cast.md:59
 msgid ""
@@ -3452,16 +3452,16 @@ msgid ""
 "    // 1000 as u8 -> 232\n"
 msgstr ""
 "// 重复上面的例子\n"
-"    // 1000 作为 u8 -> 232\n"
+"    // 1000 转换为 u8 -> 232\n"
 
 #: src/types/cast.md:62
 msgid ""
 "// and the value of 232 in 8-bit two's complement representation is -24\n"
-msgstr "// 而 232 在 8 位二进制补码表示中是 -24\n"
+msgstr "// 而 232 在 8 位二进制补码表示中为 -24\n"
 
 #: src/types/cast.md:63
 msgid "\" 232 as a i8 is : {}\""
-msgstr "\" 232 作为 i8 是：{}\""
+msgstr "\" 232 转换为 i8 是：{}\""
 
 #: src/types/cast.md:65
 msgid ""
@@ -3470,33 +3470,33 @@ msgid ""
 "    // the upper bound or is less than the lower bound, the returned value\n"
 "    // will be equal to the bound crossed.\n"
 msgstr ""
-"// 从 Rust 1.45 开始，`as` 关键字在从浮点数转换为整数时执行*饱和转换*\n"
-"    // 如果浮点值超过上界或小于下界，返回值\n"
-"    // 将等于所跨越的边界。\n"
+"// 从 Rust 1.45 开始，`as` 关键字在浮点数转整数时执行*饱和转换*\n"
+"    // 如果浮点值超出上界或低于下界，返回值\n"
+"    // 将等于所越过的边界值。\n"
 
 #: src/types/cast.md:70
 msgid "// 300.0 as u8 is 255\n"
-msgstr "// 300.0 作为 u8 是 255\n"
+msgstr "// 300.0 转换为 u8 是 255\n"
 
 #: src/types/cast.md:71 src/types/cast.md:82
 msgid "\" 300.0 as u8 is : {}\""
-msgstr "\" 300.0 作为 u8 是：{}\""
+msgstr "\" 300.0 转换为 u8 是：{}\""
 
 #: src/types/cast.md:72
 msgid "// -100.0 as u8 is 0\n"
-msgstr "// -100.0 作为 u8 是 0\n"
+msgstr "// -100.0 转换为 u8 是 0\n"
 
 #: src/types/cast.md:73 src/types/cast.md:84
 msgid "\"-100.0 as u8 is : {}\""
-msgstr "\"-100.0 作为 u8 是：{}\""
+msgstr "\"-100.0 转换为 u8 是：{}\""
 
 #: src/types/cast.md:74 src/types/cast.md:85
 msgid "// nan as u8 is 0\n"
-msgstr "// nan 作为 u8 是 0\n"
+msgstr "// NaN 转换为 u8 是 0\n"
 
 #: src/types/cast.md:75 src/types/cast.md:86
 msgid "\"   nan as u8 is : {}\""
-msgstr "\"   nan 作为 u8 是：{}\""
+msgstr "\"   NaN 转换为 u8 是：{}\""
 
 #: src/types/cast.md:77
 msgid ""
@@ -3504,17 +3504,16 @@ msgid ""
 "    // with unsafe methods, however the results might overflow and\n"
 "    // return **unsound values**. Use these methods wisely:\n"
 msgstr ""
-"// 这种行为会产生小的运行时开销，可以通过\n"
-"    // 不安全的方法来避免，但是结果可能会溢出并\n"
-"    // 返回**不健全的值**。请谨慎使用这些方法：\n"
+"// 这种行为会产生少量运行时开销，可以通过不安全方法避免，\n"
+"    // 但结果可能溢出并返回**不可靠的值**。请谨慎使用这些方法：\n"
 
 #: src/types/cast.md:81
 msgid "// 300.0 as u8 is 44\n"
-msgstr "// 300.0 作为 u8 是 44\n"
+msgstr "// 300.0 转换为 u8 是 44\n"
 
 #: src/types/cast.md:83
 msgid "// -100.0 as u8 is 156\n"
-msgstr "// -100.0 作为 u8 是 156\n"
+msgstr "// -100.0 转换为 u8 是 156\n"
 
 #: src/types/literals.md:3
 msgid ""
@@ -3522,7 +3521,7 @@ msgid ""
 "example, to specify that the literal `42` should have the type `i32`, write "
 "`42i32`."
 msgstr ""
-"数字字面值可以通过添加类型作为后缀来进行类型标注。例如，要指定字面值 `42` 应该具有 `i32` 类型，可以写成 `42i32`。"
+"数字字面值可以通过添加类型后缀进行类型标注。例如，要指定字面值 `42` 的类型为 `i32`，可以写成 `42i32`。"
 
 #: src/types/literals.md:6
 msgid ""
@@ -3530,46 +3529,46 @@ msgid ""
 "no constraint exists, the compiler will use `i32` for integers, and `f64` for "
 "floating-point numbers."
 msgstr ""
-"无后缀数字字面值的类型将取决于它们的使用方式。如果没有约束，编译器将对整数使用 `i32`，对浮点数使用 `f64`。"
+"无后缀数字字面值的类型取决于其使用方式。如果没有约束，编译器将对整数使用 `i32`，对浮点数使用 `f64`。"
 
 #: src/types/literals.md:12
 msgid "// Suffixed literals, their types are known at initialization\n"
-msgstr "// 带后缀的字面值，它们的类型在初始化时就已知\n"
+msgstr "// 带后缀的字面值，其类型在初始化时确定\n"
 
 #: src/types/literals.md:17
 msgid "// Unsuffixed literals, their types depend on how they are used\n"
-msgstr "// 无后缀的字面值，它们的类型取决于使用方式\n"
+msgstr "// 无后缀的字面值，其类型取决于使用方式\n"
 
 #: src/types/literals.md:21
 msgid "// `size_of_val` returns the size of a variable in bytes\n"
-msgstr "// `size_of_val` 返回变量的大小（以字节为单位）\n"
+msgstr "// `size_of_val` 返回变量的字节大小\n"
 
 #: src/types/literals.md:22
 msgid "\"size of `x` in bytes: {}\""
-msgstr "\"x 的大小（字节）：{}\""
+msgstr "\"`x` 的字节大小：{}\""
 
 #: src/types/literals.md:23
 msgid "\"size of `y` in bytes: {}\""
-msgstr "\"y 的大小（字节）：{}\""
+msgstr "\"`y` 的字节大小：{}\""
 
 #: src/types/literals.md:24
 msgid "\"size of `z` in bytes: {}\""
-msgstr "\"z 的大小（字节）：{}\""
+msgstr "\"`z` 的字节大小：{}\""
 
 #: src/types/literals.md:25
 msgid "\"size of `i` in bytes: {}\""
-msgstr "\"i 的大小（字节）：{}\""
+msgstr "\"`i` 的字节大小：{}\""
 
 #: src/types/literals.md:26
 msgid "\"size of `f` in bytes: {}\""
-msgstr "\"f 的大小（字节）：{}\""
+msgstr "\"`f` 的字节大小：{}\""
 
 #: src/types/literals.md:30
 msgid ""
 "There are some concepts used in the previous code that haven't been explained "
 "yet, here's a brief explanation for the impatient readers:"
 msgstr ""
-"上面的代码中使用了一些尚未解释的概念，这里为急于了解的读者提供一个简短的解释："
+"前面的代码中使用了一些尚未解释的概念。为了满足迫不及待的读者，这里简要说明如下："
 
 #: src/types/literals.md:33
 msgid ""
@@ -3579,7 +3578,7 @@ msgid ""
 "is defined in the `std` _crate_. For more details, see [modules](../mod.md) "
 "and [crates](../crates.md)."
 msgstr ""
-"`std::mem::size_of_val` 是一个函数，但使用其**完整路径**调用。代码可以分割成称为**模块**的逻辑单元。在这种情况下，`size_of_val` 函数定义在 `mem` 模块中，而 `mem` 模块定义在 `std` *crate* 中。更多详情，请参见[模块](../mod.md)和[crate](../crates.md)。"
+"`std::mem::size_of_val` 是一个函数，这里使用了它的"完整路径"来调用。代码可以被划分为称为"模块"的逻辑单元。在这个例子中，`size_of_val` 函数定义在 `mem` 模块中，而 `mem` 模块则定义在 `std` crate 中。更多详情请参阅[模块](../mod.md)和[crate](../crates.md)。"
 
 #: src/types/inference.md:3
 msgid ""
@@ -3588,43 +3587,44 @@ msgid ""
 "the variable is used afterwards to infer its type. Here's an advanced example "
 "of type inference:"
 msgstr ""
-"类型推断引擎非常智能。它不仅在初始化期间查看值表达式的类型，还会查看变量后续如何使用来推断其类型。以下是一个高级的类型推断示例："
+"类型推断引擎相当智能。它不仅在初始化时分析值表达式的类型，还会根据变量后续的使用方式来推断其类型。下面是一个类型推断的高级示例："
 
 #: src/types/inference.md:10
 msgid ""
 "// Because of the annotation, the compiler knows that `elem` has type u8.\n"
 msgstr ""
-"// 由于注解，编译器知道 `elem` 的类型是 u8。\n"
+"// 通过类型注解，编译器得知 `elem` 的类型为 u8 \n"
 
 #: src/types/inference.md:13
 msgid "// Create an empty vector (a growable array).\n"
-msgstr "// 创建一个空向量（可增长的数组）。\n"
+msgstr "// 创建一个空向量（可增长的数组）\n"
 
 #: src/types/inference.md:15
 msgid ""
 "// At this point the compiler doesn't know the exact type of `vec`, it\n"
 "    // just knows that it's a vector of something (`Vec<_>`).\n"
 msgstr ""
-"// 在这一点上，编译器不知道 `vec` 的确切类型，\n"
-"    // 它只知道这是一个某种类型的向量（`Vec<_>`）。\n"
+"// 此时编译器还不知道 `vec` 的具体类型，\n"
+"    // 只知道它是某种类型的向量（`Vec<_>`）。\n"
 
 #: src/types/inference.md:18
 msgid "// Insert `elem` in the vector.\n"
-msgstr "// 将 `elem` 插入向量。\n"
+msgstr "// 将 `elem` 插入向量中\n"
 
 #: src/types/inference.md:20
 msgid ""
 "// Aha! Now the compiler knows that `vec` is a vector of `u8`s (`Vec<u8>`)\n"
 "    // TODO ^ Try commenting out the `vec.push(elem)` line\n"
 msgstr ""
-"// 啊哈！现在编译器知道 `vec` 是一个 `u8` 类型的向量（`Vec<u8>`）\n"
+"// 啊哈！现在编译器知道 `vec` 是 `u8` 类型的向量（`Vec<u8>`）\n"
 "    // TODO ^ 尝试注释掉 `vec.push(elem)` 这一行\n"
 
 #: src/types/inference.md:27
 msgid ""
 "No type annotation of variables was needed, the compiler is happy and so is "
 "the programmer!"
-msgstr "不需要变量的类型标注，编译器很开心，程序员也很开心！"
+msgstr ""
+"无需为变量添加类型注解，编译器和程序员都很满意！"
 
 #: src/types/alias.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -15014,7 +15014,7 @@ msgid ""
 "Rust is a programming language that cares a lot about correctness and it "
 "includes support for writing software tests within the language itself."
 msgstr ""
-"Rust 是一种非常注重正确性的编程语言，它包含了在语言本身中编写软件测试的支持。"
+"Rust 是一种非常注重正确性的编程语言，它支持在语言本身内编写软件测试。"
 
 #: src/testing.md:6
 msgid "Testing comes in three styles:"
@@ -15038,7 +15038,7 @@ msgstr "Rust 还支持为测试指定额外的依赖项："
 
 #: src/testing.md:14
 msgid "[Dev-dependencies](testing/dev_dependencies.md)"
-msgstr "[开发依赖](testing/dev_dependencies.md)"
+msgstr "[开发依赖（dev-dependencies）](testing/dev_dependencies.md)"
 
 #: src/testing.md:18
 msgid ""
@@ -15076,7 +15076,7 @@ msgid ""
 "Tests fail when something in the test function [panics](../std/panic.md). "
 "There are some helper [macros](../macros.md):"
 msgstr ""
-"当测试函数中的某些内容[panic](../std/panic.md)时，测试就会失败。有一些辅助[宏](../macros.md)："
+"当测试函数中的某些内容[panic](../std/panic.md)时，测试就会失败。这是一些辅助[宏](../macros.md)："
 
 #: src/testing/unit_testing.md:14
 msgid "`assert!(expression)` - panics if expression evaluates to `false`."
@@ -15100,7 +15100,7 @@ msgstr ""
 msgid ""
 "// Note this useful idiom: importing names from outer (for mod tests) scope.\n"
 msgstr ""
-"// 注意这个有用的习惯用法：从外部（对于 mod tests）作用域导入名称。\n"
+"// 注意这个惯用法：从外部（对于 mod tests 而言）作用域导入所有可用项名称。\n"
 
 #: src/testing/unit_testing.md:42
 msgid ""
@@ -15124,7 +15124,7 @@ msgid ""
 "your unit tests can return `Result<()>`, which lets you use `?` in them! This "
 "can make them much more concise."
 msgstr ""
-"之前的单元测试示例都没有返回类型。但在 Rust 2018 中，你的单元测试可以返回 `Result<()>`，这让你可以在其中使用 `?`！这可以使它们变得更加简洁。"
+"之前的单元测试示例都没有返回类型。但在 Rust 2018 中，单元测试可以返回 `Result<()>`，这让你可以在其中使用 `?`！这可以使它们变得更加简洁。"
 
 #: src/testing/unit_testing.md:83
 msgid "\"negative floats don't have square roots\""
@@ -15136,7 +15136,7 @@ msgid ""
 "error-handling-and-panics/question-mark-in-main-and-tests.html) for more "
 "details."
 msgstr ""
-"更多详情请参见[《版本指南》](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)。"
+"更多详情可参考[《版本指南》](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)。"
 
 #: src/testing/unit_testing.md:102
 msgid "Testing panics"
@@ -15149,15 +15149,15 @@ msgid ""
 "`expected = ` with the text of the panic message. If your function can panic "
 "in multiple ways, it helps make sure your test is testing the correct panic."
 msgstr ""
-"要检查在某些情况下应该 panic 的函数，请使用 `#[should_panic]` 属性。这个属性接受可选参数 `expected = `，其中包含 panic 消息的文本。如果你的函数可能以多种方式 panic，这有助于确保你的测试正在测试正确的 panic。"
+"要测试在某些情况下应该 panic 的函数，可以使用 `#[should_panic]` 属性。这个属性接受可选参数 `expected = `，其中包含 panic 消息的文本。如果你的函数可能以多种方式 panic，这有助于确保正在测试对应的 panic。"
 
 #: src/testing/unit_testing.md:112 src/testing/doc_testing.md:45
 msgid "\"Divide-by-zero error\""
-msgstr "\"除以零错误\""
+msgstr "\"Divide-by-zero error\""
 
 #: src/testing/unit_testing.md:114 src/testing/unit_testing.md:135
 msgid "\"Divide result is zero\""
-msgstr "\"除法结果为零\""
+msgstr "\"Divide result is zero\""
 
 #: src/testing/unit_testing.md:142
 msgid "Running these tests gives us:"
@@ -15199,7 +15199,7 @@ msgid ""
 "takes care about correctness, so these code blocks are compiled and used as "
 "documentation tests."
 msgstr ""
-"Rust 项目的主要文档方式是通过注释源代码。文档注释使用 [CommonMark Markdown 规范](https://commonmark.org/)编写，并支持其中的代码块。Rust 注重正确性，因此这些代码块会被编译并用作文档测试。"
+"为 Rust 项目的编写文档的主要方式是通过在源代码中添加注释。文档注释使用 [CommonMark Markdown 规范](https://commonmark.org/)编写，并支持其中的代码块。Rust 注重正确性，因此这些代码块会被编译并用作文档测试。"
 
 #: src/testing/doc_testing.md:10
 msgid ""
@@ -15253,7 +15253,7 @@ msgstr ""
 "///\n"
 "/// 下面的函数用于除法运算。\n"
 "///\n"
-"/// # 示例\n"
+"/// # Examples\n"
 "///\n"
 "/// ```\n"
 "/// let result = doccomments::div(10, 2);\n"
@@ -15278,7 +15278,7 @@ msgstr ""
 
 #: src/testing/doc_testing.md:71
 msgid "Motivation behind documentation tests"
-msgstr "文档测试的动机"
+msgstr "文档测试的目的"
 
 #: src/testing/doc_testing.md:73
 msgid ""
@@ -15292,7 +15292,7 @@ msgid ""
 "hide it and `unwrap` it in hidden `main`. Sounds complicated? Here's an "
 "example:"
 msgstr ""
-"文档测试的主要目的是作为练习功能的示例，这是最重要的[指南](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark)之一。它允许将文档中的示例作为完整的代码片段使用。但是使用 `?` 会导致编译失败，因为 `main` 返回 `unit`。隐藏文档中的某些源代码行可以解决这个问题：可以编写 `fn try_main() -> Result<(), ErrorType>`，隐藏它并在隐藏的 `main` 中 `unwrap` 它。听起来很复杂？这里有一个例子："
+"文档测试的主要目的是作为如何使用的示例，这是最重要的[指导原则](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark)之一。它允许将文档中的示例作为完整的代码片段使用。但是使用 `?` 会导致编译失败，因为 `main` 返回 `unit`。隐藏文档中的某些源代码行可以解决这个问题：可以编写 `fn try_main() -> Result<(), ErrorType>`，隐藏并在 `main` 中 `unwrap`。听起来很复杂？这里有一个例子："
 
 #: src/testing/doc_testing.md:82
 msgid ""
@@ -15311,22 +15311,37 @@ msgid ""
 "/// # }\n"
 "/// ```\n"
 msgstr ""
+"/// 在文档测试中使用隐藏的 `try_main`。\n"
+"///\n"
+"/// ```\n"
+"/// # // 以 `#` 符号开头的行是隐藏的，但它们仍然可以编译！\n"
+"/// # fn try_main() -> Result<(), String> { // 文档中显示的包装函数体的行\n"
+"/// let res = doccomments::try_div(10, 2)?;\n"
+"/// # Ok(()) // 从 try_main 返回\n"
+"/// # }\n"
+"/// # fn main() { // 开始将要 unwrap() 的 main\n"
+"/// #    try_main().unwrap(); // 调用 try_main 并 unwrap\n"
+"/// #                         // 这样在出错时测试会 panic\n"
+"/// # }\n"
+"/// ```\n"
 
 #: src/testing/doc_testing.md:97
 msgid "\"Divide-by-zero\""
-msgstr ""
+msgstr "\"除以零\""
 
 #: src/testing/doc_testing.md:106
 msgid ""
 "[RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-"
 "conventions.md) on documentation style"
 msgstr ""
+"关于文档风格的 [RFC505](https://github.com/rust-lang/rfcs/blob/master/text/0505-api-comment-conventions.md)"
 
 #: src/testing/doc_testing.md:107
 msgid ""
 "[API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/"
 "documentation.html) on documentation guidelines"
 msgstr ""
+"关于文档指南的 [API 指南](https://rust-lang-nursery.github.io/api-guidelines/documentation.html)"
 
 #: src/testing/integration_testing.md:3
 msgid ""
@@ -15336,26 +15351,27 @@ msgid ""
 "would. Their purpose is to test that many parts of your library work "
 "correctly together."
 msgstr ""
+"[单元测试](unit_testing.md)一次单独测试一个模块：它们很小，可以测试私有代码。集成测试位于 crate 外部，并且仅使用公开接口，就像其他使用该 crate 的代码一样。集成测试的目的是测试库的各个部分是否能正确地协同工作。"
 
 #: src/testing/integration_testing.md:8
 msgid "Cargo looks for integration tests in `tests` directory next to `src`."
-msgstr ""
+msgstr "Cargo 在 `src` 目录旁边的 `tests` 目录中寻找集成测试。"
 
 #: src/testing/integration_testing.md:10 src/testing/dev_dependencies.md:17
 msgid "File `src/lib.rs`:"
-msgstr ""
+msgstr "文件 `src/lib.rs`："
 
 #: src/testing/integration_testing.md:13
 msgid "// Define this in a crate called `adder`.\n"
-msgstr ""
+msgstr "// 在一个名为 `adder` 的 crate 中定义这个。\n"
 
 #: src/testing/integration_testing.md:19
 msgid "File with test: `tests/integration_test.rs`:"
-msgstr ""
+msgstr "测试文件：`tests/integration_test.rs`："
 
 #: src/testing/integration_testing.md:28
 msgid "Running tests with `cargo test` command:"
-msgstr ""
+msgstr "使用 `cargo test` 命令运行测试："
 
 #: src/testing/integration_testing.md:50
 msgid ""
@@ -15363,28 +15379,31 @@ msgid ""
 "crate. In order to share some code between integration tests we can make a "
 "module with public functions, importing and using it within tests."
 msgstr ""
+"`tests` 目录中的每个 Rust 源文件都被编译为一个单独的 crate。为了在集成测试之间共享一些代码，我们可以创建一个带有公共函数的模块，然后在测试中导入和使用它。"
 
 #: src/testing/integration_testing.md:54
 msgid "File `tests/common/mod.rs`:"
-msgstr ""
+msgstr "文件 `tests/common/mod.rs`："
 
 #: src/testing/integration_testing.md:58
 msgid ""
 "// some setup code, like creating required files/directories, starting\n"
 "    // servers, etc.\n"
 msgstr ""
+"// 一些设置代码，比如创建所需的文件/目录，启动\n"
+"    // 服务器等。\n"
 
 #: src/testing/integration_testing.md:63
 msgid "File with test: `tests/integration_test.rs`"
-msgstr ""
+msgstr "测试文件：`tests/integration_test.rs`"
 
 #: src/testing/integration_testing.md:66
 msgid "// importing common module.\n"
-msgstr ""
+msgstr "// 导入 common 模块。\n"
 
 #: src/testing/integration_testing.md:71
 msgid "// using common code.\n"
-msgstr ""
+msgstr "// 使用公共代码。\n"
 
 #: src/testing/integration_testing.md:77
 msgid ""
@@ -15392,10 +15411,11 @@ msgid ""
 "because the test runner will treat the file as a test crate and try to run "
 "tests inside it."
 msgstr ""
+"将模块创建为 `tests/common.rs` 也可以，但不推荐这样做，因为测试执行时会将该文件视为测试 crate 并尝试运行其中的测试。"
 
 #: src/testing/dev_dependencies.md:1
 msgid "Development dependencies"
-msgstr ""
+msgstr "开发依赖"
 
 #: src/testing/dev_dependencies.md:3
 msgid ""
@@ -15404,6 +15424,7 @@ msgid ""
 "dependencies]` section. These dependencies are not propagated to other "
 "packages which depend on this package."
 msgstr ""
+"有时候我们需要仅用于测试（或示例、基准测试）的依赖项。这些依赖项被添加到 `Cargo.toml` 的 `[dev-dependencies]` 部分。这些依赖项不会被传播到依赖于这个包的其他包。"
 
 #: src/testing/dev_dependencies.md:8
 msgid ""
@@ -15412,6 +15433,8 @@ msgid ""
 "`assert_eq!` and `assert_ne!` macros, to provide colorful diff.  \n"
 "File `Cargo.toml`:"
 msgstr ""
+"例如 [`pretty_assertions`](https://docs.rs/pretty_assertions/1.0.0/pretty_assertions/index.html)，它扩展了标准的 `assert_eq!` 和 `assert_ne!` 宏，提供彩色差异。  \n"
+"文件 `Cargo.toml`："
 
 #: src/testing/dev_dependencies.md:11
 msgid ""
@@ -15421,16 +15444,22 @@ msgid ""
 "pretty_assertions = \"1\"\n"
 "```"
 msgstr ""
+"```toml\n"
+"# 标准的 crate 数据省略\n"
+"[dev-dependencies]\n"
+"pretty_assertions = \"1\"\n"
+"```"
 
 #: src/testing/dev_dependencies.md:27
 msgid "// crate for test-only use. Cannot be used in non-test code.\n"
-msgstr ""
+msgstr "// 仅用于测试的 crate。不能在非测试代码中使用。\n"
 
 #: src/testing/dev_dependencies.md:37
 msgid ""
 "[Cargo](http://doc.crates.io/specifying-dependencies.html) docs on specifying "
 "dependencies."
 msgstr ""
+"[Cargo](http://doc.crates.io/specifying-dependencies.html) 文档中关于指定依赖项的内容。"
 
 #: src/unsafe.md:3
 msgid ""
@@ -15441,28 +15470,30 @@ msgid ""
 "put in place by the compiler; specifically, there are four primary things "
 "that unsafe is used for:"
 msgstr ""
+"作为本节的介绍，借用[官方文档](https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html)的话说，\"应该尽量减少代码库中不安全代码的数量。\" 记住这一点，让我们开始吧！Rust 中的不安全标注用于绕过编译器设置的保护；具体来说，不安全主要用于以下四个方面："
 
 #: src/unsafe.md:9
 msgid "dereferencing raw pointers"
-msgstr ""
+msgstr "解引用裸指针"
 
 #: src/unsafe.md:10
 msgid ""
 "calling functions or methods which are `unsafe` (including calling a function "
 "over FFI, see [a previous chapter](std_misc/ffi.md) of the book)"
 msgstr ""
+"调用 `unsafe` 的函数或方法（包括通过 FFI 调用函数，参见本书的[前面的一章](std_misc/ffi.md)）"
 
 #: src/unsafe.md:12
 msgid "accessing or modifying static mutable variables"
-msgstr ""
+msgstr "访问或修改静态可变变量"
 
 #: src/unsafe.md:13
 msgid "implementing unsafe traits"
-msgstr ""
+msgstr "实现不安全特征"
 
 #: src/unsafe.md:15
 msgid "Raw Pointers"
-msgstr ""
+msgstr "裸指针"
 
 #: src/unsafe.md:16
 msgid ""
@@ -15471,10 +15502,11 @@ msgid ""
 "borrow checker. Dereferencing a raw pointer can only be done through an "
 "unsafe block."
 msgstr ""
+"裸指针 `*` 和引用 `&T` 的功能类似，但引用总是安全的，因为借用检查器保证它们指向有效数据。解引用裸指针只能在不安全块中进行。"
 
 #: src/unsafe.md:31
 msgid "Calling Unsafe Functions"
-msgstr ""
+msgstr "调用不安全函数"
 
 #: src/unsafe.md:32
 msgid ""
@@ -15484,6 +15516,7 @@ msgid ""
 "fn.from_raw_parts.html) which will create a slice given a pointer to the "
 "first element and a length."
 msgstr ""
+"一些函数可以被声明为 `unsafe`，这意味着确保正确性是程序员的责任，而不再是编译器的责任。一个例子是 [`std::slice::from_raw_parts`](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html)，它会根据指向第一个元素的指针和长度创建一个切片。"
 
 #: src/unsafe.md:54
 msgid ""
@@ -15492,6 +15525,7 @@ msgid ""
 "to is of the correct type. If these invariants aren't upheld then the "
 "program's behaviour is undefined and there is no knowing what will happen."
 msgstr ""
+"对于 `slice::from_raw_parts`，**必须**遵守的假设之一是传入的指针指向有效的内存，并且指向的内存类型正确。如果这些假设没有被遵守，那么程序的行为是未定义的，无法预知会发生什么。"
 
 #: src/unsafe/asm.md:3
 msgid ""
@@ -15502,40 +15536,42 @@ msgid ""
 "level hardware primitives, e.g. in kernel code, may also demand this "
 "functionality."
 msgstr ""
+"Rust 通过 `asm!` 宏提供了内联汇编支持。它可以用于在编译器生成的汇编输出中嵌入手写的汇编代码。通常这不是必需的，但在需要特定的性能或时序且无法通过其他方式实现时可能会用到。访问低级硬件原语，例如在内核代码中，也可能需要这个功能。"
 
 #: src/unsafe/asm.md:8
 msgid ""
 "**Note**: the examples here are given in x86/x86-64 assembly, but other "
 "architectures are also supported."
 msgstr ""
+"**注意**：这里的例子使用的是 x86/x86-64 汇编，但也支持其他架构。"
 
 #: src/unsafe/asm.md:10
 msgid "Inline assembly is currently supported on the following architectures:"
-msgstr ""
+msgstr "内联汇编目前支持以下架构："
 
 #: src/unsafe/asm.md:11
 msgid "x86 and x86-64"
-msgstr ""
+msgstr "x86 和 x86-64"
 
 #: src/unsafe/asm.md:12
 msgid "ARM"
-msgstr ""
+msgstr "ARM"
 
 #: src/unsafe/asm.md:13
 msgid "AArch64"
-msgstr ""
+msgstr "AArch64"
 
 #: src/unsafe/asm.md:14
 msgid "RISC-V"
-msgstr ""
+msgstr "RISC-V"
 
 #: src/unsafe/asm.md:16
 msgid "Basic usage"
-msgstr ""
+msgstr "基本用法"
 
 #: src/unsafe/asm.md:18
 msgid "Let us start with the simplest possible example:"
-msgstr ""
+msgstr "让我们从最简单的例子开始："
 
 #: src/unsafe/asm.md:21 src/unsafe/asm.md:41 src/unsafe/asm.md:68
 #: src/unsafe/asm.md:106 src/unsafe/asm.md:123 src/unsafe/asm.md:148
@@ -15544,11 +15580,11 @@ msgstr ""
 #: src/unsafe/asm.md:329 src/unsafe/asm.md:367 src/unsafe/asm.md:394
 #: src/unsafe/asm.md:418 src/unsafe/asm.md:456
 msgid "\"x86_64\""
-msgstr ""
+msgstr "\"x86_64\""
 
 #: src/unsafe/asm.md:25
 msgid "\"nop\""
-msgstr ""
+msgstr "\"nop\""
 
 #: src/unsafe/asm.md:30
 msgid ""
@@ -15558,20 +15594,22 @@ msgid ""
 "invariants. The instructions to be inserted are listed in the first argument "
 "of the `asm!` macro as a string literal."
 msgstr ""
+"这将在编译器生成的汇编中插入一条 NOP（无操作）指令。注意，所有 `asm!` 调用都必须在 `unsafe` 块内，因为它们可能插入任意指令并破坏各种不变量。要插入的指令作为字符串字面量列在 `asm!` 宏的第一个参数中。"
 
 #: src/unsafe/asm.md:35
 msgid "Inputs and outputs"
-msgstr ""
+msgstr "输入和输出"
 
 #: src/unsafe/asm.md:37
 msgid ""
 "Now inserting an instruction that does nothing is rather boring. Let us do "
 "something that actually acts on data:"
 msgstr ""
+"现在插入一个什么都不做的指令相当无聊。让我们做一些实际操作数据的事情："
 
 #: src/unsafe/asm.md:46
 msgid "\"mov {}, 5\""
-msgstr ""
+msgstr "\"mov {}, 5\""
 
 #: src/unsafe/asm.md:52
 msgid ""
@@ -15588,18 +15626,19 @@ msgid ""
 "into the template and will read the variable from there after the inline "
 "assembly finishes executing."
 msgstr ""
+"这将把值 `5` 写入 `u64` 变量 `x`。你可以看到，我们用来指定指令的字符串字面量实际上是一个模板字符串。它遵循与 Rust [格式化字符串](https://doc.rust-lang.org/std/fmt/#syntax)相同的规则。然而，插入到模板中的参数看起来可能与你熟悉的有些不同。首先，我们需要指定变量是内联汇编的输入还是输出。在这种情况下，它是一个输出。我们通过写 `out` 来声明这一点。我们还需要指定汇编期望变量在什么类型的寄存器中。在这种情况下，我们通过指定 `reg` 将其放在任意通用寄存器中。编译器将选择一个适当的寄存器插入到模板中，并在内联汇编执行完成后从那里读取变量。"
 
 #: src/unsafe/asm.md:65
 msgid "Let us see another example that also uses an input:"
-msgstr ""
+msgstr "让我们看另一个也使用输入的例子："
 
 #: src/unsafe/asm.md:75
 msgid "\"mov {0}, {1}\""
-msgstr ""
+msgstr "\"mov {0}, {1}\""
 
 #: src/unsafe/asm.md:76 src/unsafe/asm.md:111 src/unsafe/asm.md:129
 msgid "\"add {0}, 5\""
-msgstr ""
+msgstr "\"add {0}, 5\""
 
 #: src/unsafe/asm.md:85
 msgid ""
@@ -15607,10 +15646,11 @@ msgid ""
 "variable `o`. The particular way this assembly does this is first copying the "
 "value from `i` to the output, and then adding `5` to it."
 msgstr ""
+"这将把 `5` 加到变量 `i` 的输入上，并将结果写入变量 `o`。这段汇编的具体做法是先将 `i` 的值复制到输出，然后加上 `5`。"
 
 #: src/unsafe/asm.md:89
 msgid "The example shows a few things:"
-msgstr ""
+msgstr "这个例子展示了几点："
 
 #: src/unsafe/asm.md:91
 msgid ""
@@ -15619,11 +15659,13 @@ msgid ""
 "joined together with newlines between them. This makes it easy to format "
 "assembly code."
 msgstr ""
+"首先，我们可以看到 `asm!` 允许多个模板字符串参数；每个参数都被视为单独的一行汇编代码，就好像它们都用换行符连接在一起。这使得格式化汇编代码变得容易。"
 
 #: src/unsafe/asm.md:96
 msgid ""
 "Second, we can see that inputs are declared by writing `in` instead of `out`."
 msgstr ""
+"其次，我们可以看到输入是通过写 `in` 而不是 `out` 来声明的。"
 
 #: src/unsafe/asm.md:98
 msgid ""
@@ -15633,10 +15675,11 @@ msgid ""
 "using this facility is generally recommended, as it improves readability, and "
 "allows reordering instructions without changing the argument order."
 msgstr ""
+"第三，我们可以看到我们可以指定参数编号或名称，就像在任何格式字符串中一样。对于内联汇编模板，这特别有用，因为参数经常被多次使用。对于更复杂的内联汇编，通常建议使用这种方式，因为它提高了可读性，并允许在不改变参数顺序的情况下重新排序指令。"
 
 #: src/unsafe/asm.md:103
 msgid "We can further refine the above example to avoid the `mov` instruction:"
-msgstr ""
+msgstr "我们可以进一步优化上面的例子以避免 `mov` 指令："
 
 #: src/unsafe/asm.md:117
 msgid ""
@@ -15644,16 +15687,18 @@ msgid ""
 "output. This is different from specifying an input and output separately in "
 "that it is guaranteed to assign both to the same register."
 msgstr ""
+"我们可以看到 `inout` 用于指定既是输入又是输出的参数。这与分别指定输入和输出不同，它保证将两者分配到同一个寄存器。"
 
 #: src/unsafe/asm.md:120
 msgid ""
 "It is also possible to specify different variables for the input and output "
 "parts of an `inout` operand:"
 msgstr ""
+"也可以为 `inout` 操作数的输入和输出部分指定不同的变量："
 
 #: src/unsafe/asm.md:135
 msgid "Late output operands"
-msgstr ""
+msgstr "延迟输出操作数"
 
 #: src/unsafe/asm.md:137
 msgid ""
@@ -15666,20 +15711,22 @@ msgid ""
 "output that is written only after all inputs have been consumed. There is "
 "also an `inlateout` variant of this specifier."
 msgstr ""
+"Rust 编译器在分配操作数时比较保守。它假设 `out` 可以在任何时候被写入，因此不能与任何其他参数共享其位置。然而，为了保证最佳性能，使用尽可能少的寄存器很重要，这样它们就不必在内联汇编块周围保存和重新加载。为了实现这一点，Rust 提供了一个 `lateout` 说明符。这可以用于任何只在所有输入被消耗后才写入的输出。这个说明符还有一个 `inlateout` 变体。"
 
 #: src/unsafe/asm.md:145
 msgid ""
 "Here is an example where `inlateout` _cannot_ be used in `release` mode or "
 "other optimized cases:"
 msgstr ""
+"这里有一个例子，在 `release` 模式或其他优化情况下 _不能_ 使用 `inlateout`："
 
 #: src/unsafe/asm.md:156 src/unsafe/asm.md:180 src/unsafe/asm.md:463
 msgid "\"add {0}, {1}\""
-msgstr ""
+msgstr "\"add {0}, {1}\""
 
 #: src/unsafe/asm.md:157
 msgid "\"add {0}, {2}\""
-msgstr ""
+msgstr "\"add {0}, {2}\""
 
 #: src/unsafe/asm.md:167
 msgid ""
@@ -15689,6 +15736,7 @@ msgid ""
 "`inlateout(reg) a` can instead lead to the final value `a = 16`, causing the "
 "assertion to fail."
 msgstr ""
+"在未优化的情况下（例如 `Debug` 模式），在上面的例子中将 `inout(reg) a` 替换为 `inlateout(reg) a` 可以继续给出预期的结果。然而，在 `release` 模式或其他优化情况下，使用 `inlateout(reg) a` 可能会导致最终值 `a = 16`，使断言失败。"
 
 #: src/unsafe/asm.md:169
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -3862,7 +3862,7 @@ msgstr "\"    3 \""
 
 #: src/expression.md:3
 msgid "A Rust program is (mostly) made up of a series of statements:"
-msgstr ""
+msgstr "Rust 程序（大部分）由一系列语句组成:"
 
 #: src/expression.md:7
 msgid ""
@@ -3870,20 +3870,23 @@ msgid ""
 "    // statement\n"
 "    // statement\n"
 msgstr ""
+"// 语句\n"
+"    // 语句\n"
+"    // 语句\n"
 
 #: src/expression.md:13
 msgid ""
 "There are a few kinds of statements in Rust. The most common two are "
 "declaring a variable binding, and using a `;` with an expression:"
-msgstr ""
+msgstr "Rust 中有几种语句。最常见的两种是声明变量绑定，以及在表达式后使用 `;`:"
 
 #: src/expression.md:18
 msgid "// variable binding\n"
-msgstr ""
+msgstr "// 变量绑定\n"
 
 #: src/expression.md:21
 msgid "// expression;\n"
-msgstr ""
+msgstr "// 表达式;\n"
 
 #: src/expression.md:28
 msgid ""
@@ -3891,34 +3894,34 @@ msgid ""
 "last expression in the block will be assigned to the place expression such as "
 "a local variable. However, if the last expression of the block ends with a "
 "semicolon, the return value will be `()`."
-msgstr ""
+msgstr "代码块也是表达式，所以它们可以用作赋值中的值。代码块中的最后一个表达式将被赋值给左值表达式，比如局部变量。但是，如果代码块的最后一个表达式以分号结尾，返回值将是 `()`。"
 
 #: src/expression.md:41
 msgid "// This expression will be assigned to `y`\n"
-msgstr ""
+msgstr "// 这个表达式将被赋值给 `y`\n"
 
 #: src/expression.md:46
 msgid ""
 "// The semicolon suppresses this expression and `()` is assigned to `z`\n"
-msgstr ""
+msgstr "// 分号抑制了这个表达式，`()` 被赋值给 `z`\n"
 
 #: src/expression.md:50
 msgid "\"x is {:?}\""
-msgstr ""
+msgstr "\"x 是 {:?}\""
 
 #: src/expression.md:51
 msgid "\"y is {:?}\""
-msgstr ""
+msgstr "\"y 是 {:?}\""
 
 #: src/expression.md:52
 msgid "\"z is {:?}\""
-msgstr ""
+msgstr "\"z 是 {:?}\""
 
 #: src/flow_control.md:3
 msgid ""
 "An integral part of any programming language are ways to modify control flow: "
 "`if`/`else`, `for`, and others. Let's talk about them in Rust."
-msgstr ""
+msgstr "任何编程语言的一个重要部分是修改控制流的方法：`if`/`else`、`for` 等。让我们来讨论 Rust 中的这些内容。"
 
 #: src/flow_control/if_else.md:3
 msgid ""
@@ -3926,116 +3929,118 @@ msgid ""
 "them, the boolean condition doesn't need to be surrounded by parentheses, and "
 "each condition is followed by a block. `if`\\-`else` conditionals are "
 "expressions, and, all branches must return the same type."
-msgstr ""
+msgstr "使用 `if`\\-`else` 分支和其他语言类似。与许多语言不同的是，布尔条件不需要用括号括起来，每个条件后面都跟着一个代码块。`if`\\-`else` 条件是表达式，并且所有分支必须返回相同的类型。"
 
 #: src/flow_control/if_else.md:13
 msgid "\"{} is negative\""
-msgstr ""
+msgstr "\"{} 是负数\""
 
 #: src/flow_control/if_else.md:15
 msgid "\"{} is positive\""
-msgstr ""
+msgstr "\"{} 是正数\""
 
 #: src/flow_control/if_else.md:17
 msgid "\"{} is zero\""
-msgstr ""
+msgstr "\"{} 是零\""
 
 #: src/flow_control/if_else.md:22
 msgid "\", and is a small number, increase ten-fold\""
-msgstr ""
+msgstr "\"，是一个小数字，扩大十倍\""
 
 #: src/flow_control/if_else.md:24
 msgid "// This expression returns an `i32`.\n"
-msgstr ""
+msgstr "// 这个表达式返回一个 `i32`。\n"
 
 #: src/flow_control/if_else.md:27
 msgid "\", and is a big number, halve the number\""
-msgstr ""
+msgstr "\"，是一个大数字，将数字减半\""
 
 #: src/flow_control/if_else.md:29
 msgid "// This expression must return an `i32` as well.\n"
-msgstr ""
+msgstr "// 这个表达式也必须返回一个 `i32`。\n"
 
 #: src/flow_control/if_else.md:31
 msgid "// TODO ^ Try suppressing this expression with a semicolon.\n"
-msgstr ""
+msgstr "// TODO ^ 尝试用分号结束这个表达式。\n"
 
 #: src/flow_control/if_else.md:33
 msgid ""
 "//   ^ Don't forget to put a semicolon here! All `let` bindings need it.\n"
-msgstr ""
+msgstr "//   ^ 别忘了在这里加分号！所有的 `let` 绑定都需要它。\n"
 
 #: src/flow_control/if_else.md:35 src/flow_control/match.md:35
 msgid "\"{} -> {}\""
-msgstr ""
+msgstr "\"{} -> {}\""
 
 #: src/flow_control/loop.md:3
 msgid "Rust provides a `loop` keyword to indicate an infinite loop."
-msgstr ""
+msgstr "Rust 提供了 `loop` 关键字来表示一个无限循环。"
 
 #: src/flow_control/loop.md:5
 msgid ""
 "The `break` statement can be used to exit a loop at anytime, whereas the "
 "`continue` statement can be used to skip the rest of the iteration and start "
 "a new one."
-msgstr ""
+msgstr "`break` 语句可以随时退出循环，而 `continue` 语句可以用来跳过本次迭代的剩余部分并开始新的迭代。"
 
 #: src/flow_control/loop.md:13
 msgid "\"Let's count until infinity!\""
-msgstr ""
+msgstr "\"让我们数到无穷大！\""
 
 #: src/flow_control/loop.md:15
 msgid "// Infinite loop\n"
-msgstr ""
+msgstr "// 无限循环\n"
 
 #: src/flow_control/loop.md:20
 msgid "\"three\""
-msgstr ""
+msgstr "\"three\""
 
 #: src/flow_control/loop.md:22
 msgid "// Skip the rest of this iteration\n"
-msgstr ""
+msgstr "// 跳过本次迭代的剩余部分\n"
 
 #: src/flow_control/loop.md:29
 msgid "\"OK, that's enough\""
-msgstr ""
+msgstr "\"好了，够了\""
 
 #: src/flow_control/loop.md:31
 msgid "// Exit this loop\n"
-msgstr ""
+msgstr "// 退出这个循环\n"
 
 #: src/flow_control/loop/nested.md:3
 msgid ""
 "It's possible to `break` or `continue` outer loops when dealing with nested "
 "loops. In these cases, the loops must be annotated with some `'label`, and "
 "the label must be passed to the `break`/`continue` statement."
-msgstr ""
+msgstr "在处理嵌套循环时，可以 `break` 或 `continue` 外层循环。在这些情况下，循环必须用某个 `'label` 标记，并且必须将标签传递给 `break`/`continue` 语句。"
 
 #: src/flow_control/loop/nested.md:12
 msgid "\"Entered the outer loop\""
-msgstr ""
+msgstr "\"进入外层循环\""
 
 #: src/flow_control/loop/nested.md:15
 msgid "\"Entered the inner loop\""
-msgstr ""
+msgstr "\"进入内层循环\""
 
 #: src/flow_control/loop/nested.md:17
 msgid ""
 "// This would break only the inner loop\n"
 "            //break;\n"
 msgstr ""
+"// 这只会中断内层循环\n"
+"            //break;\n"
 
 #: src/flow_control/loop/nested.md:20
 msgid "// This breaks the outer loop\n"
-msgstr ""
+msgstr "// 这会中断外层循环\n"
 
 #: src/flow_control/loop/nested.md:24
 msgid "\"This point will never be reached\""
-msgstr ""
+msgstr "\"永远不会到达这一点\""
 
 #: src/flow_control/loop/nested.md:27
 msgid "\"Exited the outer loop\""
-msgstr ""
+msgstr "\"退出外层循环\""
 
 #: src/flow_control/loop/return.md:3
 msgid ""
@@ -4043,73 +4048,73 @@ msgid ""
 "the operation returns a value though, you might need to pass it to the rest "
 "of the code: put it after the `break`, and it will be returned by the `loop` "
 "expression."
-msgstr ""
+msgstr "`loop` 的一个用途是重试一个操作，直到它成功。如果操作返回一个值，你可能需要将它传递给代码的其余部分：将它放在 `break` 之后，它将被 `loop` 表达式返回。"
 
 #: src/flow_control/while.md:3
 msgid "The `while` keyword can be used to run a loop while a condition is true."
-msgstr ""
+msgstr "`while` 关键字可以用来在条件为真时运行循环。"
 
 #: src/flow_control/while.md:5
 msgid ""
 "Let's write the infamous [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) "
 "using a `while` loop."
-msgstr ""
+msgstr "让我们使用 `while` 循环来编写著名的 [FizzBuzz](https://en.wikipedia.org/wiki/Fizz_buzz) 程序。"
 
 #: src/flow_control/while.md:9
 msgid "// A counter variable\n"
-msgstr ""
+msgstr "// 一个计数器变量\n"
 
 #: src/flow_control/while.md:12
 msgid "// Loop while `n` is less than 101\n"
-msgstr ""
+msgstr "// 当 `n` 小于 101 时循环\n"
 
 #: src/flow_control/while.md:15 src/flow_control/for.md:17
 #: src/flow_control/for.md:37 src/fn.md:34
 msgid "\"fizzbuzz\""
-msgstr ""
+msgstr "\"fizzbuzz\""
 
 #: src/flow_control/while.md:17 src/flow_control/for.md:19
 #: src/flow_control/for.md:39 src/fn.md:36
 msgid "\"fizz\""
-msgstr ""
+msgstr "\"fizz\""
 
 #: src/flow_control/while.md:19 src/flow_control/for.md:21
 #: src/flow_control/for.md:41 src/fn.md:38
 msgid "\"buzz\""
-msgstr ""
+msgstr "\"buzz\""
 
 #: src/flow_control/while.md:24
 msgid "// Increment counter\n"
-msgstr ""
+msgstr "// 增加计数器\n"
 
 #: src/flow_control/for.md:1
 msgid "for loops"
-msgstr ""
+msgstr "for 循环"
 
 #: src/flow_control/for.md:5
 msgid ""
 "The `for in` construct can be used to iterate through an `Iterator`. One of "
 "the easiest ways to create an iterator is to use the range notation `a..b`. "
 "This yields values from `a` (inclusive) to `b` (exclusive) in steps of one."
-msgstr ""
+msgstr "`for in` 结构可以用来遍历 `Iterator`。创建迭代器最简单的方法之一是使用区间表示法 `a..b`。这会生成从 `a`（包含）到 `b`（不包含）的值，步长为一。"
 
 #: src/flow_control/for.md:10
 msgid "Let's write FizzBuzz using `for` instead of `while`."
-msgstr ""
+msgstr "让我们使用 `for` 而不是 `while` 来编写 FizzBuzz。"
 
 #: src/flow_control/for.md:14 src/flow_control/for.md:34
 msgid "// `n` will take the values: 1, 2, ..., 100 in each iteration\n"
-msgstr ""
+msgstr "// `n` 在每次迭代中将取值：1, 2, ..., 100\n"
 
 #: src/flow_control/for.md:29
 msgid ""
 "Alternatively, `a..=b` can be used for a range that is inclusive on both "
 "ends. The above can be written as:"
-msgstr ""
+msgstr "或者，可以使用 `a..=b` 来表示两端都包含的范围。上面的代码可以写成："
 
 #: src/flow_control/for.md:49
 msgid "for and iterators"
-msgstr ""
+msgstr "for 和迭代器"
 
 #: src/flow_control/for.md:51
 msgid ""
@@ -4118,142 +4123,144 @@ msgid ""
 "by default the `for` loop will apply the `into_iter` function to the "
 "collection. However, this is not the only means of converting collections "
 "into iterators."
-msgstr ""
+msgstr "`for in` 结构能够以多种方式与 `Iterator` 交互。正如在[迭代器](../trait/iter.md)特质一节中讨论的那样，默认情况下 `for` 循环会对集合应用 `into_iter` 函数。然而，这并不是将集合转换为迭代器的唯一方法。"
 
 #: src/flow_control/for.md:56
 msgid ""
 "`into_iter`, `iter` and `iter_mut` all handle the conversion of a collection "
 "into an iterator in different ways, by providing different views on the data "
 "within."
-msgstr ""
+msgstr "`into_iter`、`iter` 和 `iter_mut` 都以不同的方式处理集合到迭代器的转换，通过提供对数据的不同视图。"
 
 #: src/flow_control/for.md:60
 msgid ""
 "`iter` - This borrows each element of the collection through each iteration. "
 "Thus leaving the collection untouched and available for reuse after the loop."
-msgstr ""
+msgstr "`iter` - 这在每次迭代中借用集合的每个元素。因此，集合保持不变，并且在循环之后可以重复使用。"
 
 #: src/flow_control/for.md:65 src/flow_control/for.md:85
 #: src/flow_control/for.md:104
 msgid "\"Frank\""
-msgstr ""
+msgstr "\"Frank\""
 
 #: src/flow_control/for.md:65 src/flow_control/for.md:69
 #: src/flow_control/for.md:85 src/flow_control/for.md:89
 #: src/flow_control/for.md:104 src/flow_control/for.md:108
 msgid "\"Ferris\""
-msgstr ""
+msgstr "\"Ferris\""
 
 #: src/flow_control/for.md:69 src/flow_control/for.md:89
 #: src/flow_control/for.md:108
 msgid "\"There is a rustacean among us!\""
-msgstr ""
+msgstr "\"我们中间有一个 Rustacean！\""
 
 #: src/flow_control/for.md:70
 msgid "// TODO ^ Try deleting the & and matching just \"Ferris\"\n"
-msgstr ""
+msgstr "// TODO ^ 尝试删除 & 并只匹配 \"Ferris\"\n"
 
 #: src/flow_control/for.md:71 src/flow_control/for.md:90
 msgid "\"Hello {}\""
-msgstr ""
+msgstr "\"你好 {}\""
 
 #: src/flow_control/for.md:75 src/flow_control/for.md:94
 #: src/flow_control/for.md:113
 msgid "\"names: {:?}\""
-msgstr ""
+msgstr "\"names: {:?}\""
 
 #: src/flow_control/for.md:79
 msgid ""
 "`into_iter` - This consumes the collection so that on each iteration the "
 "exact data is provided. Once the collection has been consumed it is no longer "
 "available for reuse as it has been 'moved' within the loop."
-msgstr ""
+msgstr "`into_iter` - 这会消耗集合，使得在每次迭代中提供确切的数据。一旦集合被消耗，它就不再可用于重复使用，因为它已经在循环中被'移动'了。"
 
 #: src/flow_control/for.md:99
 msgid ""
 "`iter_mut` - This mutably borrows each element of the collection, allowing "
 "for the collection to be modified in place."
-msgstr ""
+msgstr "`iter_mut` - 这会可变地借用集合的每个元素，允许在原地修改集合。"
 
 #: src/flow_control/for.md:109
 msgid "\"Hello\""
-msgstr ""
+msgstr "\"你好\""
 
 #: src/flow_control/for.md:117
 msgid ""
 "In the above snippets note the type of `match` branch, that is the key "
 "difference in the types of iteration. The difference in type then of course "
 "implies differing actions that are able to be performed."
-msgstr ""
+msgstr "在上面的代码片段中，注意 `match` 分支的类型，这是迭代类型的关键区别。类型的差异意味着可以执行的操作不同。"
 
 #: src/flow_control/for.md:123
 msgid "[Iterator](../trait/iter.md)"
-msgstr ""
+msgstr "[迭代器](../trait/iter.md)"
 
 #: src/flow_control/match.md:3
 msgid ""
 "Rust provides pattern matching via the `match` keyword, which can be used "
 "like a C `switch`. The first matching arm is evaluated and all possible "
 "values must be covered."
-msgstr ""
+msgstr "Rust 通过 `match` 关键字提供模式匹配，它可以像 C 语言的 `switch` 一样使用。第一个匹配的分支会被求值，并且必须覆盖所有可能的值。"
 
 #: src/flow_control/match.md:10
 msgid "// TODO ^ Try different values for `number`\n"
-msgstr ""
+msgstr "// TODO ^ 尝试为 `number` 赋予不同的值\n"
 
 #: src/flow_control/match.md:12
 msgid "\"Tell me about {}\""
-msgstr ""
+msgstr "\"告诉我关于 {} 的信息\""
 
 #: src/flow_control/match.md:14
 msgid "// Match a single value\n"
-msgstr ""
+msgstr "// 匹配单个值\n"
 
 #: src/flow_control/match.md:15
 msgid "\"One!\""
-msgstr ""
+msgstr "\"一！\""
 
 #: src/flow_control/match.md:16
 msgid "// Match several values\n"
-msgstr ""
+msgstr "// 匹配多个值\n"
 
 #: src/flow_control/match.md:17
 msgid "\"This is a prime\""
-msgstr ""
+msgstr "\"这是一个质数\""
 
 #: src/flow_control/match.md:18
 msgid ""
 "// TODO ^ Try adding 13 to the list of prime values\n"
 "        // Match an inclusive range\n"
 msgstr ""
+"// TODO ^ 尝试将 13 添加到质数列表中\n"
+"        // 匹配一个包含的范围\n"
 
 #: src/flow_control/match.md:20
 msgid "\"A teen\""
-msgstr ""
+msgstr "\"一个青少年\""
 
 #: src/flow_control/match.md:21
 msgid "// Handle the rest of cases\n"
-msgstr ""
+msgstr "// 处理剩余的情况\n"
 
 #: src/flow_control/match.md:22
 msgid "\"Ain't special\""
-msgstr ""
+msgstr "\"没什么特别的\""
 
 #: src/flow_control/match.md:23
 msgid "// TODO ^ Try commenting out this catch-all arm\n"
-msgstr ""
+msgstr "// TODO ^ 尝试注释掉这个捕获所有情况的分支\n"
 
 #: src/flow_control/match.md:27
 msgid "// Match is an expression too\n"
-msgstr ""
+msgstr "// match 也是一个表达式\n"
 
 #: src/flow_control/match.md:29
 msgid "// The arms of a match must cover all the possible values\n"
-msgstr ""
+msgstr "// match 的分支必须覆盖所有可能的值\n"
 
 #: src/flow_control/match.md:32
 msgid "// TODO ^ Try commenting out one of these arms\n"
-msgstr ""
+msgstr "// TODO ^ 尝试注释掉其中一个分支\n"
 
 #: src/flow_control/match/destructuring.md:3
 msgid "A `match` block can destructure items in a variety of ways."

--- a/po/zh.po
+++ b/po/zh.po
@@ -4656,55 +4656,57 @@ msgstr "[结构体](../../../custom_types/structs.md)"
 
 #: src/flow_control/match/guard.md:3
 msgid "A `match` _guard_ can be added to filter the arm."
-msgstr ""
+msgstr "可以添加 `match` **守卫**来过滤分支。"
 
 #: src/flow_control/match/guard.md:14
 msgid "// ^ TODO try different values for `temperature`\n"
-msgstr ""
+msgstr "// ^ TODO 尝试不同的 `temperature` 值\n"
 
 #: src/flow_control/match/guard.md:17
 msgid "\"{}C is above 30 Celsius\""
-msgstr ""
+msgstr "\"{}摄氏度高于 30 摄氏度\""
 
 #: src/flow_control/match/guard.md:18
 msgid "// The `if condition` part ^ is a guard\n"
-msgstr ""
+msgstr "// `if condition` 部分 ^ 是一个守卫\n"
 
 #: src/flow_control/match/guard.md:19
 msgid "\"{}C is equal to or below 30 Celsius\""
-msgstr ""
+msgstr "\"{}摄氏度等于或低于 30 摄氏度\""
 
 #: src/flow_control/match/guard.md:21
 msgid "\"{}F is above 86 Fahrenheit\""
-msgstr ""
+msgstr "\"{}华氏度高于 86 华氏度\""
 
 #: src/flow_control/match/guard.md:22
 msgid "\"{}F is equal to or below 86 Fahrenheit\""
-msgstr ""
+msgstr "\"{}华氏度等于或低于 86 华氏度\""
 
 #: src/flow_control/match/guard.md:27
 msgid ""
 "Note that the compiler won't take guard conditions into account when checking "
 "if all patterns are covered by the match expression."
-msgstr ""
+msgstr "注意，编译器在检查 match 表达式是否覆盖了所有模式时，不会考虑守卫条件。"
 
 #: src/flow_control/match/guard.md:35
 msgid "\"Zero\""
-msgstr ""
+msgstr "\"零\""
 
 #: src/flow_control/match/guard.md:36
 msgid "\"Greater than zero\""
-msgstr ""
+msgstr "\"大于零\""
 
 #: src/flow_control/match/guard.md:37
 msgid ""
 "// _ => unreachable!(\"Should never happen.\"),\n"
 "        // TODO ^ uncomment to fix compilation\n"
 msgstr ""
+"// _ => unreachable!(\"永远不应该发生。\"),\n"
+"        // TODO ^ 取消注释以修复编译\n"
 
 #: src/flow_control/match/guard.md:45
 msgid "[Tuples](../../primitives/tuples.md) [Enums](../../custom_types/enum.md)"
-msgstr ""
+msgstr "[元组](../../primitives/tuples.md) [枚举](../../custom_types/enum.md)"
 
 #: src/flow_control/match/binding.md:3
 msgid ""
@@ -4712,18 +4714,19 @@ msgid ""
 "variable without re-binding. `match` provides the `@` sigil for binding "
 "values to names:"
 msgstr ""
+"间接访问变量使得无法在分支中使用该变量而不重新绑定。`match` 提供了 `@` 符号用于将值绑定到名称："
 
 #: src/flow_control/match/binding.md:8
 msgid "// A function `age` which returns a `u32`.\n"
-msgstr ""
+msgstr "// 一个返回 `u32` 的 `age` 函数。\n"
 
 #: src/flow_control/match/binding.md:14
 msgid "\"Tell me what type of person you are\""
-msgstr ""
+msgstr "\"告诉我你是什么样的人\""
 
 #: src/flow_control/match/binding.md:17
 msgid "\"I haven't celebrated my first birthday yet\""
-msgstr ""
+msgstr "\"我还没有庆祝过我的第一个生日\""
 
 #: src/flow_control/match/binding.md:18
 msgid ""
@@ -4731,55 +4734,60 @@ msgid ""
 "        // would the child be? Instead, bind to `n` for the\n"
 "        // sequence of 1 ..= 12. Now the age can be reported.\n"
 msgstr ""
+"// 可以直接 `match` 1 ..= 12，但那样孩子的年龄是多少呢？\n"
+"        // 相反，将 1 ..= 12 的序列绑定到 `n`。现在可以报告年龄了。\n"
 
 #: src/flow_control/match/binding.md:21
 msgid "\"I'm a child of age {:?}\""
-msgstr ""
+msgstr "\"我是一个 {:?} 岁的孩子\""
 
 #: src/flow_control/match/binding.md:22
 msgid "\"I'm a teen of age {:?}\""
-msgstr ""
+msgstr "\"我是一个 {:?} 岁的青少年\""
 
 #: src/flow_control/match/binding.md:23
 msgid "// Nothing bound. Return the result.\n"
-msgstr ""
+msgstr "// 没有绑定。返回结果。\n"
 
 #: src/flow_control/match/binding.md:24
 msgid "\"I'm an old person of age {:?}\""
-msgstr ""
+msgstr "\"我是一个 {:?} 岁的老年人\""
 
 #: src/flow_control/match/binding.md:29
 msgid ""
 "You can also use binding to \"destructure\" `enum` variants, such as `Option`:"
-msgstr ""
+msgstr "你也可以使用绑定来"解构" `enum` 变体，比如 `Option`："
 
 #: src/flow_control/match/binding.md:38
 msgid ""
 "// Got `Some` variant, match if its value, bound to `n`,\n"
 "        // is equal to 42.\n"
 msgstr ""
+"// 得到 `Some` 变体，匹配如果它的值等于 42，绑定到 `n`，\n"
 
 #: src/flow_control/match/binding.md:40
 msgid "\"The Answer: {}!\""
-msgstr ""
+msgstr "\"答案是：{}！\""
 
 #: src/flow_control/match/binding.md:41
 msgid "// Match any other number.\n"
-msgstr ""
+msgstr "// 匹配任何其他数字。\n"
 
 #: src/flow_control/match/binding.md:42
 msgid "\"Not interesting... {}\""
-msgstr ""
+msgstr "\"不感兴趣... {}\""
 
 #: src/flow_control/match/binding.md:43
 msgid "// Match anything else (`None` variant).\n"
-msgstr ""
+msgstr "// 匹配其他任何情况（`None` 变体）。\n"
 
 #: src/flow_control/match/binding.md:50
 msgid ""
 "[`functions`](../../fn.md), [`enums`](../../custom_types/enum.md) and "
 "[`Option`](../../std/option.md)"
 msgstr ""
+"[`函数`](../../fn.md)，[`枚举`](../../custom_types/enum.md) 和 "
+"[`Option`](../../std/option.md)"
 
 #: src/flow_control/if_let.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Rust By Example\n"
 "POT-Creation-Date: 2024-08-17T09:33:02+08:00\n"
-"PO-Revision-Date: 2024-08-17 10:48+0800\n"
+"PO-Revision-Date: 2024-08-17 22:13+0800\n"
 "Last-Translator: Binlogo <binboy@live.com>\n"
 "Language-Team: Chinese\n"
 "Language: zh\n"
@@ -13,761 +13,761 @@ msgstr ""
 
 #: src/SUMMARY.md:1
 msgid "Summary"
-msgstr ""
+msgstr "Summary"
 
 #: src/SUMMARY.md:3
 msgid "Introduction"
-msgstr ""
+msgstr "介绍"
 
 #: src/SUMMARY.md:5 src/hello.md:1
 msgid "Hello World"
-msgstr ""
+msgstr "Hello World"
 
 #: src/SUMMARY.md:6 src/hello/comment.md:1
 msgid "Comments"
-msgstr ""
+msgstr "注释"
 
 #: src/SUMMARY.md:7 src/hello/print.md:1
 msgid "Formatted print"
-msgstr ""
+msgstr "格式化打印"
 
 #: src/SUMMARY.md:8 src/hello/print/print_debug.md:1
 msgid "Debug"
-msgstr ""
+msgstr "调试 Debug"
 
 #: src/SUMMARY.md:9 src/hello/print/print_display.md:1
 msgid "Display"
-msgstr ""
+msgstr "显示 Display"
 
 #: src/SUMMARY.md:10 src/hello/print/print_display/testcase_list.md:1
 msgid "Testcase: List"
-msgstr ""
+msgstr "测试实例：列表"
 
 #: src/SUMMARY.md:11 src/hello/print/fmt.md:1
 msgid "Formatting"
-msgstr ""
+msgstr "格式化"
 
 #: src/SUMMARY.md:13 src/primitives.md:1
 msgid "Primitives"
-msgstr ""
+msgstr "原始类型"
 
 #: src/SUMMARY.md:14 src/primitives/literals.md:1
 msgid "Literals and operators"
-msgstr ""
+msgstr "字面量和运算符"
 
 #: src/SUMMARY.md:15 src/primitives/tuples.md:1
 msgid "Tuples"
-msgstr ""
+msgstr "元组"
 
 #: src/SUMMARY.md:16 src/primitives/array.md:1
 msgid "Arrays and Slices"
-msgstr ""
+msgstr "数组和切片"
 
 #: src/SUMMARY.md:18 src/custom_types.md:1
 msgid "Custom Types"
-msgstr ""
+msgstr "自定义类型"
 
 #: src/SUMMARY.md:19 src/custom_types/structs.md:1
 msgid "Structures"
-msgstr ""
+msgstr "结构体"
 
 #: src/SUMMARY.md:20 src/custom_types/enum.md:1
 msgid "Enums"
-msgstr ""
+msgstr "枚举"
 
 #: src/SUMMARY.md:21 src/custom_types/enum/enum_use.md:1
 msgid "use"
-msgstr ""
+msgstr "use"
 
 #: src/SUMMARY.md:22 src/custom_types/enum/c_like.md:1
 msgid "C-like"
-msgstr ""
+msgstr "C 风格用法"
 
 #: src/SUMMARY.md:23 src/custom_types/enum/testcase_linked_list.md:1
 msgid "Testcase: linked-list"
-msgstr ""
+msgstr "测试实例：链表"
 
 #: src/SUMMARY.md:24 src/custom_types/constants.md:1
 msgid "constants"
-msgstr ""
+msgstr "常量"
 
 #: src/SUMMARY.md:26 src/variable_bindings.md:1
 msgid "Variable Bindings"
-msgstr ""
+msgstr "变量绑定"
 
 #: src/SUMMARY.md:27 src/SUMMARY.md:120 src/SUMMARY.md:123
 #: src/variable_bindings/mut.md:1 src/scope/move/mut.md:1
 #: src/scope/borrow/mut.md:1
 msgid "Mutability"
-msgstr ""
+msgstr "可变性"
 
 #: src/SUMMARY.md:28 src/variable_bindings/scope.md:1
 msgid "Scope and Shadowing"
-msgstr ""
+msgstr "作用域和遮蔽"
 
 #: src/SUMMARY.md:29 src/variable_bindings/declare.md:1
 msgid "Declare first"
-msgstr ""
+msgstr "先声明"
 
 #: src/SUMMARY.md:30 src/variable_bindings/freeze.md:1
 msgid "Freezing"
-msgstr ""
+msgstr "冻结"
 
 #: src/SUMMARY.md:32 src/types.md:1
 msgid "Types"
-msgstr ""
+msgstr "类型"
 
 #: src/SUMMARY.md:33 src/types/cast.md:1
 msgid "Casting"
-msgstr ""
+msgstr "类型转换"
 
 #: src/SUMMARY.md:34 src/types/literals.md:1
 msgid "Literals"
-msgstr ""
+msgstr "字面量"
 
 #: src/SUMMARY.md:35 src/types/inference.md:1
 msgid "Inference"
-msgstr ""
+msgstr "类型推断"
 
 #: src/SUMMARY.md:36 src/SUMMARY.md:124 src/types/alias.md:1
 #: src/scope/borrow/alias.md:1
 msgid "Aliasing"
-msgstr ""
+msgstr "别名"
 
 #: src/SUMMARY.md:38 src/conversion.md:1
 msgid "Conversion"
-msgstr ""
+msgstr "转换"
 
 #: src/SUMMARY.md:39 src/conversion/from_into.md:1
 msgid "`From` and `Into`"
-msgstr ""
+msgstr "`From` 和 `Into`"
 
 #: src/SUMMARY.md:40 src/conversion/try_from_try_into.md:1
 msgid "`TryFrom` and `TryInto`"
-msgstr ""
+msgstr "`TryFrom` 和 `TryInto`"
 
 #: src/SUMMARY.md:41
 msgid "To and from `String`s"
-msgstr ""
+msgstr "`String` 类型转换"
 
 #: src/SUMMARY.md:43 src/expression.md:1
 msgid "Expressions"
-msgstr ""
+msgstr "表达式"
 
 #: src/SUMMARY.md:45 src/flow_control.md:1
 msgid "Flow of Control"
-msgstr ""
+msgstr "控制流"
 
 #: src/SUMMARY.md:46 src/flow_control/if_else.md:1
 msgid "if/else"
-msgstr ""
+msgstr "if/else"
 
 #: src/SUMMARY.md:47 src/flow_control/loop.md:1
 msgid "loop"
-msgstr ""
+msgstr "loop"
 
 #: src/SUMMARY.md:48 src/flow_control/loop/nested.md:1
 msgid "Nesting and labels"
-msgstr ""
+msgstr "嵌套和标签"
 
 #: src/SUMMARY.md:49 src/flow_control/loop/return.md:1
 msgid "Returning from loops"
-msgstr ""
+msgstr "在 loop 中返回值"
 
 #: src/SUMMARY.md:50 src/flow_control/while.md:1
 msgid "while"
-msgstr ""
+msgstr "while"
 
 #: src/SUMMARY.md:51 src/flow_control/for.md:3
 msgid "for and range"
-msgstr ""
+msgstr "for 和 range"
 
 #: src/SUMMARY.md:52 src/flow_control/match.md:1
 msgid "match"
-msgstr ""
+msgstr "match"
 
 #: src/SUMMARY.md:53 src/flow_control/match/destructuring.md:1
 msgid "Destructuring"
-msgstr ""
+msgstr "解构"
 
 #: src/SUMMARY.md:54 src/flow_control/match/destructuring/destructure_tuple.md:1
 msgid "tuples"
-msgstr ""
+msgstr "元组"
 
 #: src/SUMMARY.md:55 src/flow_control/match/destructuring/destructure_slice.md:1
 msgid "arrays/slices"
-msgstr ""
+msgstr "数组/切片"
 
 #: src/SUMMARY.md:56 src/flow_control/match/destructuring/destructure_enum.md:1
 msgid "enums"
-msgstr ""
+msgstr "枚举"
 
 #: src/SUMMARY.md:57
 #: src/flow_control/match/destructuring/destructure_pointers.md:1
 msgid "pointers/ref"
-msgstr ""
+msgstr "指针/引用"
 
 #: src/SUMMARY.md:58
 #: src/flow_control/match/destructuring/destructure_structures.md:1
 msgid "structs"
-msgstr ""
+msgstr "结构体"
 
 #: src/SUMMARY.md:59 src/flow_control/match/guard.md:1
 msgid "Guards"
-msgstr ""
+msgstr "守卫"
 
 #: src/SUMMARY.md:60 src/flow_control/match/binding.md:1
 msgid "Binding"
-msgstr ""
+msgstr "绑定"
 
 #: src/SUMMARY.md:61 src/flow_control/if_let.md:1
 msgid "if let"
-msgstr ""
+msgstr "if let"
 
 #: src/SUMMARY.md:62 src/flow_control/let_else.md:1
 msgid "let-else"
-msgstr ""
+msgstr "let-else"
 
 #: src/SUMMARY.md:63 src/flow_control/while_let.md:1
 msgid "while let"
-msgstr ""
+msgstr "while let"
 
 #: src/SUMMARY.md:65 src/SUMMARY.md:103 src/SUMMARY.md:128 src/fn.md:1
 #: src/generics/gen_fn.md:1 src/scope/lifetime/fn.md:1
 msgid "Functions"
-msgstr ""
+msgstr "函数"
 
 #: src/SUMMARY.md:66 src/SUMMARY.md:129 src/scope/lifetime/methods.md:1
 msgid "Methods"
-msgstr ""
+msgstr "方法"
 
 #: src/SUMMARY.md:67 src/fn/closures.md:1
 msgid "Closures"
-msgstr ""
+msgstr "闭包"
 
 #: src/SUMMARY.md:68 src/fn/closures/capture.md:1
 msgid "Capturing"
-msgstr ""
+msgstr "捕获"
 
 #: src/SUMMARY.md:69 src/fn/closures/input_parameters.md:1
 msgid "As input parameters"
-msgstr ""
+msgstr "作为输入参数"
 
 #: src/SUMMARY.md:70 src/fn/closures/anonymity.md:1
 msgid "Type anonymity"
-msgstr ""
+msgstr "类型匿名"
 
 #: src/SUMMARY.md:71 src/fn/closures/input_functions.md:1
 msgid "Input functions"
-msgstr ""
+msgstr "输入函数"
 
 #: src/SUMMARY.md:72 src/fn/closures/output_parameters.md:1
 msgid "As output parameters"
-msgstr ""
+msgstr "作为输出参数"
 
 #: src/SUMMARY.md:73 src/fn/closures/closure_examples.md:1
 msgid "Examples in `std`"
-msgstr ""
+msgstr "`std` 中的例子"
 
 #: src/SUMMARY.md:74 src/fn/closures/closure_examples/iter_any.md:1
 msgid "Iterator::any"
-msgstr ""
+msgstr "Iterator::any"
 
 #: src/SUMMARY.md:75 src/fn/closures/closure_examples/iter_find.md:1
 msgid "Searching through iterators"
-msgstr ""
+msgstr "通过迭代器搜索"
 
 #: src/SUMMARY.md:76 src/fn/hof.md:1
 msgid "Higher Order Functions"
-msgstr ""
+msgstr "高阶函数"
 
 #: src/SUMMARY.md:77 src/fn/diverging.md:1
 msgid "Diverging functions"
-msgstr ""
+msgstr "发散函数"
 
 #: src/SUMMARY.md:79 src/mod.md:1
 msgid "Modules"
-msgstr ""
+msgstr "模块"
 
 #: src/SUMMARY.md:80 src/mod/visibility.md:1
 msgid "Visibility"
-msgstr ""
+msgstr "可见性"
 
 #: src/SUMMARY.md:81 src/mod/struct_visibility.md:1
 msgid "Struct visibility"
-msgstr ""
+msgstr "结构体可见性"
 
 #: src/SUMMARY.md:82 src/mod/use.md:1
 msgid "The `use` declaration"
-msgstr ""
+msgstr "`use` 声明"
 
 #: src/SUMMARY.md:83 src/mod/super.md:1
 msgid "`super` and `self`"
-msgstr ""
+msgstr "`super` 和 `self`"
 
 #: src/SUMMARY.md:84 src/mod/split.md:1
 msgid "File hierarchy"
-msgstr ""
+msgstr "文件分层"
 
 #: src/SUMMARY.md:86 src/SUMMARY.md:98 src/crates.md:1 src/attribute/crate.md:1
 #: src/std_misc/arg.md:30
 msgid "Crates"
-msgstr ""
+msgstr "Crates"
 
 #: src/SUMMARY.md:87 src/crates/lib.md:1
 msgid "Creating a Library"
-msgstr ""
+msgstr "创建库"
 
 #: src/SUMMARY.md:88 src/crates/using_lib.md:1
 msgid "Using a Library"
-msgstr ""
+msgstr "使用库"
 
 #: src/SUMMARY.md:90 src/cargo.md:1
 msgid "Cargo"
-msgstr ""
+msgstr "Cargo"
 
 #: src/SUMMARY.md:91 src/cargo/deps.md:1
 msgid "Dependencies"
-msgstr ""
+msgstr "依赖"
 
 #: src/SUMMARY.md:92 src/cargo/conventions.md:1
 msgid "Conventions"
-msgstr ""
+msgstr "约定"
 
 #: src/SUMMARY.md:93
 msgid "Tests"
-msgstr ""
+msgstr "测试"
 
 #: src/SUMMARY.md:94 src/cargo/build_scripts.md:1
 msgid "Build Scripts"
-msgstr ""
+msgstr "构建脚本"
 
 #: src/SUMMARY.md:96 src/attribute.md:1
 msgid "Attributes"
-msgstr ""
+msgstr "属性"
 
 #: src/SUMMARY.md:97 src/attribute/unused.md:1
 msgid "`dead_code`"
-msgstr ""
+msgstr "`dead_code`"
 
 #: src/SUMMARY.md:99 src/attribute/cfg.md:1
 msgid "`cfg`"
-msgstr ""
+msgstr "`cfg`"
 
 #: src/SUMMARY.md:100 src/attribute/cfg/custom.md:1
 msgid "Custom"
-msgstr ""
+msgstr "自定义"
 
 #: src/SUMMARY.md:102 src/generics.md:1
 msgid "Generics"
-msgstr ""
+msgstr "泛型"
 
 #: src/SUMMARY.md:104 src/generics/impl.md:1
 msgid "Implementation"
-msgstr ""
+msgstr "实现"
 
 #: src/SUMMARY.md:105 src/SUMMARY.md:131 src/SUMMARY.md:137
 #: src/generics/gen_trait.md:1 src/scope/lifetime/trait.md:1 src/trait.md:1
 msgid "Traits"
-msgstr ""
+msgstr "特质"
 
 #: src/SUMMARY.md:106 src/SUMMARY.md:132 src/generics/bounds.md:1
 #: src/scope/lifetime/lifetime_bounds.md:1
 msgid "Bounds"
-msgstr ""
+msgstr "约束"
 
 #: src/SUMMARY.md:107 src/generics/bounds/testcase_empty.md:1
 msgid "Testcase: empty bounds"
-msgstr ""
+msgstr "测试实例：空约束"
 
 #: src/SUMMARY.md:108 src/generics/multi_bounds.md:1
 msgid "Multiple bounds"
-msgstr ""
+msgstr "多重约束"
 
 #: src/SUMMARY.md:109 src/generics/where.md:1
 msgid "Where clauses"
-msgstr ""
+msgstr "Where 分句"
 
 #: src/SUMMARY.md:110 src/generics/new_types.md:1
 msgid "New Type Idiom"
-msgstr ""
+msgstr "新类型惯用法"
 
 #: src/SUMMARY.md:111 src/generics/assoc_items.md:1
 msgid "Associated items"
-msgstr ""
+msgstr "关联项"
 
 #: src/SUMMARY.md:112 src/generics/assoc_items/the_problem.md:1
 msgid "The Problem"
-msgstr ""
+msgstr "问题"
 
 #: src/SUMMARY.md:113 src/generics/assoc_items/types.md:1
 msgid "Associated types"
-msgstr ""
+msgstr "关联类型"
 
 #: src/SUMMARY.md:114 src/generics/phantom.md:1
 msgid "Phantom type parameters"
-msgstr ""
+msgstr "虚类型参数"
 
 #: src/SUMMARY.md:115 src/generics/phantom/testcase_units.md:1
 msgid "Testcase: unit clarification"
-msgstr ""
+msgstr "测试实例：单位澄清"
 
 #: src/SUMMARY.md:117 src/scope.md:1
 msgid "Scoping rules"
-msgstr ""
+msgstr "作用域规则"
 
 #: src/SUMMARY.md:118 src/scope/raii.md:1
 msgid "RAII"
-msgstr ""
+msgstr "RAII"
 
 #: src/SUMMARY.md:119 src/scope/move.md:1
 msgid "Ownership and moves"
-msgstr ""
+msgstr "所有权和移动"
 
 #: src/SUMMARY.md:121 src/scope/move/partial_move.md:1
 msgid "Partial moves"
-msgstr ""
+msgstr "部分移动"
 
 #: src/SUMMARY.md:122 src/scope/borrow.md:1
 msgid "Borrowing"
-msgstr ""
+msgstr "借用"
 
 #: src/SUMMARY.md:125 src/scope/borrow/ref.md:1
 msgid "The ref pattern"
-msgstr ""
+msgstr "ref 模式"
 
 #: src/SUMMARY.md:126 src/scope/lifetime.md:1
 msgid "Lifetimes"
-msgstr ""
+msgstr "生命周期"
 
 #: src/SUMMARY.md:127 src/scope/lifetime/explicit.md:1
 msgid "Explicit annotation"
-msgstr ""
+msgstr "显式注解"
 
 #: src/SUMMARY.md:130 src/scope/lifetime/struct.md:1
 msgid "Structs"
-msgstr ""
+msgstr "结构体"
 
 #: src/SUMMARY.md:133 src/scope/lifetime/lifetime_coercion.md:1
 msgid "Coercion"
-msgstr ""
+msgstr "强制转换"
 
 #: src/SUMMARY.md:134 src/scope/lifetime/static_lifetime.md:1
 msgid "Static"
-msgstr ""
+msgstr "静态"
 
 #: src/SUMMARY.md:135 src/scope/lifetime/elision.md:1
 msgid "Elision"
-msgstr ""
+msgstr "省略"
 
 #: src/SUMMARY.md:138 src/trait/derive.md:1
 msgid "Derive"
-msgstr ""
+msgstr "派生"
 
 #: src/SUMMARY.md:139 src/trait/dyn.md:1
 msgid "Returning Traits with `dyn`"
-msgstr ""
+msgstr "使用 `dyn` 返回特性"
 
 #: src/SUMMARY.md:140 src/trait/ops.md:1
 msgid "Operator Overloading"
-msgstr ""
+msgstr "运算符重载"
 
 #: src/SUMMARY.md:141 src/trait/drop.md:1
 msgid "Drop"
-msgstr ""
+msgstr "Drop"
 
 #: src/SUMMARY.md:142 src/trait/iter.md:1
 msgid "Iterators"
-msgstr ""
+msgstr "迭代器"
 
 #: src/SUMMARY.md:143 src/trait/impl_trait.md:1
 msgid "`impl Trait`"
-msgstr ""
+msgstr "`impl Trait`"
 
 #: src/SUMMARY.md:144 src/trait/clone.md:1
 msgid "Clone"
-msgstr ""
+msgstr "克隆"
 
 #: src/SUMMARY.md:145 src/trait/supertraits.md:1
 msgid "Supertraits"
-msgstr ""
+msgstr "父特质"
 
 #: src/SUMMARY.md:146 src/trait/disambiguating.md:1
 msgid "Disambiguating overlapping traits"
-msgstr ""
+msgstr "消除重叠特质的歧义"
 
 #: src/SUMMARY.md:148 src/macros.md:1
 msgid "macro_rules!"
-msgstr ""
+msgstr "macro_rules!"
 
 #: src/SUMMARY.md:149 src/macros/syntax.md:1
 msgid "Syntax"
-msgstr ""
+msgstr "语法"
 
 #: src/SUMMARY.md:150 src/macros/designators.md:1
 msgid "Designators"
-msgstr ""
+msgstr "指示符"
 
 #: src/SUMMARY.md:151 src/macros/overload.md:1
 msgid "Overload"
-msgstr ""
+msgstr "重载"
 
 #: src/SUMMARY.md:152 src/macros/repeat.md:1
 msgid "Repeat"
-msgstr ""
+msgstr "重复"
 
 #: src/SUMMARY.md:153 src/macros/dry.md:1
 msgid "DRY (Don't Repeat Yourself)"
-msgstr ""
+msgstr "DRY(不要重复自己)"
 
 #: src/SUMMARY.md:154
 msgid "DSL (Domain Specific Languages)"
-msgstr ""
+msgstr "DSL(领域特定语言)"
 
 #: src/SUMMARY.md:155
 msgid "Variadics"
-msgstr ""
+msgstr "可变参数"
 
 #: src/SUMMARY.md:157 src/error.md:1
 msgid "Error handling"
-msgstr ""
+msgstr "错误处理"
 
 #: src/SUMMARY.md:158 src/error/panic.md:1
 msgid "`panic`"
-msgstr ""
+msgstr "`panic`"
 
 #: src/SUMMARY.md:159
 msgid "`abort` & `unwind`"
-msgstr ""
+msgstr "`abort` 和 `unwind`"
 
 #: src/SUMMARY.md:160 src/error/option_unwrap.md:1
 msgid "`Option` & `unwrap`"
-msgstr ""
+msgstr "`Option` 和 `unwrap`"
 
 #: src/SUMMARY.md:161 src/error/option_unwrap/question_mark.md:1
 msgid "Unpacking options with `?`"
-msgstr ""
+msgstr "使用 `?` 解包 Option"
 
 #: src/SUMMARY.md:162 src/error/option_unwrap/map.md:1
 msgid "Combinators: `map`"
-msgstr ""
+msgstr "组合器：`map`"
 
 #: src/SUMMARY.md:163 src/error/option_unwrap/and_then.md:1
 msgid "Combinators: `and_then`"
-msgstr ""
+msgstr "组合器：`and_then`"
 
 #: src/SUMMARY.md:164
 msgid "Defaults: `or`, `or_else`, `get_or_insert`, `get_or_insert_with`"
-msgstr ""
+msgstr "默认值：`or`、`or_else`、`get_or_insert`、`get_or_insert_with`"
 
 #: src/SUMMARY.md:165 src/SUMMARY.md:183 src/error/result.md:1
 #: src/std/result.md:1
 msgid "`Result`"
-msgstr ""
+msgstr "`Result`"
 
 #: src/SUMMARY.md:166 src/error/result/result_map.md:1
 msgid "`map` for `Result`"
-msgstr ""
+msgstr "`Result` 的 `map`"
 
 #: src/SUMMARY.md:167 src/error/result/result_alias.md:1
 msgid "aliases for `Result`"
-msgstr ""
+msgstr "`Result` 的别名"
 
 #: src/SUMMARY.md:168 src/error/result/early_returns.md:1
 msgid "Early returns"
-msgstr ""
+msgstr "提前返回"
 
 #: src/SUMMARY.md:169 src/error/result/enter_question_mark.md:1
 msgid "Introducing `?`"
-msgstr ""
+msgstr "引入 `?`"
 
 #: src/SUMMARY.md:170 src/error/multiple_error_types.md:1
 msgid "Multiple error types"
-msgstr ""
+msgstr "多种错误类型"
 
 #: src/SUMMARY.md:171 src/error/multiple_error_types/option_result.md:1
 msgid "Pulling `Result`s out of `Option`s"
-msgstr ""
+msgstr "从 `Option` 中提取 `Result`"
 
 #: src/SUMMARY.md:172 src/error/multiple_error_types/define_error_type.md:1
 msgid "Defining an error type"
-msgstr ""
+msgstr "定义错误类型"
 
 #: src/SUMMARY.md:173 src/error/multiple_error_types/boxing_errors.md:1
 msgid "`Box`ing errors"
-msgstr ""
+msgstr "使用 `Box` 将错误装箱"
 
 #: src/SUMMARY.md:174 src/error/multiple_error_types/reenter_question_mark.md:1
 msgid "Other uses of `?`"
-msgstr ""
+msgstr "`?` 的其他用途"
 
 #: src/SUMMARY.md:175 src/error/multiple_error_types/wrap_error.md:1
 msgid "Wrapping errors"
-msgstr ""
+msgstr "包装错误"
 
 #: src/SUMMARY.md:176 src/error/iter_result.md:1
 msgid "Iterating over `Result`s"
-msgstr ""
+msgstr "遍历 `Result`"
 
 #: src/SUMMARY.md:178 src/std.md:1
 msgid "Std library types"
-msgstr ""
+msgstr "标准库类型"
 
 #: src/SUMMARY.md:179 src/std/box.md:1
 msgid "Box, stack and heap"
-msgstr ""
+msgstr "Box、栈和堆"
 
 #: src/SUMMARY.md:180 src/std/vec.md:1
 msgid "Vectors"
-msgstr ""
+msgstr "Vectors"
 
 #: src/SUMMARY.md:181 src/std/str.md:1
 msgid "Strings"
-msgstr ""
+msgstr "字符串"
 
 #: src/SUMMARY.md:182 src/std/option.md:1
 msgid "`Option`"
-msgstr ""
+msgstr "`Option`"
 
 #: src/SUMMARY.md:184 src/std/result/question_mark.md:1
 msgid "`?`"
-msgstr ""
+msgstr "`?`"
 
 #: src/SUMMARY.md:185 src/std/panic.md:1
 msgid "`panic!`"
-msgstr ""
+msgstr "`panic!`"
 
 #: src/SUMMARY.md:186 src/std/hash.md:1
 msgid "HashMap"
-msgstr ""
+msgstr "HashMap"
 
 #: src/SUMMARY.md:187 src/std/hash/alt_key_types.md:1
 msgid "Alternate/custom key types"
-msgstr ""
+msgstr "更改或自定义键类型"
 
 #: src/SUMMARY.md:188 src/std/hash/hashset.md:1
 msgid "HashSet"
-msgstr ""
+msgstr "HashSet"
 
 #: src/SUMMARY.md:189 src/std/rc.md:1
 msgid "`Rc`"
-msgstr ""
+msgstr "`Rc`"
 
 #: src/SUMMARY.md:190
 msgid "`Arc`"
-msgstr ""
+msgstr "`Arc`"
 
 #: src/SUMMARY.md:192 src/std_misc.md:1
 msgid "Std misc"
-msgstr ""
+msgstr "标准库中的其他内容"
 
 #: src/SUMMARY.md:193 src/std_misc.md:6 src/std_misc/threads.md:1
 msgid "Threads"
-msgstr ""
+msgstr "线程"
 
 #: src/SUMMARY.md:194 src/std_misc/threads/testcase_mapreduce.md:1
 msgid "Testcase: map-reduce"
-msgstr ""
+msgstr "测试实例：map-reduce"
 
 #: src/SUMMARY.md:195 src/std_misc.md:7 src/std_misc/channels.md:1
 msgid "Channels"
-msgstr ""
+msgstr "通道"
 
 #: src/SUMMARY.md:196 src/std_misc/path.md:1
 msgid "Path"
-msgstr ""
+msgstr "路径"
 
 #: src/SUMMARY.md:197 src/std_misc.md:8 src/std_misc/file.md:1
 msgid "File I/O"
-msgstr ""
+msgstr "文件 I/O"
 
 #: src/SUMMARY.md:198 src/std_misc/file/open.md:1
 msgid "`open`"
-msgstr ""
+msgstr "`open`"
 
 #: src/SUMMARY.md:199 src/std_misc/file/create.md:1
 msgid "`create`"
-msgstr ""
+msgstr "`create`"
 
 #: src/SUMMARY.md:200 src/std_misc/file/read_lines.md:1
 msgid "`read_lines`"
-msgstr ""
+msgstr "`read_lines`"
 
 #: src/SUMMARY.md:201 src/std_misc/process.md:1
 msgid "Child processes"
-msgstr ""
+msgstr "子进程"
 
 #: src/SUMMARY.md:202 src/std_misc/process/pipe.md:1
 msgid "Pipes"
-msgstr ""
+msgstr "管道"
 
 #: src/SUMMARY.md:203 src/std_misc/process/wait.md:1
 msgid "Wait"
-msgstr ""
+msgstr "等待"
 
 #: src/SUMMARY.md:204 src/std_misc/fs.md:1
 msgid "Filesystem Operations"
-msgstr ""
+msgstr "文件系统操作"
 
 #: src/SUMMARY.md:205 src/std_misc/arg.md:1
 msgid "Program arguments"
-msgstr ""
+msgstr "程序参数"
 
 #: src/SUMMARY.md:206 src/std_misc/arg/matching.md:1
 msgid "Argument parsing"
-msgstr ""
+msgstr "参数解析"
 
 #: src/SUMMARY.md:207 src/std_misc/ffi.md:1
 msgid "Foreign Function Interface"
-msgstr ""
+msgstr "外部函数接口"
 
 #: src/SUMMARY.md:209 src/cargo/test.md:1 src/testing.md:1
 msgid "Testing"
-msgstr ""
+msgstr "测试"
 
 #: src/SUMMARY.md:210 src/testing/unit_testing.md:1
 msgid "Unit testing"
-msgstr ""
+msgstr "单元测试"
 
 #: src/SUMMARY.md:211 src/testing/doc_testing.md:1
 msgid "Documentation testing"
-msgstr ""
+msgstr "文档测试"
 
 #: src/SUMMARY.md:212 src/testing/integration_testing.md:1
 msgid "Integration testing"
-msgstr ""
+msgstr "集成测试"
 
 #: src/SUMMARY.md:213
 msgid "Dev-dependencies"
-msgstr ""
+msgstr "开发依赖"
 
 #: src/SUMMARY.md:215 src/unsafe.md:1
 msgid "Unsafe Operations"
-msgstr ""
+msgstr "不安全操作"
 
 #: src/SUMMARY.md:216 src/unsafe/asm.md:1
 msgid "Inline assembly"
-msgstr ""
+msgstr "内联汇编"
 
 #: src/SUMMARY.md:218 src/compatibility.md:1
 msgid "Compatibility"
-msgstr ""
+msgstr "兼容性"
 
 #: src/SUMMARY.md:219 src/compatibility/raw_identifiers.md:1
 msgid "Raw identifiers"
-msgstr ""
+msgstr "原始标识符"
 
 #: src/SUMMARY.md:221 src/meta.md:1
 msgid "Meta"
-msgstr ""
+msgstr "补充"
 
 #: src/SUMMARY.md:222 src/meta/doc.md:1
 msgid "Documentation"
-msgstr ""
+msgstr "文档"
 
 #: src/SUMMARY.md:223 src/meta/playground.md:1
 msgid "Playground"
-msgstr ""
+msgstr "Playground"
 
 #: src/index.md:1
 msgid "Rust by Example"

--- a/po/zh.po
+++ b/po/zh.po
@@ -7040,6 +7040,7 @@ msgid ""
 "support for unit and integration testing ([see this chapter](https://doc.rust-"
 "lang.org/book/ch11-00-testing.html) in TRPL)."
 msgstr ""
+"我们知道测试对于任何软件都是不可或缺的！Rust 对单元测试和集成测试有一流的支持（参见《Rust 程序设计语言》中的[这一章](https://doc.rust-lang.org/book/ch11-00-testing.html)）。"
 
 #: src/cargo/test.md:8
 msgid ""
@@ -7047,6 +7048,7 @@ msgid ""
 "integration tests. Organizationally, we can place unit tests in the modules "
 "they test and integration tests in their own `tests/` directory:"
 msgstr ""
+"从上面链接的测试章节中，我们可以看到如何编写单元测试和集成测试。在组织上，我们可以将单元测试放在它们所测试的模块中，而将集成测试放在它们自己的 `tests/` 目录中："
 
 #: src/cargo/test.md:23
 msgid ""
@@ -7055,6 +7057,7 @@ msgid ""
 "is meant to test your library as if it were being called from a dependent "
 "crate."
 msgstr ""
+"`tests` 中的每个文件都是一个单独的[集成测试](https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests)，即旨在测试你的库，就像它被依赖的 crate 调用一样。"
 
 #: src/cargo/test.md:28
 msgid ""
@@ -7062,14 +7065,15 @@ msgid ""
 "testing styles: [Unit](../testing/unit_testing.md), [Doc](../testing/"
 "doc_testing.md), and [Integration](../testing/integration_testing.md)."
 msgstr ""
+"[测试](../testing.md)章节详细阐述了三种不同的测试风格：[单元](../testing/unit_testing.md)、[文档](../testing/doc_testing.md)和[集成](../testing/integration_testing.md)。"
 
 #: src/cargo/test.md:31
 msgid "`cargo` naturally provides an easy way to run all of your tests!"
-msgstr ""
+msgstr "`cargo` 提供了一个简单的方式运行所有测试！"
 
 #: src/cargo/test.md:37
 msgid "You should see output like this:"
-msgstr ""
+msgstr "你应该会看到类似这样的输出："
 
 #: src/cargo/test.md:39
 msgid ""
@@ -7088,10 +7092,24 @@ msgid ""
 "test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ cargo test\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.89 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 4 tests\n"
+"test test_bar ... ok\n"
+"test test_baz ... ok\n"
+"test test_foo_bar ... ok\n"
+"test test_foo ... ok\n"
+"\n"
+"test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n"
+"```"
 
 #: src/cargo/test.md:54
 msgid "You can also run tests whose name matches a pattern:"
-msgstr ""
+msgstr "你也可以运行名称匹配某个模式的测试："
 
 #: src/cargo/test.md:60
 msgid ""
@@ -7108,70 +7126,84 @@ msgid ""
 "test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ cargo test test_foo\n"
+"   Compiling blah v0.1.0 (file:///nobackup/blah)\n"
+"    Finished dev [unoptimized + debuginfo] target(s) in 0.35 secs\n"
+"     Running target/debug/deps/blah-d3b32b97275ec472\n"
+"\n"
+"running 2 tests\n"
+"test test_foo ... ok\n"
+"test test_foo_bar ... ok\n"
+"\n"
+"test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out\n"
+"```"
 
 #: src/cargo/test.md:73
 msgid ""
 "One word of caution: Cargo may run multiple tests concurrently, so make sure "
 "that they don't race with each other."
 msgstr ""
+"需要注意的是：Cargo 可能会并发运行多个测试，所以要确保它们之间不会相互竞争。"
 
 #: src/cargo/test.md:76
 msgid ""
 "One example of this concurrency causing issues is if two tests output to a "
 "file, such as below:"
 msgstr ""
+"这种并发可能导致问题的一个例子是，如果两个测试输出到同一个文件，比如下面这样："
 
 #: src/cargo/test.md:82
 msgid "// Import the necessary modules\n"
-msgstr ""
+msgstr "// 导入必要的模块\n"
 
 #: src/cargo/test.md:86
 msgid "// This test writes to a file\n"
-msgstr ""
+msgstr "// 这个测试写入一个文件\n"
 
 #: src/cargo/test.md:89 src/cargo/test.md:106
 msgid "// Opens the file ferris.txt or creates one if it doesn't exist.\n"
-msgstr ""
+msgstr "// 打开 ferris.txt 文件，如果不存在则创建一个。\n"
 
 #: src/cargo/test.md:93 src/cargo/test.md:110
 msgid "\"ferris.txt\""
-msgstr ""
+msgstr "\"ferris.txt\""
 
 #: src/cargo/test.md:94 src/cargo/test.md:111
 msgid "\"Failed to open ferris.txt\""
-msgstr ""
+msgstr "\"Failed to open ferris.txt\""
 
 #: src/cargo/test.md:96
 msgid "// Print \"Ferris\" 5 times.\n"
-msgstr ""
+msgstr "// 打印 \"Ferris\" 5 次。\n"
 
 #: src/cargo/test.md:98
 msgid "\"Ferris\\n\""
-msgstr ""
+msgstr "\"Ferris\\n\""
 
 #: src/cargo/test.md:99 src/cargo/test.md:116
 msgid "\"Could not write to ferris.txt\""
-msgstr ""
+msgstr "\"Could not write to ferris.txt\""
 
 #: src/cargo/test.md:103
 msgid "// This test tries to write to the same file\n"
-msgstr ""
+msgstr "// 这个测试尝试写入同一个文件\n"
 
 #: src/cargo/test.md:113
 msgid "// Print \"Corro\" 5 times.\n"
-msgstr ""
+msgstr "// 打印 \"Corro\" 5 次。\n"
 
 #: src/cargo/test.md:115
 msgid "\"Corro\\n\""
-msgstr ""
+msgstr "\"Corro\\n\""
 
 #: src/cargo/test.md:122
 msgid "Although the intent is to get the following:"
-msgstr ""
+msgstr "尽管预期的结果是得到以下内容："
 
 #: src/cargo/test.md:136
 msgid "What actually gets put into `ferris.txt` is this:"
-msgstr ""
+msgstr "实际上 `ferris.txt` 中的内容可能是这样的："
 
 #: src/cargo/build_scripts.md:3
 msgid ""
@@ -7180,12 +7212,14 @@ msgid ""
 "code generation, or some native code that needs to be compiled. To solve this "
 "problem we have build scripts that Cargo can run."
 msgstr ""
+"有时候常规的 `cargo` 构建是不够的。也许你的 crate 在 `cargo` 成功编译之前需要一些先决条件，比如代码生成，或者需要编译一些本地代码。为了解决这个问题，我们有 Cargo 可以运行的构建脚本。"
 
 #: src/cargo/build_scripts.md:8
 msgid ""
 "To add a build script to your package it can either be specified in the "
 "`Cargo.toml` as follows:"
 msgstr ""
+"要为你的包添加构建脚本，可以在 `Cargo.toml` 中指定，如下所示："
 
 #: src/cargo/build_scripts.md:11
 msgid ""
@@ -7195,16 +7229,22 @@ msgid ""
 "build = \"build.rs\"\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"...\n"
+"build = \"build.rs\"\n"
+"```"
 
 #: src/cargo/build_scripts.md:17
 msgid ""
 "Otherwise Cargo will look for a `build.rs` file in the project directory by "
 "default."
 msgstr ""
+"否则，Cargo 默认会在项目目录中寻找 `build.rs` 文件。"
 
 #: src/cargo/build_scripts.md:20
 msgid "How to use a build script"
-msgstr ""
+msgstr "如何使用构建脚本"
 
 #: src/cargo/build_scripts.md:22
 msgid ""
@@ -7212,6 +7252,7 @@ msgid ""
 "invoked prior to compiling anything else in the package. Hence it can be used "
 "to fulfill pre-requisites of your crate."
 msgstr ""
+"构建脚本只是另一个 Rust 文件，它会在编译包中的其他内容之前被编译和调用。因此，它可以用来满足你的 crate 的先决条件。"
 
 #: src/cargo/build_scripts.md:26
 msgid ""
@@ -7219,6 +7260,7 @@ msgid ""
 "here](https://doc.rust-lang.org/cargo/reference/environment-variables."
 "html#environment-variables-cargo-sets-for-build-scripts) that can be used."
 msgstr ""
+"Cargo 通过环境变量为脚本提供输入，这些环境变量[在这里指定](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)，可以被使用。"
 
 #: src/cargo/build_scripts.md:29
 msgid ""
@@ -7227,12 +7269,14 @@ msgid ""
 "be interpreted by Cargo directly and hence can be used to define parameters "
 "for the package's compilation."
 msgstr ""
+"脚本通过标准输出提供输出。所有打印的行都被写入 `target/debug/build/<pkg>/output`。此外，以 `cargo:` 为前缀的行将被 Cargo 直接解释，因此可以用来为包的编译定义参数。"
 
 #: src/cargo/build_scripts.md:34
 msgid ""
 "For further specification and examples have a read of the [Cargo "
 "specification](https://doc.rust-lang.org/cargo/reference/build-scripts.html)."
 msgstr ""
+"有关更多规范和示例，请阅读 [Cargo 规范](https://doc.rust-lang.org/cargo/reference/build-scripts.html)。"
 
 #: src/attribute.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -3670,6 +3670,7 @@ msgid ""
 "Primitive types can be converted to each other through [casting](types/cast."
 "md)."
 msgstr ""
+"原始类型可以通过[类型转换](types/cast.md)相互转换。"
 
 #: src/conversion.md:5
 msgid ""
@@ -3680,6 +3681,7 @@ msgid ""
 "specific ones for the more common cases, in particular when converting to and "
 "from `String`s."
 msgstr ""
+"Rust 通过使用[特质](trait.md)来处理自定义类型（即 `struct` 和 `enum`）之间的转换。通用转换将使用 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质。然而，对于更常见的情况，特别是在与 `String` 相互转换时，还有一些更具体的特质。"
 
 #: src/conversion/from_into.md:3
 msgid ""
@@ -3689,10 +3691,11 @@ msgid ""
 "are able to convert type A from type B, then it should be easy to believe "
 "that we should be able to convert type B to type A."
 msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质本质上是相互关联的，这实际上是其实现的一部分。如果你能够将类型 A 从类型 B 转换，那么我们应该很容易相信我们也能够将类型 B 转换为类型 A。"
 
 #: src/conversion/from_into.md:7
 msgid "`From`"
-msgstr ""
+msgstr "`From`"
 
 #: src/conversion/from_into.md:9
 msgid ""
@@ -3702,23 +3705,24 @@ msgid ""
 "are numerous implementations of this trait within the standard library for "
 "conversion of primitive and common types."
 msgstr ""
+"[`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 特质允许一个类型定义如何从另一个类型创建自己，从而提供了一种非常简单的机制来在几种类型之间进行转换。标准库中有许多这个特质的实现，用于原始类型和常见类型的转换。"
 
 #: src/conversion/from_into.md:14
 msgid "For example we can easily convert a `str` into a `String`"
-msgstr ""
+msgstr "例如，我们可以轻松地将 `str` 转换为 `String`"
 
 #: src/conversion/from_into.md:21
 msgid "We can do something similar for defining a conversion for our own type."
-msgstr ""
+msgstr "我们可以为自己的类型定义类似的转换。"
 
 #: src/conversion/from_into.md:39 src/conversion/from_into.md:68
 #: src/conversion/from_into.md:98
 msgid "\"My number is {:?}\""
-msgstr ""
+msgstr "\"My number is {:?}\""
 
 #: src/conversion/from_into.md:43
 msgid "`Into`"
-msgstr ""
+msgstr "`Into`"
 
 #: src/conversion/from_into.md:45
 msgid ""
@@ -3726,20 +3730,22 @@ msgid ""
 "simply the reciprocal of the `From` trait. It defines how to convert a type "
 "into another type."
 msgstr ""
+"[`Into`](https://doc.rust-lang.org/std/convert/trait.Into.html) 特质简单来说就是 `From` 特质的反向操作。它定义了如何将一个类型转换为另一个类型。"
 
 #: src/conversion/from_into.md:48
 msgid ""
 "Calling `into()` typically requires us to specify the result type as the "
 "compiler is unable to determine this most of the time."
 msgstr ""
+"调用 `into()` 通常需要我们指定结果类型，因为编译器大多数时候无法确定这一点。"
 
 #: src/conversion/from_into.md:66
 msgid "// Try removing the type annotation\n"
-msgstr ""
+msgstr "// 尝试移除类型注解\n"
 
 #: src/conversion/from_into.md:72
 msgid "`From` and `Into` are interchangable"
-msgstr ""
+msgstr "`From` 和 `Into` 是可互换的"
 
 #: src/conversion/from_into.md:74
 msgid ""
@@ -3749,14 +3755,15 @@ msgid ""
 "converse is not true: implementing `Into` for your type will not "
 "automatically provide it with an implementation of `From`."
 msgstr ""
+"`From` 和 `Into` 被设计为互补的。我们不需要为两个特质都提供实现。如果你为你的类型实现了 `From` 特质，`Into` 会在必要时调用它。但是请注意，反过来并不成立：为你的类型实现 `Into` 不会自动为它提供 `From` 的实现。"
 
 #: src/conversion/from_into.md:86
 msgid "// Define `From`\n"
-msgstr ""
+msgstr "// 定义 `From`\n"
 
 #: src/conversion/from_into.md:96
 msgid "// use `Into`\n"
-msgstr ""
+msgstr "// 使用 `Into`\n"
 
 #: src/conversion/try_from_try_into.md:3
 msgid ""
@@ -3767,22 +3774,23 @@ msgid ""
 "for fallible conversions, and as such, return [`Result`](https://doc.rust-"
 "lang.org/std/result/enum.Result.html)s."
 msgstr ""
+"与 [`From` 和 `Into`](from_into.html) 类似，[`TryFrom`](https://doc.rust-lang.org/std/convert/trait.TryFrom.html) 和 [`TryInto`](https://doc.rust-lang.org/std/convert/trait.TryInto.html) 是用于类型之间转换的泛型特质。与 `From`/`Into` 不同，`TryFrom`/`TryInto` 特质用于可能失败的转换，因此返回 [`Result`](https://doc.rust-lang.org/std/result/enum.Result.html)。"
 
 #: src/conversion/try_from_try_into.md:33
 msgid "// TryFrom\n"
-msgstr ""
+msgstr "// TryFrom\n"
 
 #: src/conversion/try_from_try_into.md:38
 msgid "// TryInto\n"
-msgstr ""
+msgstr "// TryInto\n"
 
 #: src/conversion/string.md:1
 msgid "To and from Strings"
-msgstr ""
+msgstr "字符串的相互转换"
 
 #: src/conversion/string.md:3
 msgid "Converting to String"
-msgstr ""
+msgstr "转换为字符串"
 
 #: src/conversion/string.md:5
 msgid ""
@@ -3794,14 +3802,15 @@ msgid ""
 "trait.ToString.html) and also allows printing the type as discussed in the "
 "section on [`print!`](../hello/print.md)."
 msgstr ""
+"将任何类型转换为 `String` 就像为该类型实现 [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) 特质一样简单。但是，你应该实现 [`fmt::Display`](https://doc.rust-lang.org/std/fmt/trait.Display.html) 特质，而不是直接实现 `ToString`。`fmt::Display` 会自动提供 [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html)，并且还允许打印类型，就像在 [`print!`](../hello/print.md) 部分讨论的那样。"
 
 #: src/conversion/string.md:19
 msgid "\"Circle of radius {}\""
-msgstr ""
+msgstr "\"Circle of radius {}\""
 
 #: src/conversion/string.md:29
 msgid "Parsing a String"
-msgstr ""
+msgstr "解析字符串"
 
 #: src/conversion/string.md:31
 msgid ""
@@ -3812,6 +3821,7 @@ msgid ""
 "inference or to specify the type to parse using the 'turbofish' syntax. Both "
 "alternatives are shown in the following example."
 msgstr ""
+"将字符串转换为许多类型是很有用的，但最常见的字符串操作之一是将它们从字符串转换为数字。惯用的方法是使用 [`parse`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) 函数，并通过类型推断或使用 'turbofish' 语法指定要解析的类型。以下示例展示了这两种方法。"
 
 #: src/conversion/string.md:37
 msgid ""
@@ -3820,10 +3830,11 @@ msgid ""
 "implemented for that type. This is implemented for numerous types within the "
 "standard library."
 msgstr ""
+"只要为该类型实现了 [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) 特质，这就会将字符串转换为指定的类型。标准库中为许多类型实现了这个特质。"
 
 #: src/conversion/string.md:43 src/std_misc/process/wait.md:10
 msgid "\"5\""
-msgstr ""
+msgstr "\"5\""
 
 #: src/conversion/string.md:44 src/error/result.md:33 src/error/result.md:68
 #: src/error/result/result_map.md:42 src/error/result/result_map.md:75
@@ -3831,11 +3842,11 @@ msgstr ""
 #: src/error/result/enter_question_mark.md:34
 #: src/error/result/enter_question_mark.md:67
 msgid "\"10\""
-msgstr ""
+msgstr "\"10\""
 
 #: src/conversion/string.md:47
 msgid "\"Sum: {:?}\""
-msgstr ""
+msgstr "\"Sum: {:?}\""
 
 #: src/conversion/string.md:51
 msgid ""
@@ -3843,10 +3854,11 @@ msgid ""
 "[`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait for "
 "that type."
 msgstr ""
+"要在用户定义的类型上获得这个功能，只需为该类型实现 [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) 特质。"
 
 #: src/conversion/string.md:74
 msgid "\"    3 \""
-msgstr ""
+msgstr "\"    3 \""
 
 #: src/expression.md:3
 msgid "A Rust program is (mostly) made up of a series of statements:"

--- a/po/zh.po
+++ b/po/zh.po
@@ -9811,7 +9811,7 @@ msgstr "// 创建一个整数用于 `coerce_static` 函数：\n"
 
 #: src/scope/lifetime/static_lifetime.md:55
 msgid "// Coerce `NUM` to lifetime of `lifetime_num`:\n"
-msgstr "// 将 `NUM` 强制转换为 `lifetime_num` 的生命周期：\n"
+msgstr "// 将 `NUM` 的生命周期强制转换为与 `lifetime_num` 一致：\n"
 
 #: src/scope/lifetime/static_lifetime.md:58
 msgid "\"coerced_static: {}\""
@@ -9819,7 +9819,7 @@ msgstr "\"coerced_static: {}\""
 
 #: src/scope/lifetime/static_lifetime.md:61
 msgid "\"NUM: {} stays accessible!\""
-msgstr "\"NUM: {} 仍然可访问！\""
+msgstr "\"NUM：{} 仍然可以访问！\""
 
 #: src/scope/lifetime/static_lifetime.md:65
 msgid ""
@@ -9830,7 +9830,7 @@ msgid ""
 "references. In that case it definitely doesn't live for the entire duration, "
 "but only for the leaking point onward."
 msgstr ""
-"由于 `'static` 引用只需要在程序生命周期的**剩余部分**有效，它们可以在程序执行过程中创建。为了演示，下面的例子使用 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) 动态创建 `'static` 引用。在这种情况下，它肯定不会存活整个程序的生命周期，而只是从泄漏点开始存在。"
+"`'static` 引用只需在程序生命周期的**剩余部分**有效，因此可以在程序执行过程中创建。为了演示这一点，下面的例子使用 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) 动态创建 `'static` 引用。在这种情况下，它显然不会存在于整个程序生命周期，而只是从泄漏点开始存在。"
 
 #: src/scope/lifetime/static_lifetime.md:90
 msgid "Trait bound"
@@ -9842,7 +9842,7 @@ msgid ""
 "references. Eg. the receiver can hold on to the type for as long as they want "
 "and it will never become invalid until they drop it."
 msgstr ""
-"作为 trait 约束，它表示该类型不包含任何非静态引用。例如，接收者可以随意保留该类型，并且它永远不会失效，直到他们放弃它为止。。"
+"作为 trait 约束时，它表示该类型不包含任何非静态引用。例如，接收者可以随意持有该类型，直到主动丢弃之前，它都不会变为无效。"
 
 #: src/scope/lifetime/static_lifetime.md:96
 msgid ""
@@ -9850,7 +9850,7 @@ msgid ""
 "`'static` lifetime bound, but a reference to that owned data generally does "
 "not:"
 msgstr ""
-"理解这一点很重要：任何拥有所有权的数据总是满足 `'static` 生命周期约束，但对该拥有所有权数据的引用通常不满足："
+"理解这一点很重要：任何拥有所有权的数据总是满足 `'static` 生命周期约束，但对该数据的引用通常不满足："
 
 #: src/scope/lifetime/static_lifetime.md:104
 msgid "\"'static value passed in is: {:?}\""
@@ -9858,19 +9858,19 @@ msgstr "\"传入的 'static 值是：{:?}\""
 
 #: src/scope/lifetime/static_lifetime.md:108
 msgid "// i is owned and contains no references, thus it's 'static:\n"
-msgstr "// i 是拥有所有权的，不包含任何引用，因此它是 'static 的：\n"
+msgstr "// i 拥有所有权且不包含任何引用，因此它是 'static 的：\n"
 
 #: src/scope/lifetime/static_lifetime.md:112
 msgid ""
 "// oops, &i only has the lifetime defined by the scope of\n"
 "    // main(), so it's not 'static:\n"
 msgstr ""
-"// 糟糕，&i 只有 main() 作用域定义的生命周期，\n"
+"// 糟糕，&i 的生命周期仅由 main() 的作用域定义，\n"
 "    // 所以它不是 'static 的：\n"
 
 #: src/scope/lifetime/static_lifetime.md:117
 msgid "The compiler will tell you:"
-msgstr "编译器会告诉你："
+msgstr "编译器会提示你："
 
 #: src/scope/lifetime/static_lifetime.md:133
 msgid "[`'static` constants](../../custom_types/constants.md)"
@@ -9883,7 +9883,7 @@ msgid ""
 "is known as elision. Elision exists in Rust solely because these patterns are "
 "common."
 msgstr ""
-"有些生命周期模式非常常见，因此借用检查器允许你省略它们以减少代码并提高可读性。这被称为省略。Rust 中存在省略仅仅是因为这些模式很常见。"
+"有些生命周期模式非常常见，因此借用检查器允许省略它们以减少代码量并提高可读性。这被称为省略。Rust 中的省略存在的唯一原因是这些模式很常见。"
 
 #: src/scope/lifetime/elision.md:8
 msgid ""
@@ -9891,7 +9891,7 @@ msgid ""
 "description of elision, see [lifetime elision](https://doc.rust-lang.org/book/"
 "ch10-03-lifetime-syntax.html#lifetime-elision) in the book."
 msgstr ""
-"以下代码展示了一些省略的例子。要更全面地了解省略，请参阅 Rust 程序设计语言中的[生命周期省略](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision)。"
+"以下代码展示了一些省略的例子。要更全面地了解省略，请参阅 Rust 程序设计语言中的[生命周期省略](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision)章节。"
 
 #: src/scope/lifetime/elision.md:12
 msgid ""
@@ -9939,7 +9939,7 @@ msgid ""
 "A `trait` is a collection of methods defined for an unknown type: `Self`. "
 "They can access other methods declared in the same trait."
 msgstr ""
-"`trait` 是为未知类型 `Self` 定义的一组方法的集合。它们可以访问在同一个 trait 中声明的其他方法。"
+"`trait` 是为未知类型 `Self` 定义的一组方法集合。这些方法可以访问同一 trait 中声明的其他方法。"
 
 #: src/trait.md:6
 msgid ""
@@ -9948,7 +9948,7 @@ msgid ""
 "the `Sheep` data type, allowing the use of methods from `Animal` with a "
 "`Sheep`."
 msgstr ""
-"trait 可以为任何数据类型实现。在下面的例子中，我们定义了 `Animal`，一组方法的集合。然后为 `Sheep` 数据类型实现 `Animal` `trait`，这样就可以对 `Sheep` 使用 `Animal` 中的方法。"
+"trait 可以为任何数据类型实现。在下面的例子中，我们定义了 `Animal`，一组方法的集合。然后为 `Sheep` 数据类型实现 `Animal` trait，这样就可以对 `Sheep` 使用 `Animal` 中的方法。"
 
 #: src/trait.md:15
 msgid ""
@@ -9962,7 +9962,7 @@ msgstr "// 方法签名；这些方法将返回一个字符串。\n"
 
 #: src/trait.md:22
 msgid "// Traits can provide default method definitions.\n"
-msgstr "// trait 可以提供默认的方法定义。\n"
+msgstr "// trait 可以提供默认的方法实现。\n"
 
 #: src/trait.md:24
 msgid "\"{} says {}\""
@@ -9982,35 +9982,35 @@ msgstr "\"{} 剃了个毛！\""
 
 #: src/trait.md:44 src/trait/dyn.md:17
 msgid "// Implement the `Animal` trait for `Sheep`.\n"
-msgstr "// 为 `Sheep` 实现 `Animal` trait。\n"
+msgstr "// 为 `Sheep` 实现 `Animal` trait\n"
 
 #: src/trait.md:47
 msgid "// `Self` is the implementor type: `Sheep`.\n"
-msgstr "// `Self` 是实现者类型：`Sheep`。\n"
+msgstr "// `Self` 是实现者类型，即 `Sheep`\n"
 
 #: src/trait.md:58
 msgid "\"baaaaah?\""
-msgstr "\"咩~?\""
+msgstr "\"咩～？\""
 
 #: src/trait.md:60 src/trait/dyn.md:21
 msgid "\"baaaaah!\""
-msgstr "\"咩~！\""
+msgstr "\"咩～！\""
 
 #: src/trait.md:64
 msgid "// Default trait methods can be overridden.\n"
-msgstr "// 默认的 trait 方法可以被重写。\n"
+msgstr "// 可以重写默认的 trait 方法\n"
 
 #: src/trait.md:66
 msgid "// For example, we can add some quiet contemplation.\n"
-msgstr "// 例如，我们可以添加一些安静的沉思。\n"
+msgstr "// 例如，我们可以添加一些安静的思考\n"
 
 #: src/trait.md:67
 msgid "\"{} pauses briefly... {}\""
-msgstr "\"{} 短暂停顿... {}\""
+msgstr "\"{} 短暂停顿…… {}\""
 
 #: src/trait.md:72
 msgid "// Type annotation is necessary in this case.\n"
-msgstr "// 在这种情况下类型标注是必要的。\n"
+msgstr "// 在这种情况下需要类型标注\n"
 
 #: src/trait.md:73
 msgid "\"Dolly\""
@@ -10018,7 +10018,7 @@ msgstr "\"多莉\""
 
 #: src/trait.md:74
 msgid "// TODO ^ Try removing the type annotations.\n"
-msgstr "// TODO ^ 尝试移除类型标注。\n"
+msgstr "// TODO ^ 尝试移除类型标注\n"
 
 #: src/trait/derive.md:3
 msgid ""
@@ -10026,11 +10026,12 @@ msgid ""
 "via the `#[derive]` [attribute](../attribute.md). These traits can still be "
 "manually implemented if a more complex behavior is required."
 msgstr ""
-"编译器能够通过 `#[derive]` [属性](../attribute.md)为一些 trait 提供基本实现。如果需要更复杂的行为，这些 trait 仍然可以手动实现。"
+"编译器可以通过 `#[derive]` [属性](../attribute.md)为某些 trait 提供基本实现。"
+"如果需要更复杂的行为，这些 trait 仍然可以手动实现。"
 
 #: src/trait/derive.md:7
 msgid "The following is a list of derivable traits:"
-msgstr "以下是可派生 trait 的列表："
+msgstr "以下是可派生的 trait 列表："
 
 #: src/trait/derive.md:8
 msgid ""
@@ -10081,11 +10082,11 @@ msgstr ""
 
 #: src/trait/derive.md:17
 msgid "// `Centimeters`, a tuple struct that can be compared\n"
-msgstr "// `Centimeters`，一个可以比较的元组结构体\n"
+msgstr "// `Centimeters`，一个可比较的元组结构体\n"
 
 #: src/trait/derive.md:20
 msgid "// `Inches`, a tuple struct that can be printed\n"
-msgstr "// `Inches`，一个可以打印的元组结构体\n"
+msgstr "// `Inches`，一个可打印的元组结构体\n"
 
 #: src/trait/derive.md:32
 msgid "// `Seconds`, a tuple struct with no additional attributes\n"
@@ -10097,7 +10098,7 @@ msgid ""
 "    //println!(\"One second looks like: {:?}\", _one_second);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 错误：`Seconds` 不能被打印；它没有实现 `Debug` trait\n"
+"// 错误：`Seconds` 无法打印，因为它没有实现 `Debug` trait\n"
 "    //println!(\"One second looks like: {:?}\", _one_second);\n"
 "    // TODO ^ 尝试取消这行的注释\n"
 
@@ -10108,7 +10109,7 @@ msgid ""
 "    //let _this_is_true = (_one_second == _one_second);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 错误：`Seconds` 不能被比较；它没有实现 `PartialEq` trait\n"
+"// 错误：`Seconds` 无法比较，因为它没有实现 `PartialEq` trait\n"
 "    //let _this_is_true = (_one_second == _one_second);\n"
 "    // TODO ^ 尝试取消这行的注释\n"
 
@@ -10126,7 +10127,7 @@ msgstr "\"更大\""
 
 #: src/trait/derive.md:60
 msgid "\"One foot is {} than one meter.\""
-msgstr "\"一英尺比一米 {}。\""
+msgstr "\"一英尺比一米{}\""
 
 #: src/trait/derive.md:65
 msgid "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
@@ -10140,7 +10141,7 @@ msgid ""
 "function that returns `Animal`, because its different implementations will "
 "need different amounts of memory."
 msgstr ""
-"Rust 编译器需要知道每个函数的返回类型需要多少空间。这意味着所有的函数都必须返回一个具体的类型。与其他语言不同，如果你有一个像 `Animal` 这样的 trait，你不能编写一个返回 `Animal` 的函数，因为它的不同实现需要不同的内存量。"
+"Rust 编译器需要知道每个函数的返回类型所需的内存空间。这意味着所有函数都必须返回一个具体类型。与其他语言不同，如果你有一个像 `Animal` 这样的 trait，你不能编写一个直接返回 `Animal` 的函数，因为它的不同实现可能需要不同大小的内存。"
 
 #: src/trait/dyn.md:5
 msgid ""
@@ -10150,7 +10151,7 @@ msgid ""
 "a statically-known size, and the compiler can guarantee it points to a heap-"
 "allocated `Animal`, we can return a trait from our function!"
 msgstr ""
-"然而，有一个简单的解决方法。我们的函数不直接返回一个 trait 对象，而是返回一个**包含**某个 `Animal` 的 `Box`。`box` 只是一个指向堆上某些内存的引用。因为引用有一个静态已知的大小，并且编译器可以保证它指向一个堆分配的 `Animal`，因此我们可以从函数中返回一个 trait！"
+"然而，有一个简单的解决方法。我们可以让函数返回一个**包含** `Animal` 的 `Box`，而不是直接返回 trait 对象。`Box` 本质上是一个指向堆内存的引用。由于引用的大小是静态已知的，且编译器可以保证它指向堆上分配的 `Animal`，这样我们就能从函数中返回一个 trait 了！"
 
 #: src/trait/dyn.md:7
 msgid ""
@@ -10158,7 +10159,7 @@ msgid ""
 "heap. So if your function returns a pointer-to-trait-on-heap in this way, you "
 "need to write the return type with the `dyn` keyword, e.g. `Box<dyn Animal>`."
 msgstr ""
-"Rust 在堆上分配内存时尽可能地明确。所以如果你的函数以这种方式返回一个指向堆上 trait 的指针，则需要使用 `dyn` 关键字来写返回类型，例如 `Box<dyn Animal>`。"
+"Rust 在堆上分配内存时力求明确。因此，如果你的函数以这种方式返回一个指向堆上 trait 的指针，你需要在返回类型中使用 `dyn` 关键字，例如 `Box<dyn Animal>`。"
 
 #: src/trait/dyn.md:14
 msgid "// Instance method signature\n"
@@ -10166,21 +10167,21 @@ msgstr "// 实例方法签名\n"
 
 #: src/trait/dyn.md:24
 msgid "// Implement the `Animal` trait for `Cow`.\n"
-msgstr "// 为 `Cow` 实现 `Animal` trait。\n"
+msgstr "// 为 `Cow` 实现 `Animal` trait\n"
 
 #: src/trait/dyn.md:28
 msgid "\"moooooo!\""
-msgstr "\"哞哞哞！\""
+msgstr "\"哞~哞~哞~\""
 
 #: src/trait/dyn.md:31
 msgid ""
 "// Returns some struct that implements Animal, but we don't know which one at "
 "compile time.\n"
-msgstr "// 返回某个实现了 Animal 的结构体，但在编译时我们并不知道是哪一个。\n"
+msgstr "// 返回某个实现了 Animal 的结构体，但在编译时我们并不知道具体是哪一个\n"
 
 #: src/trait/dyn.md:44
 msgid "\"You've randomly chosen an animal, and it says {}\""
-msgstr "\"你随机选择了一个动物，它说 {}\""
+msgstr "\"你随机选择了一个动物，它说：{}\""
 
 #: src/trait/ops.md:3
 msgid ""
@@ -10191,14 +10192,14 @@ msgid ""
 "`a.add(b)`). This `add` method is part of the `Add` trait. Hence, the `+` "
 "operator can be used by any implementor of the `Add` trait."
 msgstr ""
-"在 Rust 中，许多运算符可以通过 trait 来重载。也就是说，一些运算符可以根据其输入参数来完成不同的任务。这是可能的，因为运算符是方法调用的语法糖。例如，`a + b` 中的 `+` 运算符调用 `add` 方法（如 `a.add(b)`）。这个 `add` 方法是 `Add` trait 的一部分。因此，`+` 运算符可以被任何实现了 `Add` trait 的类型使用。"
+"在 Rust 中，许多运算符可以通过 trait 进行重载。这意味着某些运算符可以根据输入参数执行不同的任务。之所以可能，是因为运算符实际上是方法调用的语法糖。例如，`a + b` 中的 `+` 运算符会调用 `add` 方法（相当于 `a.add(b)`）。这个 `add` 方法是 `Add` trait 的一部分。因此，任何实现了 `Add` trait 的类型都可以使用 `+` 运算符。"
 
 #: src/trait/ops.md:9
 msgid ""
 "A list of the traits, such as `Add`, that overload operators can be found in "
 "[`core::ops`](https://doc.rust-lang.org/core/ops/)."
 msgstr ""
-"可以在 [`core::ops`](https://doc.rust-lang.org/core/ops/) 中找到重载运算符的 trait 列表，如 `Add`。"
+"可以在 [`core::ops`](https://doc.rust-lang.org/core/ops/) 模块中找到用于重载运算符的 trait 列表，如 `Add` 等。"
 
 #: src/trait/ops.md:22
 msgid ""
@@ -10207,8 +10208,8 @@ msgid ""
 "`Bar`.\n"
 "// The following block implements the operation: Foo + Bar = FooBar\n"
 msgstr ""
-"// `std::ops::Add` trait 用于指定 `+` 的功能。\n"
-"// 这里，我们创建 `Add<Bar>` - 这个 trait 用于与 `Bar` 类型的右操作数相加。\n"
+"// `std::ops::Add` trait 用于指定 `+` 的功能\n"
+"// 这里我们实现 `Add<Bar>` - 这个 trait 用于与 `Bar` 类型的右操作数相加\n"
 "// 下面的代码块实现了操作：Foo + Bar = FooBar\n"
 
 #: src/trait/ops.md:30
@@ -10222,9 +10223,9 @@ msgid ""
 "`Foo`.\n"
 "// This block implements the operation: Bar + Foo = BarFoo\n"
 msgstr ""
-"// 通过颠倒类型，我们最终实现了非交换加法。\n"
-"// 这里，我们创建 `Add<Foo>` - 这个 trait 用于与 `Foo` 类型的右操作数相加。\n"
-"// 这个代码块实现了操作：Bar + Foo = BarFoo\n"
+"// 通过交换类型顺序，我们实现了非交换加法。\n"
+"// 这里我们实现 `Add<Foo>` trait —— 用于处理右操作数类型为 `Foo` 的加法。\n"
+"// 此代码块实现了如下操作：Bar + Foo = BarFoo\n"
 
 #: src/trait/ops.md:43
 msgid "\"> Bar.add(Foo) was called\""
@@ -10258,7 +10259,8 @@ msgid ""
 "of scope. The main use of the `Drop` trait is to free the resources that the "
 "implementor instance owns."
 msgstr ""
-"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 只有一个方法：`drop`，当对象离开作用域时会自动调用该方法。`Drop` trait 的主要用途是释放实现者实例拥有的资源。"
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 只有一个方法：`drop`，"
+"它会在对象离开作用域时自动调用。`Drop` trait 的主要用途是释放实现该 trait 的实例所拥有的资源。"
 
 #: src/trait/drop.md:7
 msgid ""
@@ -10266,22 +10268,23 @@ msgid ""
 "implement the `Drop` trait to free resources. The `Drop` trait can also be "
 "manually implemented for any custom data type."
 msgstr ""
-"`Box`、`Vec`、`String`、`File` 和 `Process` 是一些实现了 `Drop` trait 以释放资源的类型例子。`Drop` trait 也可以为任何自定义数据类型手动实现。"
+"`Box`、`Vec`、`String`、`File` 和 `Process` 是一些实现了 `Drop` trait 以释放资源的类型示例。"
+"你也可以为任何自定义数据类型手动实现 `Drop` trait。"
 
 #: src/trait/drop.md:11
 msgid ""
 "The following example adds a print to console to the `drop` function to "
 "announce when it is called."
 msgstr ""
-"下面的例子在 `drop` 函数中添加了一个控制台打印，以宣告它何时被调用。"
+"下面的例子在 `drop` 函数中添加了一个控制台打印，用于宣告它被调用的时机。"
 
 #: src/trait/drop.md:18
 msgid "// This trivial implementation of `drop` adds a print to console.\n"
-msgstr "// 这个简单的 `drop` 实现添加了一个控制台打印。\n"
+msgstr "// 这个简单的 `drop` 实现添加了一个控制台打印\n"
 
 #: src/trait/drop.md:22
 msgid "\"> Dropping {}\""
-msgstr "\"> 正在丢弃 {}\""
+msgstr "\"> 正在释放 {}\""
 
 #: src/trait/drop.md:27 src/std_misc/path.md:33 src/std_misc/fs.md:44
 #: src/std_misc/fs.md:87
@@ -10326,11 +10329,11 @@ msgstr "\"刚刚退出了块 A\""
 
 #: src/trait/drop.md:46
 msgid "// Variable can be manually dropped using the `drop` function\n"
-msgstr "// 变量可以使用 `drop` 函数手动丢弃\n"
+msgstr "// 可以使用 `drop` 函数手动释放变量\n"
 
 #: src/trait/drop.md:48
 msgid "// TODO ^ Try commenting this line\n"
-msgstr "// TODO ^ 尝试注释掉这一行\n"
+msgstr "// TODO ^ 试试注释掉这一行\n"
 
 #: src/trait/drop.md:50
 msgid "\"end of the main function\""
@@ -10341,15 +10344,16 @@ msgid ""
 "// `_a` *won't* be `drop`ed again here, because it already has been\n"
 "    // (manually) `drop`ed\n"
 msgstr ""
-"// `_a` 在这里**不会**被再次 `drop`，因为它已经被\n"
-"    // （手动）`drop` 过了\n"
+"// `_a` 在这里**不会**被再次 `drop`，因为它已经\n"
+"    // 被（手动）`drop` 过了\n"
 
 #: src/trait/iter.md:3
 msgid ""
 "The [`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
 "trait is used to implement iterators over collections such as arrays."
 msgstr ""
-"[`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) trait 用于实现对诸如数组等集合的迭代器。"
+"[`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) trait "
+"用于实现对数组等集合的迭代器。"
 
 #: src/trait/iter.md:6
 msgid ""
@@ -10357,7 +10361,8 @@ msgid ""
 "may be manually defined in an `impl` block or automatically defined (as in "
 "arrays and ranges)."
 msgstr ""
-"该 trait 只要求为 `next` 元素定义一个方法，这个方法可以在 `impl` 块中手动定义，也可以自动定义（如在数组和区间中）。"
+"该 trait 只要求为 `next` 元素定义一个方法，这个方法可以在 `impl` 块中手动定义，"
+"也可以自动定义（如在数组和区间中）。"
 
 #: src/trait/iter.md:10
 msgid ""
@@ -10365,7 +10370,8 @@ msgid ""
 "some collections into iterators using the [`.into_iter()`](https://doc.rust-"
 "lang.org/std/iter/trait.IntoIterator.html) method."
 msgstr ""
-"为方便起见, `for` 结构使用 [`.into_iter()`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) 方法将一些集合转换为迭代器。"
+"为了在常见情况下提供便利，`for` 结构使用 [`.into_iter()`](https://doc.rust-"
+"lang.org/std/iter/trait.IntoIterator.html) 方法将某些集合转换为迭代器。"
 
 #: src/trait/iter.md:18
 msgid ""
@@ -10392,9 +10398,9 @@ msgstr ""
 "// 这里，我们使用 `.curr` 和 `.next` 定义序列。\n"
 "    // 返回类型是 `Option<T>`：\n"
 "    //     * 当 `Iterator` 结束时，返回 `None`。\n"
-"    //     * 否则，下一个值被包装在 `Some` 中并返回。\n"
-"    // 我们在返回类型中使用 Self::Item，这样我们可以更改\n"
-"    // 类型而不必更新函数签名。\n"
+"    //     * 否则，将下一个值包装在 `Some` 中并返回。\n"
+"    // 我们在返回类型中使用 Self::Item，这样可以更改\n"
+"    // 类型而无需更新函数签名。\n"
 
 #: src/trait/iter.md:37
 msgid ""
@@ -10402,7 +10408,7 @@ msgid ""
 "        // will never return `None`, and `Some` is always returned.\n"
 msgstr ""
 "// 由于斐波那契序列没有终点，`Iterator` \n"
-"        // 永远不会返回 `None`，总是返回 `Some`。\n"
+"        // 永远不会返回 `None`，始终返回 `Some`。\n"
 
 #: src/trait/iter.md:42
 msgid "// Returns a Fibonacci sequence generator\n"
@@ -10410,7 +10416,7 @@ msgstr "// 返回一个斐波那契序列生成器\n"
 
 #: src/trait/iter.md:49
 msgid "// `0..3` is an `Iterator` that generates: 0, 1, and 2.\n"
-msgstr "// `0..3` 是一个生成：0、1 和 2 的 `Iterator`。\n"
+msgstr "// `0..3` 是一个生成 0、1 和 2 的 `Iterator`。\n"
 
 #: src/trait/iter.md:52
 msgid "\"Four consecutive `next` calls on 0..3\""
@@ -10441,7 +10447,7 @@ msgstr "\"> {}\""
 
 #: src/trait/iter.md:65
 msgid "// The `take(n)` method reduces an `Iterator` to its first `n` terms.\n"
-msgstr "// `take(n)` 方法将 `Iterator` 缩减为其前 `n` 项。\n"
+msgstr "// `take(n)` 方法将 `Iterator` 限制为其前 `n` 项。\n"
 
 #: src/trait/iter.md:66
 msgid "\"The first four terms of the Fibonacci sequence are: \""
@@ -10451,7 +10457,7 @@ msgstr "\"斐波那契序列的前四项是：\""
 msgid ""
 "// The `skip(n)` method shortens an `Iterator` by dropping its first `n` "
 "terms.\n"
-msgstr "// `skip(n)` 方法通过丢弃前 `n` 项来缩短 `Iterator`。\n"
+msgstr "// `skip(n)` 方法通过跳过前 `n` 项来缩短 `Iterator`。\n"
 
 #: src/trait/iter.md:72
 msgid "\"The next four terms of the Fibonacci sequence are: \""
@@ -10459,7 +10465,7 @@ msgstr "\"斐波那契序列的接下来四项是：\""
 
 #: src/trait/iter.md:79
 msgid "// The `iter` method produces an `Iterator` over an array/slice.\n"
-msgstr "// `iter` 方法在数组/切片上产生一个 `Iterator`。\n"
+msgstr "// `iter` 方法为数组/切片创建一个 `Iterator`。\n"
 
 #: src/trait/iter.md:80
 msgid "\"Iterate the following array {:?}\""
@@ -10486,20 +10492,22 @@ msgid ""
 "If your function is generic over a trait but you don't mind the specific "
 "type, you can simplify the function declaration using `impl Trait` as the "
 "type of the argument."
-msgstr "如果函数对某个 trait 是泛型的，但与具体类型无关，你可以使用 `impl Trait` 作为参数的类型来简化函数声明。"
+msgstr ""
+"如果你的函数对某个 trait 是泛型的，但不关心具体类型，"
+"你可以使用 `impl Trait` 作为参数类型来简化函数声明。"
 
 #: src/trait/impl_trait.md:12
 msgid "For example, consider the following code:"
-msgstr "例如，想想以下代码："
+msgstr "例如，考虑以下代码："
 
 #: src/trait/impl_trait.md:18 src/trait/impl_trait.md:37
 msgid "// For each line in the source\n"
-msgstr "// 对于数据源中的每一行\n"
+msgstr "// 遍历数据源中的每一行\n"
 
 #: src/trait/impl_trait.md:20 src/trait/impl_trait.md:39
 msgid ""
 "// If the line was read successfully, process it, if not, return the error\n"
-msgstr "// 如果行读取成功，处理它，如果不成功，返回错误\n"
+msgstr "// 如果成功读取行，则处理它；否则，返回错误\n"
 
 #: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40 src/std/str.md:41
 msgid "','"
@@ -10511,11 +10519,11 @@ msgstr "// 按逗号分割行\n"
 
 #: src/trait/impl_trait.md:22 src/trait/impl_trait.md:41
 msgid "// Remove leading and trailing whitespace\n"
-msgstr "// 移除首尾的空白\n"
+msgstr "// 去除首尾空白\n"
 
 #: src/trait/impl_trait.md:23 src/trait/impl_trait.md:42
 msgid "// Collect all strings in a row into a Vec<String>\n"
-msgstr "// 将一行中的所有字符串收集到 Vec<String> 中\n"
+msgstr "// 将该行的所有字符串收集到 Vec<String> 中\n"
 
 #: src/trait/impl_trait.md:26 src/trait/impl_trait.md:45
 msgid "// Collect all lines into a Vec<Vec<String>>\n"
@@ -10527,14 +10535,19 @@ msgid ""
 "implements BufRead, such as `BufReader<File>` or `[u8]`, but it's not "
 "important what type `R` is, and `R` is only used to declare the type of "
 "`src`, so the function can also be written as:"
-msgstr "`parse_csv_document` 是泛型的，允许它接受任何实现了 BufRead 的类型，比如 `BufReader<File>` 或 `[u8]`，但 `R` 的具体类型并不重要，`R` 只用于声明 `src` 的类型，所以这个函数也可以写成："
+msgstr ""
+"`parse_csv_document` 是泛型函数，可以接受任何实现了 `BufRead` 的类型，"
+"如 `BufReader<File>` 或 `[u8]`。但具体的 `R` 类型并不重要，`R` 仅用于声明 `src` 的类型。"
+"因此，这个函数也可以写成："
 
 #: src/trait/impl_trait.md:49
 msgid ""
 "Note that using `impl Trait` as an argument type means that you cannot "
 "explicitly state what form of the function you use, i.e. `parse_csv_document::"
 "<std::io::Empty>(std::io::empty())` will not work with the second example."
-msgstr "注意，使用 `impl Trait` 作为参数类型意味着你不能显式地声明你使用的函数形式，例如 `parse_csv_document::<std::io::Empty>(std::io::empty())` 在第二个例子中将不起作用。"
+msgstr ""
+"注意，使用 `impl Trait` 作为参数类型意味着你无法显式指定使用的函数形式。"
+"例如，`parse_csv_document::<std::io::Empty>(std::io::empty())` 在第二个例子中将无法工作。"
 
 #: src/trait/impl_trait.md:52
 msgid "As a return type"
@@ -10551,13 +10564,17 @@ msgstr "如果函数返回一个实现了 `MyTrait` 的类型，你可以将其�
 msgid ""
 "// This function combines two `Vec<i32>` and returns an iterator over it.\n"
 "// Look how complicated its return type is!\n"
-msgstr "// 这个函数组合两个 `Vec<i32>` 并返回一个迭代器。\n// 看看它的返回类型有多复杂！\n"
+msgstr ""
+"// 这个函数合并两个 `Vec<i32>` 并返回一个迭代器。\n"
+"// 看看它的返回类型有多复杂！\n"
 
 #: src/trait/impl_trait.md:69
 msgid ""
 "// This is the exact same function, but its return type uses `impl Trait`.\n"
 "// Look how much simpler it is!\n"
-msgstr "// 这是完全相同的函数，但它的返回类型使用了 `impl Trait`。\n// 看看它有多简单！\n"
+msgstr ""
+"// 这是完全相同的函数，但它的返回类型使用了 `impl Trait`。\n"
+"// 看看它变得多么简单！\n"
 
 #: src/trait/impl_trait.md:88
 msgid "\"all done\""
@@ -10569,11 +10586,14 @@ msgid ""
 "closure has its own unnamed concrete type. Before `impl Trait` syntax, you "
 "had to allocate on the heap in order to return a closure. But now you can do "
 "it all statically, like this:"
-msgstr "更重要的是，某些 Rust 类型无法写出来。例如，每个闭包都有自己的未命名具体类型。在 `impl Trait` 语法之前，你必须在堆上分配才能返回一个闭包。但现在你可以完全静态地做到这一点，像这样："
+msgstr ""
+"更重要的是，某些 Rust 类型无法直接写出。例如，每个闭包都有自己的未命名具体类型。"
+"在 `impl Trait` 语法出现之前，你必须在堆上分配内存才能返回闭包。"
+"但现在你可以完全静态地做到这一点，像这样："
 
 #: src/trait/impl_trait.md:98
 msgid "// Returns a function that adds `y` to its input\n"
-msgstr "// 返回一个将 `y` 加到其输入的函数\n"
+msgstr "// 返回一个将 `y` 加到输入值上的函数\n"
 
 #: src/trait/impl_trait.md:110
 msgid ""
@@ -10582,29 +10602,37 @@ msgid ""
 "closure types don't have names, you can't write out an explicit return type "
 "if your function returns iterators with closures. But with `impl Trait` you "
 "can do this easily:"
-msgstr "你还可以使用 `impl Trait` 来返回使用 `map` 或 `filter` 闭包的迭代器！这使得使用 `map` 和 `filter` 更加容易。因为闭包类型没有名称，如果你的函数返回带有闭包的迭代器，你就无法写出显式的返回类型。但使用 `impl Trait`，你可以轻松做到这一点："
+msgstr ""
+"你还可以使用 `impl Trait` 返回一个使用 `map` 或 `filter` 闭包的迭代器！"
+"这使得使用 `map` 和 `filter` 更加容易。由于闭包类型没有名称，"
+"如果你的函数返回带有闭包的迭代器，你无法写出显式的返回类型。"
+"但使用 `impl Trait`，你可以轻松实现："
 
 #: src/trait/clone.md:3
 msgid ""
 "When dealing with resources, the default behavior is to transfer them during "
 "assignments or function calls. However, sometimes we need to make a copy of "
 "the resource as well."
-msgstr "在处理资源时，默认行为是在赋值或函数调用期间转移它们。然而，有时我们也需要复制资源。"
+msgstr ""
+"在处理资源时，默认行为是在赋值或函数调用期间转移它们。"
+"然而，有时我们也需要复制资源。"
 
 #: src/trait/clone.md:7
 msgid ""
 "The [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait "
 "helps us do exactly this. Most commonly, we can use the `.clone()` method "
 "defined by the `Clone` trait."
-msgstr "[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait 帮助我们实现这一点。最常见的是，我们可以使用 `Clone` trait 定义的 `.clone()` 方法。"
+msgstr ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait "
+"帮助我们实现这一点。最常见的是，我们可以使用 `Clone` trait 定义的 `.clone()` 方法。"
 
 #: src/trait/clone.md:11
 msgid "// A unit struct without resources\n"
-msgstr "// 一个没有资源的单元结构体\n"
+msgstr "// 一个不包含资源的单元结构体\n"
 
 #: src/trait/clone.md:14
 msgid "// A tuple struct with resources that implements the `Clone` trait\n"
-msgstr "// 一个带有资源并实现了 `Clone` trait 的元组结构体\n"
+msgstr "// 一个包含资源并实现了 `Clone` trait 的元组结构体\n"
 
 #: src/trait/clone.md:20
 msgid "// Instantiate `Unit`\n"
@@ -10632,11 +10660,11 @@ msgstr "// 实例化 `Pair`\n"
 
 #: src/trait/clone.md:33
 msgid "// Move `pair` into `moved_pair`, moves resources\n"
-msgstr "// 将 `pair` 移动到 `moved_pair`，移动资源\n"
+msgstr "// 将 `pair` 移动到 `moved_pair`，资源也随之移动\n"
 
 #: src/trait/clone.md:35
 msgid "\"moved: {:?}\""
-msgstr "\"移动: {:?}\""
+msgstr "\"已移动: {:?}\""
 
 #: src/trait/clone.md:37
 msgid ""
@@ -10654,7 +10682,7 @@ msgstr "// 将 `moved_pair` 克隆到 `cloned_pair`（包括资源）\n"
 
 #: src/trait/clone.md:43
 msgid "// Drop the moved original pair using std::mem::drop\n"
-msgstr "// 使用 std::mem::drop 丢弃移动的原始对\n"
+msgstr "// 使用 std::mem::drop 丢弃已移动的原始对\n"
 
 #: src/trait/clone.md:46
 msgid ""
@@ -10663,7 +10691,7 @@ msgid ""
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
 "// 错误！`moved_pair` 已被丢弃\n"
-"    //println!(\"移动并丢弃: {:?}\", moved_pair);\n"
+"    //println!(\"已移动并丢弃: {:?}\", moved_pair);\n"
 "    // TODO ^ 尝试取消注释此行\n"
 
 #: src/trait/clone.md:50
@@ -10678,14 +10706,15 @@ msgstr "\"克隆: {:?}\""
 msgid ""
 "Rust doesn't have \"inheritance\", but you can define a trait as being a "
 "superset of another trait. For example:"
-msgstr "Rust 没有"继承"，但你可以将一个 trait 定义为另一个 trait 的超集。例如："
+msgstr ""
+"Rust 没有“继承”，但你可以将一个 trait 定义为另一个 trait 的超集。例如："
 
 #: src/trait/supertraits.md:10
 msgid ""
 "// Person is a supertrait of Student.\n"
 "// Implementing Student requires you to also impl Person.\n"
 msgstr ""
-"// Person 是 Student 的超级 trait。\n"
+"// Person 是 Student 的超 trait。\n"
 "// 实现 Student 需要你同时实现 Person。\n"
 
 #: src/trait/supertraits.md:20
@@ -10695,8 +10724,8 @@ msgid ""
 "// and Student. Implementing CompSciStudent requires you to impl both "
 "supertraits.\n"
 msgstr ""
-"// CompSciStudent（计算机科学学生）是 Programmer \n"
-"// 和 Student 的子 trait。实现 CompSciStudent 需要你实现两个超级 trait。\n"
+"// CompSciStudent（计算机科学学生）是 Programmer 和 Student 的子 trait。\n"
+"// 实现 CompSciStudent 需要你实现两个超 trait。\n"
 
 #: src/trait/supertraits.md:29
 msgid ""
@@ -10711,7 +10740,7 @@ msgid ""
 "org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-"
 "functionality-within-another-trait)"
 msgstr ""
-"[《Rust 程序设计语言》中关于父级 trait 的章节](https://doc.rust-lang."
+"[《Rust 程序设计语言》中关于超 trait 的章节](https://doc.rust-lang."
 "org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-"
 "functionality-within-another-trait)"
 
@@ -10721,22 +10750,22 @@ msgid ""
 "the same name for a function? For example, many traits might have a method "
 "named `get()`. They might even have different return types!"
 msgstr ""
-"一个类型可以实现许多不同的 trait。如果两个 trait 都要求函数使用相同的名称怎么办？"
-"例如，许多 trait 可能都有一个名为 `get()` 的方法。它们甚至可能有不同的返回类型！"
+"一个类型可以实现多个不同的 trait。如果两个 trait 都要求函数使用相同的名称，该怎么办？"
+"例如，许多 trait 可能都有一个名为 `get()` 的方法，它们甚至可能有不同的返回类型！"
 
 #: src/trait/disambiguating.md:7
 msgid ""
 "Good news: because each trait implementation gets its own `impl` block, it's "
 "clear which trait's `get` method you're implementing."
 msgstr ""
-"好消息是：因为每个 trait 实现都有自己的 `impl` 块，所以很清楚你正在实现哪个 trait 的 `get` 方法。"
+"好消息是：由于每个 trait 实现都有自己的 `impl` 块，因此很容易分清楚你正在实现哪个 trait 的 `get` 方法。"
 
 #: src/trait/disambiguating.md:10
 msgid ""
 "What about when it comes time to _call_ those methods? To disambiguate "
 "between them, we have to use Fully Qualified Syntax."
 msgstr ""
-"那么当需要**调用**这些方法时呢？为了消除它们之间的歧义，我们必须使用完全限定语法。"
+"那么在调用这些方法时又该如何处理呢？为了消除它们之间的歧义，我们必须使用完全限定语法。"
 
 #: src/trait/disambiguating.md:15
 msgid "// Get the selected username out of this widget\n"
@@ -10762,8 +10791,8 @@ msgid ""
 "    // named `get`.\n"
 "    // println!(\"{}\", form.get());\n"
 msgstr ""
-"// 如果你取消注释这一行，你会得到一个错误，说\n"
-"    // \"找到多个 `get`\"。因为毕竟有多个\n"
+"// 如果你取消注释这一行，你会得到一个错误，提示\n"
+"    // \"找到多个 `get`\"。这是因为确实存在多个\n"
 "    // 名为 `get` 的方法。\n"
 "    // println!(\"{}\", form.get());\n"
 
@@ -10787,11 +10816,14 @@ msgid ""
 "into abstract syntax trees, rather than string preprocessing, so you don't "
 "get unexpected precedence bugs."
 msgstr ""
-"Rust 提供了一个强大的宏系统，允许元编程。正如你在前面章节中看到的，宏看起来像函数，除了它们的名字以感叹号 `!` 结尾，但是宏不是生成函数调用，而是展开成源代码，然后与程序的其余部分一起编译。然而，与 C 和其他语言中的宏不同，Rust 宏被展开成抽象语法树，而不是字符串预处理，所以你不会遇到意外的优先级错误。"
+"Rust 提供了一个强大的宏系统，支持元编程。正如你在前面章节中所看到的，宏看起来像函数，"
+"只是它们的名字以感叹号 `!` 结尾。但与生成函数调用不同，宏会展开成源代码，然后与程序的其余部分一起编译。"
+"与 C 和其他语言中的宏不同，Rust 宏展开成抽象语法树，而不是进行字符串预处理，"
+"因此你不会遇到意外的优先级错误。"
 
 #: src/macros.md:11
 msgid "Macros are created using the `macro_rules!` macro."
-msgstr "宏是使用 `macro_rules!` 宏创建的。"
+msgstr "宏是使用 `macro_rules!` 宏来创建的。"
 
 #: src/macros.md:14
 msgid "// This is a simple macro named `say_hello`.\n"
@@ -10803,7 +10835,7 @@ msgstr "// `()` 表示该宏不接受任何参数。\n"
 
 #: src/macros.md:18
 msgid "// The macro will expand into the contents of this block.\n"
-msgstr "// 宏将展开成这个块的内容。\n"
+msgstr "// 宏将展开成这个代码块的内容。\n"
 
 #: src/macros.md:19
 msgid "\"Hello!\""
@@ -10815,7 +10847,7 @@ msgstr "// 这个调用将展开成 `println!(\"Hello!\")`\n"
 
 #: src/macros.md:29
 msgid "So why are macros useful?"
-msgstr "那么为什么宏是有用的呢？"
+msgstr "那么，为什么宏是有用的呢？"
 
 #: src/macros.md:31
 msgid ""
@@ -10823,14 +10855,15 @@ msgid ""
 "functionality in multiple places but with different types. Often, writing a "
 "macro is a useful way to avoid repeating code. (More on this later)"
 msgstr ""
-"不要重复自己。在许多情况下，你可能需要在多个地方使用类似的功能，但类型不同。通常，编写宏是避免重复代码的有用方法。（稍后会详细介绍）"
+"不要重复自己。在许多情况下，你可能需要在多个地方使用相似的功能，但类型不同。"
+"通常，编写宏是避免代码重复的有效方法。（稍后会详细介绍）"
 
 #: src/macros.md:35
 msgid ""
 "Domain-specific languages. Macros allow you to define special syntax for a "
 "specific purpose. (More on this later)"
 msgstr ""
-"领域特定语言。宏允许你为特定目的定义特殊语法。（稍后会详细介绍）"
+"领域特定语言。宏允许你为特定目的定义专门的语法。（稍后会详细介绍）"
 
 #: src/macros.md:38
 msgid ""
@@ -10838,7 +10871,8 @@ msgid ""
 "variable number of arguments. An example is `println!` which could take any "
 "number of arguments, depending on the format string. (More on this later)"
 msgstr ""
-"可变参数接口。有时你想定义一个接受可变数量参数的接口。一个例子是 `println!`，它可以根据格式字符串接受任意数量的参数。（稍后会详细介绍）"
+"可变参数接口。有时你可能想定义一个接受可变数量参数的接口。"
+"例如 `println!`，它可以根据格式字符串接受任意数量的参数。（稍后会详细介绍）"
 
 #: src/macros/syntax.md:3
 msgid ""
@@ -10882,7 +10916,7 @@ msgstr "// `stringify!` 宏将 `ident` 转换为字符串。\n"
 
 #: src/macros/designators.md:14
 msgid "\"You called {:?}()\""
-msgstr "\"You called {:?}()\""
+msgstr "\"你调用了 {:?}()\""
 
 #: src/macros/designators.md:19
 msgid "// Create functions named `foo` and `bar` with the above macro.\n"
@@ -10908,7 +10942,7 @@ msgstr "\"{:?} = {:?}\""
 
 #: src/macros/designators.md:42
 msgid "// Recall that blocks are expressions too!\n"
-msgstr "// 回想一下，代码块也是表达式！\n"
+msgstr "// 记住，代码块也是表达式！\n"
 
 #: src/macros/designators.md:51
 msgid "These are some of the available designators:"
@@ -10963,14 +10997,14 @@ msgid ""
 "For a complete list, see the [Rust Reference](https://doc.rust-lang.org/"
 "reference/macros-by-example.html)."
 msgstr ""
-"完整列表详见 [Rust 参考](https://doc.rust-lang.org/reference/macros-by-example.html)。"
+"完整列表请参阅 [Rust 参考手册](https://doc.rust-lang.org/reference/macros-by-example.html)。"
 
 #: src/macros/overload.md:3
 msgid ""
 "Macros can be overloaded to accept different combinations of arguments. In "
 "that regard, `macro_rules!` can work similarly to a match block:"
 msgstr ""
-"宏可以被重载以接受不同的参数组合。在这方面，`macro_rules!` 的作用类似于 match 块："
+"宏可以被重载以接受不同的参数组合。在这方面，`macro_rules!` 的工作方式类似于 match 块："
 
 #: src/macros/overload.md:7
 msgid ""
@@ -10978,7 +11012,7 @@ msgid ""
 "// in different ways depending on how you invoke it:\n"
 msgstr ""
 "// `test!` 将以不同的方式比较 `$left` 和 `$right`\n"
-"// 取决于你如何调用它：\n"
+"// 具体取决于你如何调用它：\n"
 
 #: src/macros/overload.md:10
 msgid ""
@@ -10990,7 +11024,7 @@ msgstr ""
 
 #: src/macros/overload.md:13
 msgid "\"{:?} and {:?} is {:?}\""
-msgstr "\"{:?} and {:?} is {:?}\""
+msgstr "\"{:?} 和 {:?} 是 {:?}\""
 
 #: src/macros/overload.md:18
 msgid "// ^ each arm must end with a semicolon.\n"
@@ -11014,11 +11048,12 @@ msgid ""
 "one or more expression, separated by commas. Also note that the semicolon is "
 "optional on the last case."
 msgstr ""
-"在下面的例子中，用 `$(...),+` 包围匹配器将匹配一个或多个由逗号分隔的表达式。还要注意，最后一个情况的分号是可选的。"
+"在下面的例子中，用 `$(...),+` 包围匹配器将匹配一个或多个由逗号分隔的表达式。"
+"另外请注意，最后一个情况的分号是可选的。"
 
 #: src/macros/repeat.md:12
 msgid "// `find_min!` will calculate the minimum of any number of arguments.\n"
-msgstr "// `find_min!` 将计算任意数量参数的最小值。\n"
+msgstr "// `find_min!` 将计算任意数量参数中的最小值。\n"
 
 #: src/macros/repeat.md:14
 msgid "// Base case:\n"
@@ -11030,7 +11065,7 @@ msgstr "// `$x` 后面至少跟着一个 `$y,`\n"
 
 #: src/macros/repeat.md:18
 msgid "// Call `find_min!` on the tail `$y`\n"
-msgstr "// 对尾部 `$y` 调用 `find_min!`\n"
+msgstr "// 对剩余的 `$y` 递归调用 `find_min!`\n"
 
 #: src/macros/dry.md:3
 msgid ""
@@ -11038,14 +11073,16 @@ msgid ""
 "and/or test suites. Here is an example that implements and tests the `+=`, "
 "`*=` and `-=` operators on `Vec<T>`:"
 msgstr ""
-"宏允许通过提取函数和/或测试套件的公共部分来编写 DRY（Don't Repeat Yourself）代码。这里有一个在 `Vec<T>` 上实现和测试 `+=`、`*=` 和 `-=` 运算符的例子："
+"宏通过提取函数和/或测试套件的共同部分，使我们能够编写符合 DRY（Don't Repeat Yourself）原则的代码。"
+"下面是一个在 `Vec<T>` 上实现并测试 `+=`、`*=` 和 `-=` 运算符的示例："
 
 #: src/macros/dry.md:11
 msgid ""
 "// The `tt` (token tree) designator is used for\n"
 "    // operators and tokens.\n"
 msgstr ""
-"// `tt`（标记树, token tree）指示符用于运算符和标记。\n"
+"// `tt`（token tree，标记树）指示符用于\n"
+"    // 运算符和标记。\n"
 
 #: src/macros/dry.md:15
 msgid "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
@@ -11065,7 +11102,7 @@ msgstr "// 测试 `add_assign`、`mul_assign` 和 `sub_assign`。\n"
 
 #: src/macros/dsl.md:1
 msgid "Domain Specific Languages (DSLs)"
-msgstr "领域特定语言（DSLs）"
+msgstr "领域特定语言（DSL）"
 
 #: src/macros/dsl.md:3
 msgid ""
@@ -11074,14 +11111,15 @@ msgid ""
 "looks like a small language. This allows you to define concise or intuitive "
 "syntax for some special functionality (within bounds)."
 msgstr ""
-"DSL 是嵌入在 Rust 宏中的一种小型"语言"。它是完全有效的 Rust，因为宏系统会展开为普通的 Rust 结构，但它看起来像一种小型语言。这允许你为一些特殊功能定义简洁或直观的语法（在一定范围内）。"
+"DSL 是嵌入在 Rust 宏中的一种微型"语言"。它是完全有效的 Rust 代码，因为宏系统会将其展开为普通的 Rust 结构，"
+"但它看起来像一种小型语言。这使你能够为某些特定功能定义简洁或直观的语法（在一定范围内）。"
 
 #: src/macros/dsl.md:8
 msgid ""
 "Suppose that I want to define a little calculator API. I would like to supply "
 "an expression and have the output printed to console."
 msgstr ""
-"假设我想定义一个小型计算器 API。我希望提供一个表达式，并将输出打印到控制台。"
+"假设我想定义一个简单的计算器 API。我希望提供一个表达式，并将计算结果打印到控制台。"
 
 #: src/macros/dsl.md:15
 msgid "// Force types to be unsigned integers\n"
@@ -11093,7 +11131,7 @@ msgstr "\"{} = {}\""
 
 #: src/macros/dsl.md:23
 msgid "// hehehe `eval` is _not_ a Rust keyword!\n"
-msgstr "// 看到了吧，`eval` 可并不是 Rust 的关键字！\n"
+msgstr "// 嘿嘿，`eval` 可不是 Rust 的关键字哦！\n"
 
 #: src/macros/dsl.md:32 src/macros/variadics.md:35
 msgid "Output:"
@@ -11130,7 +11168,7 @@ msgstr ""
 msgid ""
 "We can extend our `calculate!` macro from the previous section to be variadic:"
 msgstr ""
-"我们可以扩展前一节的 `calculate!` 宏，使其成为可变参数的："
+"我们可以将上一节的 `calculate!` 宏扩展为可变参数的形式："
 
 #: src/macros/variadics.md:11
 msgid "// The pattern for a single `eval`\n"
@@ -11146,7 +11184,7 @@ msgstr "// 递归分解多个 `eval`\n"
 
 #: src/macros/variadics.md:27
 msgid "// Look ma! Variadic `calculate!`!\n"
-msgstr "// 妈妈快看！可变参数的 `calculate!`！\n"
+msgstr "// 瞧瞧！这是可变参数的 `calculate!`！\n"
 
 #: src/error.md:3
 msgid ""
@@ -11155,7 +11193,8 @@ msgid ""
 "would clearly be problematic. Noticing and explicitly managing those errors "
 "saves the rest of the program from various pitfalls."
 msgstr ""
-"错误处理是处理可能失败情况的过程。例如，读取文件失败然后继续使用那个**错误的**输入显然会有问题。注意并明确管理这些错误可以使程序的其余部分避免各种陷阱。"
+"错误处理是处理可能出现失败情况的过程。例如，读取文件失败后继续使用那个**错误的**输入显然会导致问题。"
+"注意并明确管理这些错误可以使程序的其他部分避免各种陷阱。"
 
 #: src/error.md:8
 msgid ""
@@ -11163,7 +11202,8 @@ msgid ""
 "the following subchapters. They all have more or less subtle differences and "
 "different use cases. As a rule of thumb:"
 msgstr ""
-"Rust 中有多种处理错误的方法，在接下来的小节中会一一介绍。它们或多或少都有些细微差别和不同的使用场景。总的来说："
+"Rust 中有多种处理错误的方法，这些方法将在接下来的小节中详细介绍。它们或多或少都有一些细微的差别和不同的使用场景。"
+"一般来说："
 
 #: src/error.md:12
 msgid ""
@@ -11173,7 +11213,8 @@ msgid ""
 "descriptive `unimplemented` is better. In tests `panic` is a reasonable way "
 "to explicitly fail."
 msgstr ""
-"显式的 `panic` 主要用于测试和处理不可恢复的错误。在原型开发中这可能有用，例如在处理尚未实现的函数时，但在这些情况下，更具描述性的 `unimplemented` 更好。在测试中，`panic` 是一种合理的显式失败方式。"
+"显式的 `panic` 主要用于测试和处理不可恢复的错误。在原型开发中，它可能会有用，例如在处理尚未实现的函数时。"
+"但在这些情况下，使用更具描述性的 `unimplemented` 会更好。在测试中，`panic` 是一种合理的显式失败方式。"
 
 #: src/error.md:17
 msgid ""
@@ -11184,7 +11225,9 @@ msgid ""
 "to be a value. However `expect` is more useful since it lets you specify an "
 "error message in case something goes wrong anyway."
 msgstr ""
-"`Option` 类型用于值是可选的情况，或者缺少值不是错误条件的情况。例如目录的父目录 - `/` 和 `C:` 就没有父目录。在处理 `Option` 时，对于原型设计和绝对确定有值的情况，使用 `unwrap` 是可以的。然而，`expect` 更有用，因为它允许你指定一个错误消息，以防万一出错。"
+"`Option` 类型用于值是可选的情况，或者缺少值不构成错误条件的情况。例如目录的父目录 - `/` 和 `C:` 就没有父目录。"
+"在处理 `Option` 时，对于原型设计和绝对确定有值的情况，使用 `unwrap` 是可以的。然而，`expect` 更有用，"
+"因为它允许你指定一个错误消息，以防万一出错。"
 
 #: src/error.md:24
 msgid ""
@@ -11192,7 +11235,8 @@ msgid ""
 "with the problem, use `Result`. You can `unwrap` and `expect` them as well "
 "(please don't do that unless it's a test or quick prototype)."
 msgstr ""
-"当有可能出错且调用者必须处理问题时，使用 `Result`。你也可以对它们使用 `unwrap` 和 `expect`（除非是测试或快速原型，否则请不要这样做）。"
+"当有可能出错且调用者必须处理问题时，请使用 `Result`。你也可以对它们使用 `unwrap` 和 `expect`"
+"（除非是测试或快速原型，否则请不要这样做）。"
 
 #: src/error.md:28
 msgid ""
@@ -11200,7 +11244,7 @@ msgid ""
 "section in the [official book](https://doc.rust-lang.org/book/ch09-00-error-"
 "handling.html)."
 msgstr ""
-"关于错误处理更详尽的内容，请参阅[官方文档](https://doc.rust-lang.org/book/ch09-00-error-handling.html)中的错误处理章节。"
+"关于错误处理更详尽的讨论，请参阅[官方文档](https://doc.rust-lang.org/book/ch09-00-error-handling.html)中的错误处理章节。"
 
 #: src/error/panic.md:3
 msgid ""
@@ -11208,7 +11252,8 @@ msgid ""
 "error message, starts unwinding the stack, and usually exits the program. "
 "Here, we explicitly call `panic` on our error condition:"
 msgstr ""
-"我们将看到的最简单的错误处理机制是 `panic`。它会打印一条错误消息，开始展开栈，并通常会退出程序。在这里，我们在错误条件下显式调用 `panic`："
+"我们将看到的最简单的错误处理机制是 `panic`。它会打印一条错误消息，开始展开栈，并通常会退出程序。"
+"在这里，我们在错误条件下显式调用 `panic`："
 
 #: src/error/panic.md:9 src/error/abort_unwind.md:10
 msgid "// You shouldn't drink too much sugary beverages.\n"
@@ -11219,31 +11264,31 @@ msgstr "// 你不应该喝太多含糖饮料。\n"
 #: src/error/abort_unwind.md:51 src/error/option_unwrap.md:32
 #: src/error/option_unwrap.md:43 src/error/option_unwrap.md:50
 msgid "\"lemonade\""
-msgstr "\"lemonade\""
+msgstr "\"柠檬水\""
 
 #: src/error/panic.md:10 src/error/option_unwrap.md:43
 msgid "\"AAAaaaaa!!!!\""
-msgstr "\"AAAaaaaa!!!!\""
+msgstr "\"啊啊啊啊啊！！！！\""
 
 #: src/error/panic.md:12 src/error/abort_unwind.md:18
 #: src/error/abort_unwind.md:45
 msgid "\"Some refreshing {} is all I need.\""
-msgstr "\"{} 就是我所需要的。\""
+msgstr "\"来点清爽的{}就是我现在需要的。\""
 
 #: src/error/panic.md:16 src/error/abort_unwind.md:23
 #: src/error/abort_unwind.md:50 src/error/option_unwrap.md:49
 msgid "\"water\""
-msgstr "\"water\""
+msgstr "\"水\""
 
 #: src/error/panic.md:18
 msgid "\"still water\""
-msgstr "\"still water\""
+msgstr "\"纯净水\""
 
 #: src/error/panic.md:22
 msgid ""
 "The first call to `drink` works. The second panics and thus the third is "
 "never called."
-msgstr "第一次调用 `drink` 正常工作。第二次调用会 panic，因此第三次调用永远不会被执行。"
+msgstr "第一次调用 `drink` 正常执行。第二次调用会引发 panic，因此第三次调用永远不会被执行。"
 
 #: src/error/abort_unwind.md:1
 msgid "`abort` and `unwind`"
@@ -11254,17 +11299,17 @@ msgid ""
 "The previous section illustrates the error handling mechanism `panic`.  "
 "Different code paths can be conditionally compiled based on the panic "
 "setting. The current values available are `unwind` and `abort`."
-msgstr "上一节说明了错误处理机制 `panic`。不同的代码路径可以根据 panic 设置进行条件编译。当前可用的值是 `unwind` 和 `abort`。"
+msgstr "上一节介绍了错误处理机制 `panic`。可以根据 panic 设置有条件地编译不同的代码路径。当前可用的值有 `unwind` 和 `abort`。"
 
 #: src/error/abort_unwind.md:6
 msgid ""
 "Building on the prior lemonade example, we explicitly use the panic strategy "
 "to exercise different lines of code."
-msgstr "基于之前的柠檬水示例，我们显式使用 panic 策略来执行不同的代码行。"
+msgstr "基于之前的柠檬水示例，我们明确使用 panic 策略来执行不同的代码行。"
 
 #: src/error/abort_unwind.md:12
 msgid "\"abort\""
-msgstr "\"abort\""
+msgstr "\"中止\""
 
 #: src/error/abort_unwind.md:13 src/error/abort_unwind.md:38
 msgid "\"This is not your party. Run!!!!\""
@@ -11272,13 +11317,13 @@ msgstr "\"这不是你的派对。快跑！！！！\""
 
 #: src/error/abort_unwind.md:15 src/error/abort_unwind.md:33
 msgid "\"Spit it out!!!!\""
-msgstr "\"吐出来！！！！\""
+msgstr "\"快吐出来！！！！\""
 
 #: src/error/abort_unwind.md:28
 msgid ""
 "Here is another example focusing on rewriting `drink()` and explicitly use "
 "the `unwind` keyword."
-msgstr "这里是另一个示例，重点是重写 `drink()` 并显式使用 `unwind` 关键字。"
+msgstr "这里是另一个示例，重点是重写 `drink()` 函数并明确使用 `unwind` 关键字。"
 
 #: src/error/abort_unwind.md:31 src/error/abort_unwind.md:36
 msgid "\"unwind\""
@@ -11296,7 +11341,7 @@ msgid ""
 "told our program to `panic` if we drink a sugary lemonade. But what if we "
 "expect _some_ drink but don't receive one? That case would be just as bad, so "
 "it needs to be handled!"
-msgstr "在上一个例子中，我们展示了如何主动引发程序失败。我们告诉程序在喝含糖柠檬水时 `panic`。但如果我们期望得到**某种**饮料却没有收到呢？这种情况同样糟糕，所以需要处理！"
+msgstr "在上一个例子中，我们展示了如何主动引发程序失败。我们让程序在喝含糖柠檬水时触发 `panic`。但如果我们期望得到**某种**饮料却没有收到呢？这种情况同样糟糕，所以需要处理！"
 
 #: src/error/option_unwrap.md:8
 msgid ""
@@ -11309,7 +11354,7 @@ msgstr "我们**可以**像处理柠檬水那样对空字符串（`\"\"`）进�
 msgid ""
 "An `enum` called `Option<T>` in the `std` library is used when absence is a "
 "possibility. It manifests itself as one of two \"options\":"
-msgstr "`std` 库中名为 `Option<T>` 的 `enum` 用于处理可能存在缺失的情况。它表现为两个"选项"之一："
+msgstr "`std` 库中的 `Option<T>` 枚举用于处理可能存在缺失的情况。它表现为两个"选项"之一："
 
 #: src/error/option_unwrap.md:15
 msgid "`Some(T)`: An element of type `T` was found"
@@ -11323,7 +11368,7 @@ msgstr "`None`：没有找到元素"
 msgid ""
 "These cases can either be explicitly handled via `match` or implicitly with "
 "`unwrap`. Implicit handling will either return the inner element or `panic`."
-msgstr "这些情况可以通过 `match` 显式处理，也可以用 `unwrap` 隐式处理。隐式处理要么返回内部元素，要么 `panic`。"
+msgstr "这些情况可以通过 `match` 显式处理，也可以用 `unwrap` 隐式处理。隐式处理要么返回内部元素，要么触发 `panic`。"
 
 #: src/error/option_unwrap.md:21
 msgid ""
@@ -11332,7 +11377,7 @@ msgid ""
 "otherwise leaves us with a less meaningful output than explicit handling. In "
 "the following example, explicit handling yields a more controlled result "
 "while retaining the option to `panic` if desired."
-msgstr "注意，可以使用 [expect](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect) 手动自定义 `panic`，但 `unwrap` 相比显式处理会留下一个不太有意义的输出。在下面的例子中，显式处理产生了一个更可控的结果，同时保留了在需要时 `panic` 的选项。"
+msgstr "注意，可以使用 [`expect`](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect) 手动自定义 `panic`，但 `unwrap` 相比显式处理会产生一个不太有意义的输出。在下面的例子中，显式处理产生了一个更可控的结果，同时保留了在需要时触发 `panic` 的选项。"
 
 #: src/error/option_unwrap.md:27
 msgid ""
@@ -11344,7 +11389,7 @@ msgstr ""
 
 #: src/error/option_unwrap.md:30
 msgid "// Specify a course of action for each case.\n"
-msgstr "// 为每种情况指定一个行动方案。\n"
+msgstr "// 为每种情况指定一个处理方案。\n"
 
 #: src/error/option_unwrap.md:32
 msgid "\"Yuck! Too sugary.\""
@@ -11363,20 +11408,20 @@ msgid ""
 "// Others will `panic` before drinking sugary drinks.\n"
 "// All drinks are handled implicitly using `unwrap`.\n"
 msgstr ""
-"// 其他人在喝含糖饮料前会 `panic`。\n"
+"// 其他人在喝含糖饮料前会触发 `panic`。\n"
 "// 所有饮料都使用 `unwrap` 隐式处理。\n"
 
 #: src/error/option_unwrap.md:41
 msgid "// `unwrap` returns a `panic` when it receives a `None`.\n"
-msgstr "// 当 `unwrap` 收到 `None` 时会返回一个 `panic`。\n"
+msgstr "// 当 `unwrap` 收到 `None` 时会触发 `panic`。\n"
 
 #: src/error/option_unwrap.md:45
 msgid "\"I love {}s!!!!!\""
-msgstr "\"我爱 {}！！！！！\""
+msgstr "\"我超爱{}！！！！！\""
 
 #: src/error/option_unwrap.md:57
 msgid "\"coffee\""
-msgstr "\"coffee\""
+msgstr "\"咖啡\""
 
 #: src/error/option_unwrap/question_mark.md:3
 msgid ""
@@ -11384,7 +11429,7 @@ msgid ""
 "to use the `?` operator. If `x` is an `Option`, then evaluating `x?` will "
 "return the underlying value if `x` is `Some`, otherwise it will terminate "
 "whatever function is being executed and return `None`."
-msgstr "你可以使用 `match` 语句来解包 `Option`，但使用 `?` 运算符通常更容易。如果 `x` 是一个 `Option`，那么求值 `x?` 将在 `x` 是 `Some` 时返回底层值，否则它将终止正在执行的函数并返回 `None`。"
+msgstr "你可以使用 `match` 语句来解包 `Option`，但使用 `?` 运算符通常更简便。如果 `x` 是一个 `Option`，那么求值 `x?` 将在 `x` 是 `Some` 时返回其内部值，否则它将终止当前执行的函数并返回 `None`。"
 
 #: src/error/option_unwrap/question_mark.md:10
 msgid ""
@@ -11393,8 +11438,8 @@ msgid ""
 "    // gets assigned to `next_age`\n"
 msgstr ""
 "// 如果 `current_age` 是 `None`，这将返回 `None`。\n"
-"\t// 如果 `current_age` 是 `Some`，内部的 `u8` 值 + 1\n"
-"    // 被赋值给 `next_age`\n"
+"\t// 如果 `current_age` 是 `Some`，内部的 `u8` 值加 1\n"
+"    // 后被赋值给 `next_age`\n"
 
 #: src/error/option_unwrap/question_mark.md:14
 msgid "\"Next year I will be {}\""
@@ -11417,7 +11462,8 @@ msgid ""
 "        // is easier.\n"
 msgstr ""
 "// 如果没有 `?` 运算符，这将需要许多嵌套的 `match` 语句。\n"
-"        // 这将需要更多的代码 - 试着自己写一下，看看哪个更容易。\n"
+"        // 这将需要更多的代码 - 试着自己写一下，看看哪种方式\n"
+"        // 更容易。\n"
 
 #: src/error/option_unwrap/map.md:3
 msgid ""
@@ -11426,20 +11472,27 @@ msgid ""
 "input. In these cases, [combinators](https://doc.rust-lang.org/reference/"
 "glossary.html#combinator) can be used to manage control flow in a modular "
 "fashion."
-msgstr "`match` 是处理 `Option` 的有效方法。然而，你最终可能会发现大量使用它会变得乏味，特别是对于只在有输入时才有效的操作。在这些情况下，可以使用[组合器](https://doc.rust-lang.org/reference/glossary.html#combinator)以模块化的方式管理控制流。"
+msgstr ""
+"`match` 是处理 `Option` 的有效方法。然而，频繁使用可能会让人感到繁琐，"
+"尤其是在只有输入时才有效的操作中。在这些情况下，可以使用"
+"[组合器](https://doc.rust-lang.org/reference/glossary.html#combinator)"
+"以模块化的方式管理控制流。"
 
 #: src/error/option_unwrap/map.md:8
 msgid ""
 "`Option` has a built in method called `map()`, a combinator for the simple "
 "mapping of `Some -> Some` and `None -> None`. Multiple `map()` calls can be "
 "chained together for even more flexibility."
-msgstr "`Option` 有一个内置方法叫做 `map()`，它是一个组合器，用于简单地将 `Some -> Some` 和 `None -> None` 进行映射。多个 `map()` 调用可以链接在一起，以获得更大的灵活性。"
+msgstr ""
+"`Option` 有一个内置方法 `map()`，这是一个用于简单映射 `Some -> Some` 和 "
+"`None -> None` 的组合器。多个 `map()` 调用可以链式使用，从而提供更大的灵活性。"
 
 #: src/error/option_unwrap/map.md:12
 msgid ""
 "In the following example, `process()` replaces all functions previous to it "
 "while staying compact."
-msgstr "在下面的例子中，`process()` 替换了之前的所有函数，同时保持代码简洁。"
+msgstr ""
+"在下面的例子中，`process()` 函数以简洁的方式替代了之前的所有函数。"
 
 #: src/error/option_unwrap/map.md:23
 msgid ""
@@ -11461,7 +11514,8 @@ msgstr ""
 msgid ""
 "// Cooking food. Here, we showcase `map()` instead of `match` for case "
 "handling.\n"
-msgstr "// 烹饪食物。这里，我们展示了使用 `map()` 而不是 `match` 来处理情况。\n"
+msgstr ""
+"// 烹饪食物。这里我们展示了使用 `map()` 而非 `match` 来处理不同情况。\n"
 
 #: src/error/option_unwrap/map.md:46
 msgid ""
@@ -11469,30 +11523,33 @@ msgid ""
 "// We chain multiple uses of `map()` to simplify the code.\n"
 msgstr ""
 "// 一个按顺序剥皮、切碎和烹饪食物的函数。\n"
-"// 我们链接多个 `map()` 的使用来简化代码。\n"
+"// 我们通过链式调用多个 `map()` 来简化代码。\n"
 
 #: src/error/option_unwrap/map.md:54
 msgid "// Check whether there's food or not before trying to eat it!\n"
-msgstr "// 在尝试吃之前检查是否有食物！\n"
+msgstr "// 在尝试吃之前，先检查是否有食物！\n"
 
 #: src/error/option_unwrap/map.md:58
 msgid "\"Mmm. I love {:?}\""
-msgstr "\"嗯。我喜欢 {:?}\""
+msgstr "\"嗯，我喜欢 {:?}\""
 
 #: src/error/option_unwrap/map.md:59
 msgid "\"Oh no! It wasn't edible.\""
-msgstr "\"哦不！这不能吃。\""
+msgstr "\"哎呀！这不能吃。\""
 
 #: src/error/option_unwrap/map.md:70
 msgid "// Let's try the simpler looking `process()` now.\n"
-msgstr "// 现在让我们试试看起来更简单的 `process()`。\n"
+msgstr "// 现在让我们试试看起来更简洁的 `process()` 函数。\n"
 
 #: src/error/option_unwrap/map.md:81
 msgid ""
 "[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
 "option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/"
 "option/enum.Option.html#method.map)"
-msgstr "[闭包](../../fn/closures.md)，[`Option`](https://doc.rust-lang.org/std/option/enum.Option.html)，[`Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)"
+msgstr ""
+"[闭包](../../fn/closures.md)、[`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html)、[`Option::map()`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html#method.map)"
 
 #: src/error/option_unwrap/and_then.md:3
 msgid ""
@@ -11501,20 +11558,29 @@ msgid ""
 "the nested `Option<Option<T>>`. Chaining multiple calls together can then "
 "become confusing. That's where another combinator called `and_then()`, known "
 "in some languages as flatmap, comes in."
-msgstr "`map()` 被描述为一种可链式调用的方式来简化 `match` 语句。然而，在返回 `Option<T>` 的函数上使用 `map()` 会导致嵌套的 `Option<Option<T>>`。链接多个调用可能会变得令人困惑。这就是另一个称为 `and_then()` 的组合器（在一些语言中称为 flatmap）发挥作用的地方。"
+msgstr ""
+"`map()` 被描述为一种可链式调用的方式来简化 `match` 语句。然而，在返回 "
+"`Option<T>` 的函数上使用 `map()` 会导致嵌套的 `Option<Option<T>>`。链式调用"
+"多个这样的函数可能会变得令人困惑。这时，另一个称为 `and_then()` 的组合器"
+"（在某些语言中称为 flatmap）就派上用场了。"
 
 #: src/error/option_unwrap/and_then.md:9
 msgid ""
 "`and_then()` calls its function input with the wrapped value and returns the "
 "result. If the `Option` is `None`, then it returns `None` instead."
-msgstr "`and_then()` 使用包装的值调用其函数输入并返回结果。如果 `Option` 是 `None`，则返回 `None`。"
+msgstr ""
+"`and_then()` 使用包装的值调用其函数输入并返回结果。如果 `Option` 是 `None`，"
+"则直接返回 `None`。"
 
 #: src/error/option_unwrap/and_then.md:11
 msgid ""
 "In the following example, `cookable_v3()` results in an `Option<Food>`. Using "
 "`map()` instead of `and_then()` would have given an `Option<Option<Food>>`, "
 "which is an invalid type for `eat()`."
-msgstr "在下面的例子中，`cookable_v3()` 的结果是一个 `Option<Food>`。如果使用 `map()` 而不是 `and_then()`，将会得到一个 `Option<Option<Food>>`，这对于 `eat()` 来说是一个无效的类型。"
+msgstr ""
+"在下面的例子中，`cookable_v3()` 返回一个 `Option<Food>`。如果使用 `map()` "
+"而不是 `and_then()`，将会得到一个 `Option<Option<Food>>`，这对于 `eat()` "
+"函数来说是一个无效的类型。"
 
 #: src/error/option_unwrap/and_then.md:20
 msgid "// We don't have the ingredients to make Sushi.\n"
@@ -11522,7 +11588,7 @@ msgstr "// 我们没有制作寿司的原料。\n"
 
 #: src/error/option_unwrap/and_then.md:28
 msgid "// We have the recipe for everything except Cordon Bleu.\n"
-msgstr "// 我们有除了蓝带猪排以外所有菜的食谱。\n"
+msgstr "// 我们有除了蓝带猪排以外所有菜品的食谱。\n"
 
 #: src/error/option_unwrap/and_then.md:36
 msgid ""
@@ -11535,19 +11601,19 @@ msgstr ""
 #: src/error/option_unwrap/and_then.md:45
 msgid ""
 "// This can conveniently be rewritten more compactly with `and_then()`:\n"
-msgstr "// 这可以方便地用 `and_then()` 更紧凑地重写：\n"
+msgstr "// 这可以使用 `and_then()` 更简洁地重写：\n"
 
 #: src/error/option_unwrap/and_then.md:50
 msgid ""
 "// Otherwise we'd need to `flatten()` an `Option<Option<Food>>`\n"
 "// to get an `Option<Food>`:\n"
 msgstr ""
-"// 否则我们需要 `flatten()` 一个 `Option<Option<Food>>`\n"
-"// 来获得一个 `Option<Food>`：\n"
+"// 否则我们需要对 `Option<Option<Food>>` 使用 `flatten()`\n"
+"// 来获得 `Option<Food>`：\n"
 
 #: src/error/option_unwrap/and_then.md:59
 msgid "\"Yay! On {:?} we get to eat {:?}.\""
-msgstr "\"太好了！在 {:?} 我们可以吃 {:?}。\""
+msgstr "\"太好了！在 {:?} 我们可以吃到 {:?}。\""
 
 #: src/error/option_unwrap/and_then.md:60
 msgid "\"Oh no. We don't get to eat on {:?}?\""
@@ -11559,18 +11625,24 @@ msgid ""
 "option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/"
 "std/option/enum.Option.html#method.and_then), and [`Option::flatten()`]"
 "(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
-msgstr "[闭包](../../fn/closures.md)，[`Option`](https://doc.rust-lang.org/std/option/enum.Option.html)，[`Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then)，以及 [`Option::flatten()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
+msgstr ""
+"[闭包](../../fn/closures.md)、[`Option`](https://doc.rust-lang.org/std/"
+"option/enum.Option.html)、[`Option::and_then()`](https://doc.rust-lang.org/"
+"std/option/enum.Option.html#method.and_then) 和 [`Option::flatten()`]"
+"(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
 
 #: src/error/option_unwrap/defaults.md:1
 msgid "Unpacking options and defaults"
-msgstr "解包 Option 和默认值"
+msgstr "解包 Option 和设置默认值"
 
 #: src/error/option_unwrap/defaults.md:3
 msgid ""
 "There is more than one way to unpack an `Option` and fall back on a default "
 "if it is `None`. To choose the one that meets our needs, we need to consider "
 "the following:"
-msgstr "有多种方法可以解包 `Option` 并在其为 `None` 时回退到默认值。为了选择满足我们需求的方法，我们需要考虑以下几点："
+msgstr ""
+"有多种方法可以解包 `Option` 并在其为 `None` 时使用默认值。为了选择满足我们"
+"需求的方法，我们需要考虑以下几点："
 
 #: src/error/option_unwrap/defaults.md:4
 msgid "do we need eager or lazy evaluation?"
@@ -11590,7 +11662,9 @@ msgid ""
 "`or()`is chainable and eagerly evaluates its argument, as is shown in the "
 "following example. Note that because `or`'s arguments are evaluated eagerly, "
 "the variable passed to `or` is moved."
-msgstr "`or()` 可链式调用，并且立即地求值其参数，如下例所示。注意，由于 `or` 的参数是立即求值的，传递给 `or` 的变量会被移动。"
+msgstr ""
+"`or()` 可以链式调用，并且会立即求值其参数，如下例所示。注意，由于 `or` 的"
+"参数是立即求值的，传递给 `or` 的变量会被移动。"
 
 #: src/error/option_unwrap/defaults.md:21 src/error/option_unwrap/defaults.md:54
 msgid "\"first_available_fruit: {:?}\""
@@ -11611,41 +11685,42 @@ msgid ""
 "{:?}\", apple);\n"
 "    // TODO: uncomment the line above to see the compiler error\n"
 msgstr ""
-"// `or` 移动了它的参数。\n"
-"    // 在上面的例子中，`or(orange)` 返回了一个 `Some`，所以 `or(apple)` 没有被调用。\n"
+"// `or` 会移动其参数。\n"
+"    // 在上面的例子中，`or(orange)` 返回了 `Some`，所以 `or(apple)` 没有被调用。\n"
 "    // 但是名为 `apple` 的变量无论如何都被移动了，不能再使用。\n"
 "    // println!(\"变量 apple 被移动了，所以这行不会编译：{:?}\", apple);\n"
-"    // TODO: 取消上面这行的注释来查看编译器错误\n"
+"    // TODO：取消上面这行的注释来查看编译器错误\n"
 
 #: src/error/option_unwrap/defaults.md:32
 msgid "`or_else()` is chainable, evaluates lazily, keeps empty value intact"
-msgstr "`or_else()` 可链式调用，惰性求值，保持空值不变"
+msgstr "`or_else()` 可以链式调用，惰性求值，保持空值不变"
 
 #: src/error/option_unwrap/defaults.md:34
 msgid ""
 "Another alternative is to use `or_else`, which is also chainable, and "
 "evaluates lazily, as is shown in the following example:"
-msgstr "另一种选择是使用 `or_else`，它也是可链式调用的，并且是惰性求值的，如下例所示："
+msgstr ""
+"另一种选择是使用 `or_else`，它同样支持链式调用，并且采用惰性求值。以下是一个示例："
 
 #: src/error/option_unwrap/defaults.md:43
 msgid "\"Providing kiwi as fallback\""
-msgstr "\"提供猕猴桃作为后备\""
+msgstr "\"提供猕猴桃作为备选\""
 
 #: src/error/option_unwrap/defaults.md:47 src/error/option_unwrap/defaults.md:91
 msgid "\"Providing lemon as fallback\""
-msgstr "\"提供柠檬作为后备\""
+msgstr "\"提供柠檬作为备选\""
 
 #: src/error/option_unwrap/defaults.md:55
 msgid ""
 "// Providing kiwi as fallback\n"
 "    // first_available_fruit: Some(Kiwi)\n"
 msgstr ""
-"// 提供猕猴桃作为后备\n"
+"// 提供猕猴桃作为备选\n"
 "    // first_available_fruit: Some(Kiwi)\n"
 
 #: src/error/option_unwrap/defaults.md:60
 msgid "`get_or_insert()` evaluates eagerly, modifies empty value in place"
-msgstr "`get_or_insert()` 立即求值，就地修改空值"
+msgstr "`get_or_insert()` 立即求值，原地修改空值"
 
 #: src/error/option_unwrap/defaults.md:62
 msgid ""
@@ -11654,15 +11729,16 @@ msgid ""
 "example. Note that `get_or_insert` eagerly evaluates its parameter, so "
 "variable `apple` is moved:"
 msgstr ""
-"为了确保 `Option` 包含一个值，我们可以使用 `get_or_insert` 来就地修改它，使用一个后备值，如下例所示。注意 `get_or_insert` 会立即求值其参数，所以变量 `apple` 被移动了："
+"为确保 `Option` 包含一个值，我们可以使用 `get_or_insert` 来原地修改它，提供一个备选值。"
+"下面的例子展示了这一点。请注意，`get_or_insert` 会立即求值其参数，因此变量 `apple` 会被移动："
 
 #: src/error/option_unwrap/defaults.md:72 src/error/option_unwrap/defaults.md:96
 msgid "\"first_available_fruit is: {:?}\""
-msgstr "\"first_available_fruit is: {:?}\""
+msgstr "\"第一个可用的水果是：{:?}\""
 
 #: src/error/option_unwrap/defaults.md:73 src/error/option_unwrap/defaults.md:97
 msgid "\"my_fruit is: {:?}\""
-msgstr "\"my_fruit is: {:?}\""
+msgstr "\"我的水果是：{:?}\""
 
 #: src/error/option_unwrap/defaults.md:74
 msgid ""
@@ -11673,18 +11749,19 @@ msgid ""
 msgstr ""
 "// first_available_fruit is: Apple\n"
 "    // my_fruit is: Some(Apple)\n"
-"    //println!(\"名为 `apple` 的变量被移动了：{:?}\", apple);\n"
-"    // TODO：取消上面这行的注释来查看编译器错误\n"
+"    //println!(\"名为 `apple` 的变量已被移动：{:?}\", apple);\n"
+"    // TODO：取消上面这行的注释以查看编译器错误\n"
 
 #: src/error/option_unwrap/defaults.md:81
 msgid "`get_or_insert_with()` evaluates lazily, modifies empty value in place"
-msgstr "`get_or_insert_with()` 惰性求值，就地修改空值"
+msgstr "`get_or_insert_with()` 惰性求值，原地修改空值"
 
 #: src/error/option_unwrap/defaults.md:83
 msgid ""
 "Instead of explicitly providing a value to fall back on, we can pass a "
 "closure to `get_or_insert_with`, as follows:"
-msgstr "我们可以传递一个闭包给 `get_or_insert_with`，而不是显式提供一个后备值，如下所示："
+msgstr ""
+"我们可以向 `get_or_insert_with` 传递一个闭包，而不是显式提供一个备选值。示例如下："
 
 #: src/error/option_unwrap/defaults.md:98
 msgid ""
@@ -11692,7 +11769,7 @@ msgid ""
 "    // first_available_fruit is: Lemon\n"
 "    // my_fruit is: Some(Lemon)\n"
 msgstr ""
-"// 提供柠檬作为后备\n"
+"// 提供柠檬作为备选\n"
 "    // first_available_fruit is: Lemon\n"
 "    // my_fruit is: Some(Lemon)\n"
 
@@ -11700,15 +11777,15 @@ msgstr ""
 msgid ""
 "// If the Option has a value, it is left unchanged, and the closure is not "
 "invoked\n"
-msgstr "// 如果 Option 有值，它保持不变，闭包不会被调用\n"
+msgstr "// 如果 Option 已有值，它将保持不变，闭包不会被调用\n"
 
 #: src/error/option_unwrap/defaults.md:105
 msgid "\"should_be_apple is: {:?}\""
-msgstr "\"should_be_apple is: {:?}\""
+msgstr "\"should_be_apple 的值为：{:?}\""
 
 #: src/error/option_unwrap/defaults.md:106
 msgid "\"my_apple is unchanged: {:?}\""
-msgstr "\"my_apple is unchanged: {:?}\""
+msgstr "\"my_apple 保持不变：{:?}\""
 
 #: src/error/option_unwrap/defaults.md:107
 msgid ""
@@ -11717,7 +11794,7 @@ msgid ""
 "    // should_be_apple is: Apple\n"
 "    // my_apple is unchanged: Some(Apple)\n"
 msgstr ""
-"// 输出如下。注意闭包 `get_lemon_as_fallback` 没有被调用\n"
+"// 输出如下。注意闭包 `get_lemon_as_fallback` 并未被调用\n"
 "    // should_be_apple is: Apple\n"
 "    // my_apple is unchanged: Some(Apple)\n"
 
@@ -11732,12 +11809,12 @@ msgid ""
 "[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
 "or_else)"
 msgstr ""
-"[`闭包`](https://doc.rust-lang.org/book/ch13-01-closures.html), "
+"[`闭包`](https://doc.rust-lang.org/book/ch13-01-closures.html)、"
 "[`get_or_insert`](https://doc.rust-lang.org/core/option/enum.Option."
-"html#method.get_or_insert), [`get_or_insert_with`](https://doc.rust-lang.org/"
-"core/option/enum.Option.html#method.get_or_insert_with), [`移动变量`]"
-"(https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html), [`or`]"
-"(https://doc.rust-lang.org/core/option/enum.Option.html#method.or), "
+"html#method.get_or_insert)、[`get_or_insert_with`](https://doc.rust-lang.org/"
+"core/option/enum.Option.html#method.get_or_insert_with)、[`变量移动`]"
+"(https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html)、[`or`]"
+"(https://doc.rust-lang.org/core/option/enum.Option.html#method.or)、"
 "[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
 "or_else)"
 
@@ -11748,7 +11825,7 @@ msgid ""
 "html) type that describes possible _error_ instead of possible _absence_."
 msgstr ""
 "[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) 是 [`Option`](https://doc.rust-lang.org/std/option/enum.Option."
-"html) 类型的更丰富版本，它描述可能的**错误**而不是可能的**缺失**。"
+"html) 类型的增强版，它描述可能的**错误**而非可能的**缺失**。"
 
 #: src/error/result.md:6
 msgid "That is, `Result<T, E>` could have one of two outcomes:"
@@ -11756,11 +11833,11 @@ msgstr "也就是说，`Result<T, E>` 可能有两种结果之一："
 
 #: src/error/result.md:8
 msgid "`Ok(T)`: An element `T` was found"
-msgstr "`Ok(T)`：找到了一个元素 `T`"
+msgstr "`Ok(T)`：找到了一个 `T` 类型的元素"
 
 #: src/error/result.md:9
 msgid "`Err(E)`: An error was found with element `E`"
-msgstr "`Err(E)`：找到了一个错误，错误类型为 `E`"
+msgstr "`Err(E)`：发生了一个 `E` 类型的错误"
 
 #: src/error/result.md:11
 msgid ""
@@ -11774,7 +11851,8 @@ msgid ""
 "example, either yields the element `T` or `panic`s. For case handling, there "
 "are many combinators between `Result` and `Option` that overlap."
 msgstr ""
-"与 `Option` 类似，`Result` 也有许多与之关联的方法。例如，`unwrap()` 要么产生元素 `T`，要么 `panic`。对于情况处理，`Result` 和 `Option` 之间有许多重叠的组合子。"
+"与 `Option` 类似，`Result` 也有许多关联方法。例如，`unwrap()` 要么返回元素 `T`，要么触发 `panic`。"
+"对于情况处理，`Result` 和 `Option` 之间有许多重叠的组合子。"
 
 #: src/error/result.md:17
 msgid ""
@@ -11785,7 +11863,7 @@ msgid ""
 "indicating possible failure."
 msgstr ""
 "在使用 Rust 时，你可能会遇到返回 `Result` 类型的方法，比如 [`parse()`](https://doc.rust-lang.org/std/"
-"primitive.str.html#method.parse) 方法。将字符串解析为其他类型并不总是可能的，所以 `parse()` 返回一个 `Result` "
+"primitive.str.html#method.parse) 方法。将字符串解析为其他类型并非总是可行，因此 `parse()` 返回一个 `Result` "
 "来表示可能的失败。"
 
 #: src/error/result.md:22
@@ -11796,7 +11874,7 @@ msgstr "让我们看看成功和失败地 `parse()` 一个字符串会发生什�
 
 #: src/error/result.md:26
 msgid "// Let's try using `unwrap()` to get the number out. Will it bite us?\n"
-msgstr "// 让我们尝试使用 `unwrap()` 来获取数字。它会咬我们吗？\n"
+msgstr "// 让我们尝试使用 `unwrap()` 来获取数字。这样做会有问题吗？\n"
 
 #: src/error/result.md:33 src/error/result.md:36
 #: src/error/result/result_map.md:42 src/error/result/result_map.md:46
@@ -11828,25 +11906,27 @@ msgid ""
 "`panic` on. Additionally, the `panic` exits our program and provides an "
 "unpleasant error message."
 msgstr ""
-"在失败的情况下，`parse()` 给我们留下了一个错误，`unwrap()` 会在这个错误上 `panic`。此外，`panic` 会退出我们的程序并提供一个令人不愉快的错误消息。"
+"在解析失败的情况下，`parse()` 会返回一个错误，导致 `unwrap()` 触发 panic。"
+"此外，panic 会终止程序并输出一条不友好的错误信息。"
 
 #: src/error/result.md:45
 msgid ""
 "To improve the quality of our error message, we should be more specific about "
 "the return type and consider explicitly handling the error."
 msgstr ""
-"为了改善我们的错误消息的质量，我们应该更具体地指定返回类型，并考虑显式地处理错误。"
+"为了提高错误信息的质量，我们应该更明确地指定返回类型，并考虑显式地处理错误。"
 
 #: src/error/result.md:48
 msgid "Using `Result` in `main`"
-msgstr "在 `main` 中使用 `Result`"
+msgstr "在 `main` 函数中使用 `Result`"
 
 #: src/error/result.md:50
 msgid ""
 "The `Result` type can also be the return type of the `main` function if "
 "specified explicitly. Typically the `main` function will be of the form:"
 msgstr ""
-"`Result` 类型也可以是 `main` 函数的返回类型，如果显式指定的话。通常，`main` 函数的形式如下："
+"如果显式指定，`Result` 类型也可以作为 `main` 函数的返回类型。"
+"通常，`main` 函数的形式如下："
 
 #: src/error/result.md:59
 msgid ""
@@ -11857,7 +11937,12 @@ msgid ""
 "scenario and touches on aspects covered in [the following section](result/"
 "early_returns.md)."
 msgstr ""
-"然而，`main` 函数也可以有 `Result` 的返回类型。如果在 `main` 函数内发生错误，它将返回一个错误代码并打印错误的调试表示（使用 [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait）。以下示例展示了这样一个场景，并涉及了[下一节](result/early_returns.md)中涵盖的方面。"
+"然而，`main` 函数也可以返回 `Result` 类型。如果 `main` 函数内发生错误，"
+"它将返回一个错误代码并打印该错误的调试表示（使用 [`Debug`] trait）。"
+"以下示例展示了这种情况，并涉及了[下一节]中讨论的内容。\n"
+"\n"
+"[`Debug`]: https://doc.rust-lang.org/std/fmt/trait.Debug.html\n"
+"[下一节]: result/early_returns.md"
 
 #: src/error/result/result_map.md:3
 msgid ""
@@ -11865,7 +11950,8 @@ msgid ""
 "Generally, we want to return the error to the caller so it can decide what is "
 "the right way to respond to errors."
 msgstr ""
-"在前面示例的 `multiply` 中使用 panic 并不能产生健壮的代码。通常，我们希望将错误返回给调用者，以便它可以决定如何正确地响应错误。"
+"在前面示例的 `multiply` 函数中使用 panic 并不能产生健壮的代码。"
+"通常，我们希望将错误返回给调用者，让它决定如何正确地处理错误。"
 
 #: src/error/result/result_map.md:7
 msgid ""
@@ -11877,7 +11963,13 @@ msgid ""
 "`Err` type is specified as [`ParseIntError`](https://doc.rust-lang.org/std/"
 "num/struct.ParseIntError.html)."
 msgstr ""
-"首先，我们需要知道我们正在处理的错误类型。为了确定 `Err` 类型，我们查看 [`parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse)，它是通过 [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait 为 [`i32`](https://doc.rust-lang.org/std/primitive.i32.html) 实现的。因此，`Err` 类型被指定为 [`ParseIntError`](https://doc.rust-lang.org/std/num/struct.ParseIntError.html)。"
+"首先，我们需要知道我们正在处理的错误类型。要确定 `Err` 类型，我们可以查看 [`parse()`] 方法，"
+"它是通过 [`FromStr`] trait 为 [`i32`] 实现的。因此，`Err` 类型被指定为 [`ParseIntError`]。\n"
+"\n"
+"[`parse()`]: https://doc.rust-lang.org/std/primitive.str.html#method.parse\n"
+"[`FromStr`]: https://doc.rust-lang.org/std/str/trait.FromStr.html\n"
+"[`i32`]: https://doc.rust-lang.org/std/primitive.i32.html\n"
+"[`ParseIntError`]: https://doc.rust-lang.org/std/num/struct.ParseIntError.html"
 
 #: src/error/result/result_map.md:12
 msgid ""
@@ -11898,7 +11990,7 @@ msgstr ""
 #: src/error/result/enter_question_mark.md:28
 #: src/error/result/enter_question_mark.md:61
 msgid "\"n is {}\""
-msgstr "\"n is {}\""
+msgstr "\"n 是 {}\""
 
 #: src/error/result/result_map.md:36 src/error/result/result_map.md:69
 #: src/error/result/result_alias.md:31 src/error/result/early_returns.md:31
@@ -11909,7 +12001,7 @@ msgstr "\"n is {}\""
 #: src/error/multiple_error_types/reenter_question_mark.md:54
 #: src/error/multiple_error_types/wrap_error.md:68
 msgid "\"Error: {}\""
-msgstr "\"Error: {}\""
+msgstr "\"错误：{}\""
 
 #: src/error/result/result_map.md:41 src/error/result/result_map.md:74
 msgid "// This still presents a reasonable answer.\n"
@@ -11917,7 +12009,7 @@ msgstr "// 这仍然给出了一个合理的答案。\n"
 
 #: src/error/result/result_map.md:45 src/error/result/result_map.md:78
 msgid "// The following now provides a much more helpful error message.\n"
-msgstr "// 以下现在提供了一个更有帮助的错误消息。\n"
+msgstr "// 以下代码现在提供了一个更有帮助的错误消息。\n"
 
 #: src/error/result/result_map.md:51
 msgid ""
@@ -11925,8 +12017,8 @@ msgid ""
 "implemented for `Result`. [`Result`](https://doc.rust-lang.org/std/result/"
 "enum.Result.html) contains a complete listing."
 msgstr ""
-"幸运的是，`Option` 的 `map`、`and_then` 和许多其他组合器也为 `Result` 实现了。[`Result`](https://doc.rust-lang.org/std/result/"
-"enum.Result.html) 包含了完整的列表。"
+"幸运的是，`Option` 的 `map`、`and_then` 以及许多其他组合器也为 `Result` 实现了。"
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) 文档中包含了完整的列表。"
 
 #: src/error/result/result_map.md:56
 msgid ""
@@ -11935,9 +12027,9 @@ msgid ""
 "// Multiply if both values can be parsed from str, otherwise pass on the "
 "error.\n"
 msgstr ""
-"// 与 `Option` 一样，我们可以使用诸如 `map()` 之类的组合器。\n"
+"// 与 `Option` 类似，我们可以使用诸如 `map()` 之类的组合器。\n"
 "// 这个函数除此之外与上面的函数相同，其含义为：\n"
-"// 如果两个值都可以从字符串解析，则相乘，否则传递错误。\n"
+"// 如果两个值都可以从字符串解析，则相乘；否则传递错误。\n"
 
 #: src/error/result/result_alias.md:3
 msgid ""
@@ -11945,8 +12037,8 @@ msgid ""
 "that Rust allows us to create [aliases](../../types/alias.md). Conveniently, "
 "we can define one for the specific `Result` in question."
 msgstr ""
-"当我们想多次重用特定的 `Result` 类型时该怎么办？回想一下，Rust 允许我们创建[别名](../../types/alias.md)。方便的是，"
-"我们可以为特定的 `Result` 定义一个别名。"
+"如果我们想多次重用特定的 `Result` 类型，该怎么办？回想一下，Rust 允许我们创建"
+"[别名](../../types/alias.md)。方便的是，我们可以为特定的 `Result` 定义一个别名。"
 
 #: src/error/result/result_alias.md:7
 msgid ""
@@ -11956,13 +12048,13 @@ msgid ""
 "`std` library even supplies one: [`io::Result`](https://doc.rust-lang.org/std/"
 "io/type.Result.html)!"
 msgstr ""
-"在模块级别，创建别名可能特别有用。在特定模块中发现的错误通常具有相同的 `Err` 类型，因此单个别名可以简洁地定义**所有**相关的 `Results`。这非常有用，以至于 "
-"`std` 库甚至提供了一个：[`io::Result`](https://doc.rust-lang.org/std/"
-"io/type.Result.html)！"
+"在模块级别，创建别名特别有用。在特定模块中发现的错误通常具有相同的 `Err` 类型，"
+"因此单个别名可以简洁地定义**所有**相关的 `Result`。这非常实用，以至于 `std` 库"
+"甚至提供了一个：[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)！"
 
 #: src/error/result/result_alias.md:12
 msgid "Here's a quick example to show off the syntax:"
-msgstr "这里有一个快速示例来展示语法："
+msgstr "这里有一个简单的例子来展示语法："
 
 #: src/error/result/result_alias.md:16
 msgid ""
@@ -11973,11 +12065,11 @@ msgstr ""
 
 #: src/error/result/result_alias.md:19
 msgid "// Use the above alias to refer to our specific `Result` type.\n"
-msgstr "// 使用上面的别名来引用我们特定的 `Result` 类型。\n"
+msgstr "// 使用上面定义的别名来引用我们特定的 `Result` 类型。\n"
 
 #: src/error/result/result_alias.md:26
 msgid "// Here, the alias again allows us to save some space.\n"
-msgstr "// 在这里，别名再次让我们节省了一些空间。\n"
+msgstr "// 在这里，别名再次让我们节省了一些代码空间。\n"
 
 #: src/error/result/result_alias.md:43
 msgid "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
@@ -11989,7 +12081,8 @@ msgid ""
 "Another way to deal with this case analysis is to use a combination of "
 "`match` statements and _early returns_."
 msgstr ""
-"在前面的例子中，我们使用组合器显式地处理了错误。处理这种情况分析的另一种方法是使用 `match` 语句和**提前返回**的组合。"
+"在前面的例子中，我们使用组合器显式地处理了错误。处理这种情况分析的另一种方法是"
+"使用 `match` 语句和**提前返回**的组合。"
 
 #: src/error/result/early_returns.md:7
 msgid ""
@@ -11997,8 +12090,8 @@ msgid ""
 "one occurs. For some, this form of code can be easier to both read and write. "
 "Consider this version of the previous example, rewritten using early returns:"
 msgstr ""
-"也就是说，如果发生错误，我们可以简单地停止执行函数并返回错误。对某些人来说，这种形式的代码可能更容易阅读和编写。"
-"考虑使用提前返回重写的前面示例的这个版本："
+"也就是说，如果发生错误，我们可以简单地停止执行函数并返回错误。对某些人来说，"
+"这种形式的代码可能更容易阅读和编写。考虑使用提前返回重写的前面示例的这个版本："
 
 #: src/error/result/early_returns.md:41
 msgid ""
@@ -12006,14 +12099,15 @@ msgid ""
 "and early returns. While we generally want to avoid panicking, explicitly "
 "handling all of our errors is cumbersome."
 msgstr ""
-"到目前为止，我们已经学会了使用组合器和提前返回来显式处理错误。虽然我们通常想避免 panic，但显式处理所有错误是很麻烦的。"
+"到目前为止，我们已经学会了使用组合器和提前返回来显式处理错误。虽然我们通常想"
+"避免 panic，但显式处理所有错误是很繁琐的。"
 
 #: src/error/result/early_returns.md:45
 msgid ""
 "In the next section, we'll introduce `?` for the cases where we simply need "
 "to `unwrap` without possibly inducing `panic`."
 msgstr ""
-"在下一节中，我们将介绍 `?`，用于我们只需要 `unwrap` 而不可能引发 `panic` 的情况。"
+"在下一节中，我们将介绍 `?` 运算符，用于我们只需要 `unwrap` 而不可能引发 `panic` 的情况。"
 
 #: src/error/result/enter_question_mark.md:3
 msgid ""
@@ -12022,20 +12116,20 @@ msgid ""
 "what we really wanted was to get the variable _out_. This is exactly the "
 "purpose of `?`."
 msgstr ""
-"有时我们只想要 `unwrap` 的简单性，而不希望有 `panic` 的可能性。到目前为止，当我们真正想要的是获取变量**出来**时，`unwrap` 迫使我们不断地嵌套。"
-"这正是 `?` 的目的。"
+"有时我们只想要 `unwrap` 的简单性，而不希望有 `panic` 的可能。到目前为止，当我们"
+"真正想要的是获取变量**值**时，`unwrap` 迫使我们不断地增加嵌套。这正是 `?` 运算符的目的。"
 
 #: src/error/result/enter_question_mark.md:7
 msgid "Upon finding an `Err`, there are two valid actions to take:"
-msgstr "在发现 `Err` 时，有两种有效的行动："
+msgstr "当遇到 `Err` 时，有两种可行的处理方式："
 
 #: src/error/result/enter_question_mark.md:9
 msgid "`panic!` which we already decided to try to avoid if possible"
-msgstr "`panic!`，我们已经决定尽可能避免"
+msgstr "1. 使用 `panic!`（我们已经决定尽可能避免这种方式）"
 
 #: src/error/result/enter_question_mark.md:10
 msgid "`return` because an `Err` means it cannot be handled"
-msgstr "`return`，因为 `Err` 意味着它无法被处理"
+msgstr "2. 使用 `return`（因为 `Err` 表示无法处理该错误）"
 
 #: src/error/result/enter_question_mark.md:12
 msgid ""
@@ -12043,7 +12137,8 @@ msgid ""
 "of `panic`king on `Err`s. Let's see how we can simplify the earlier example "
 "that used combinators:"
 msgstr ""
-"`?` **几乎**[^†]完全等同于在 `Err` 上 `return` 而不是 `panic` 的 `unwrap`。让我们看看如何简化之前使用组合器的例子："
+"`?` 运算符**几乎**[^†]等同于在遇到 `Err` 时执行 `return` 而非 `panic` 的 `unwrap`。"
+"让我们看看如何简化之前使用组合器的例子："
 
 #: src/error/result/enter_question_mark.md:39
 msgid "The `try!` macro"
@@ -12056,8 +12151,9 @@ msgid ""
 "when looking at older code. The same `multiply` function from the previous "
 "example would look like this using `try!`:"
 msgstr ""
-"在有 `?` 之前，相同的功能是通过 `try!` 宏实现的。现在推荐使用 `?` 运算符，但在查看旧代码时，你可能仍会看到 `try!`。"
-"前面例子中的相同 `multiply` 函数使用 `try!` 看起来像这样："
+"在 `?` 运算符出现之前，相同的功能是通过 `try!` 宏实现的。现在推荐使用 `?` 运算符，"
+"但在查看旧代码时，你可能仍会遇到 `try!`。使用 `try!` 宏，前面例子中的 `multiply` 函数"
+"会是这样的："
 
 #: src/error/result/enter_question_mark.md:47
 msgid ""
@@ -12066,22 +12162,22 @@ msgid ""
 "// of the `edition` field, in the `[package]` section of the `Cargo.toml` "
 "file, to \"2015\".\n"
 msgstr ""
-"// 要在使用 Cargo 时编译并运行此示例而不出错，请更改\n"
-"// `Cargo.toml` 文件的 `[package]` 部分中 `edition` 字段的值为 \"2015\"。\n"
+"// 要使用 Cargo 编译并运行此示例而不出错，请将 `Cargo.toml` 文件中\n"
+"// `[package]` 部分的 `edition` 字段值更改为 \"2015\"。\n"
 
 #: src/error/result/enter_question_mark.md:73
 msgid ""
 "See [re-enter ?](../multiple_error_types/reenter_question_mark.md) for more "
 "details."
 msgstr ""
-"更多详情请 [重新回顾 ?](../multiple_error_types/reenter_question_mark.md)。"
+"更多详情请参阅[重新认识 ?](../multiple_error_types/reenter_question_mark.md)。"
 
 #: src/error/multiple_error_types.md:3
 msgid ""
 "The previous examples have always been very convenient; `Result`s interact "
 "with other `Result`s and `Option`s interact with other `Option`s."
 msgstr ""
-"前面的例子一直都很方便；`Result` 与其他 `Result` 交互，`Option` 与其他 `Option` 交互。"
+"前面的例子一直都很方便：`Result` 与 `Result` 交互，`Option` 与 `Option` 交互。"
 
 #: src/error/multiple_error_types.md:6
 msgid ""
@@ -12090,8 +12186,8 @@ msgid ""
 "want to manage our different error types in a way that makes them composable "
 "and easy to interact with."
 msgstr ""
-"有时 `Option` 需要与 `Result` 交互，或者 `Result<T, Error1>` 需要与 `Result<T, Error2>` 交互。在这些情况下，"
-"我们希望以一种使它们可组合且易于交互的方式来管理不同的错误类型。"
+"有时，`Option` 需要与 `Result` 交互，或者 `Result<T, Error1>` 需要与 `Result<T, Error2>` 交互。"
+"在这些情况下，我们希望以一种使不同错误类型可组合且易于交互的方式来管理它们。"
 
 #: src/error/multiple_error_types.md:11
 msgid ""
@@ -12099,8 +12195,8 @@ msgid ""
 "types. `Vec::first` returns an `Option`, while `parse::<i32>` returns a "
 "`Result<i32, ParseIntError>`:"
 msgstr ""
-"在下面的代码中，两个 `unwrap` 实例生成不同的错误类型。`Vec::first` 返回一个 `Option`，而 `parse::<i32>` 返回一个 "
-"`Result<i32, ParseIntError>`："
+"在下面的代码中，两个 `unwrap` 实例生成了不同的错误类型。`Vec::first` 返回一个 `Option`，"
+"而 `parse::<i32>` 返回一个 `Result<i32, ParseIntError>`："
 
 #: src/error/multiple_error_types.md:17
 msgid "// Generate error 1\n"
@@ -12194,13 +12290,13 @@ msgstr "// 错误 2：元素无法解析为数字\n"
 msgid ""
 "Over the next sections, we'll see several strategies for handling these kind "
 "of problems."
-msgstr "在接下来的章节中，我们将看到几种处理这类问题的策略。"
+msgstr "在接下来的章节中，我们将探讨几种处理此类问题的策略。"
 
 #: src/error/multiple_error_types/option_result.md:3
 msgid ""
 "The most basic way of handling mixed error types is to just embed them in "
 "each other."
-msgstr "处理混合错误类型最基本的方法就是将它们相互嵌套。"
+msgstr "处理混合错误类型最基本的方法是将它们相互嵌套。"
 
 #: src/error/multiple_error_types/option_result.md:20
 #: src/error/multiple_error_types/option_result.md:22
@@ -12218,28 +12314,28 @@ msgid ""
 "`None`. The `transpose` function comes in handy to swap the `Result` and "
 "`Option`."
 msgstr ""
-"有时我们希望在遇到错误时停止处理（就像使用 [`?`](../result/enter_question_mark.md) 一样），但在 `Option` 为 `None` 时继续执行。"
-"`transpose` 函数在交换 `Result` 和 `Option` 时非常有用。"
+"有时我们希望在遇到错误时停止处理（例如使用 [`?`](../result/enter_question_mark.md)），但在 `Option` 为 `None` 时继续执行。"
+"这时 `transpose` 函数就派上用场了，它可以方便地交换 `Result` 和 `Option`。"
 
 #: src/error/multiple_error_types/define_error_type.md:3
 msgid ""
 "Sometimes it simplifies the code to mask all of the different errors with a "
 "single type of error.  We'll show this with a custom error."
-msgstr "有时，用单一类型的错误来掩盖所有不同的错误可以简化代码。我们将通过自定义错误来展示这一点。"
+msgstr "有时，用单一类型的错误来掩盖所有不同的错误可以简化代码。我们将通过自定义错误来演示这一点。"
 
 #: src/error/multiple_error_types/define_error_type.md:6
 msgid ""
 "Rust allows us to define our own error types. In general, a \"good\" error "
 "type:"
-msgstr "Rust 允许我们定义自己的错误类型。通常，一个"好的"错误类型："
+msgstr "Rust 允许我们定义自己的错误类型。通常，一个"好的"错误类型应该："
 
 #: src/error/multiple_error_types/define_error_type.md:8
 msgid "Represents different errors with the same type"
-msgstr "用相同的类型表示不同的错误"
+msgstr "用同一类型表示不同的错误"
 
 #: src/error/multiple_error_types/define_error_type.md:9
 msgid "Presents nice error messages to the user"
-msgstr "向用户呈现友好的错误消息"
+msgstr "向用户展示友好的错误消息"
 
 #: src/error/multiple_error_types/define_error_type.md:10
 msgid "Is easy to compare with other types"
@@ -12247,23 +12343,23 @@ msgstr "易于与其他类型进行比较"
 
 #: src/error/multiple_error_types/define_error_type.md:11
 msgid "Good: `Err(EmptyVec)`"
-msgstr "示例：`Err(EmptyVec)`"
+msgstr "好的示例：`Err(EmptyVec)`"
 
 #: src/error/multiple_error_types/define_error_type.md:12
 msgid "Bad: `Err(\"Please use a vector with at least one element\".to_owned())`"
-msgstr "反例：`Err(\"Please use a vector with at least one element\".to_owned())`"
+msgstr "不好的示例：`Err(\"请使用至少包含一个元素的向量\".to_owned())`"
 
 #: src/error/multiple_error_types/define_error_type.md:13
 msgid "Can hold information about the error"
-msgstr "可以保存有关错误的信息"
+msgstr "能够保存错误的相关信息"
 
 #: src/error/multiple_error_types/define_error_type.md:14
 msgid "Good: `Err(BadChar(c, position))`"
-msgstr "示例：`Err(BadChar(c, position))`"
+msgstr "好的示例：`Err(BadChar(c, position))`"
 
 #: src/error/multiple_error_types/define_error_type.md:15
 msgid "Bad: `Err(\"+ cannot be used here\".to_owned())`"
-msgstr "反例：`Err(\"+ cannot be used here\".to_owned())`"
+msgstr "不好的示例：`Err(\"此处不能使用 +\".to_owned())`"
 
 #: src/error/multiple_error_types/define_error_type.md:16
 msgid "Composes well with other errors"
@@ -12277,8 +12373,8 @@ msgid ""
 "// implementation, or do something in between.\n"
 msgstr ""
 "// 定义我们的错误类型。这些可以根据我们的错误处理情况进行自定义。\n"
-"// 现在我们将能够编写自己的错误，依赖于底层的错误实现，\n"
-"// 或者在两者之间做些处理。\n"
+"// 现在我们可以编写自己的错误，依赖底层的错误实现，\n"
+"// 或者在两者之间做一些处理。\n"
 
 #: src/error/multiple_error_types/define_error_type.md:28
 msgid ""
@@ -12291,21 +12387,21 @@ msgid ""
 "// which string failed to parse without modifying our types to carry that "
 "information.\n"
 msgstr ""
-"// 错误的生成与其显示方式完全分离。\n"
-"// 不需要担心用显示样式使复杂的逻辑变得混乱。\n"
+"// 错误的生成与其显示方式是完全分离的。\n"
+"// 无需担心显示样式会使复杂的逻辑变得混乱。\n"
 "//\n"
-"// 注意，我们没有存储关于错误的任何额外信息。这意味着我们无法说明\n"
-"// 哪个字符串解析失败，除非修改我们的类型以携带该信息。\n"
+"// 注意，我们没有存储关于错误的任何额外信息。这意味着如果不修改类型\n"
+"// 来携带相关信息，我们就无法指出具体是哪个字符串解析失败了。\n"
 
 #: src/error/multiple_error_types/define_error_type.md:36
 #: src/error/multiple_error_types/boxing_errors.md:23
 #: src/error/multiple_error_types/reenter_question_mark.md:37
 msgid "\"invalid first item to double\""
-msgstr "\"无效的第一个要加倍的项\""
+msgstr "\"无效的第一个待加倍项\""
 
 #: src/error/multiple_error_types/define_error_type.md:42
 msgid "// Change the error to our new type.\n"
-msgstr "// 将错误改为我们的新类型。\n"
+msgstr "// 将错误更改为我们的新类型。\n"
 
 #: src/error/multiple_error_types/define_error_type.md:46
 msgid "// Update to the new error type here also.\n"
@@ -12319,8 +12415,8 @@ msgid ""
 "determined](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-"
 "objects-perform-dynamic-dispatch)."
 msgstr ""
-"如果又想写简单的代码，又想保存原始错误信息，一个方法是把它们装箱（[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html)）。"
-"缺点是底层错误类型只在运行时才知道，而不是[静态确定的](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)。"
+"一种既能编写简洁代码又能保留原始错误信息的方法是使用 [`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html) 将它们装箱。"
+"这种方法的缺点是底层错误类型只能在运行时确定，而不是[静态确定](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)的。"
 
 #: src/error/multiple_error_types/boxing_errors.md:7
 msgid ""
@@ -12329,13 +12425,13 @@ msgid ""
 "`Box<Error>`, via [`From`](https://doc.rust-lang.org/std/convert/trait.From."
 "html)."
 msgstr ""
-"标准库通过让 `Box` 实现从任何实现 `Error` trait 的类型到 trait 对象 `Box<Error>` 的转换，来帮助我们将错误装箱，"
+"标准库通过让 `Box` 实现从任何实现了 `Error` trait 的类型到 trait 对象 `Box<Error>` 的转换来帮助我们装箱错误，"
 "这是通过 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 实现的。"
 
 #: src/error/multiple_error_types/boxing_errors.md:14
 #: src/error/multiple_error_types/reenter_question_mark.md:28
 msgid "// Change the alias to use `Box<dyn error::Error>`.\n"
-msgstr "// 更改别名以使用 `Box<dyn error::Error>`。\n"
+msgstr "// 将别名改为使用 `Box<dyn error::Error>`。\n"
 
 #: src/error/multiple_error_types/boxing_errors.md:31
 #: src/error/multiple_error_types/boxing_errors.md:34
@@ -12357,7 +12453,7 @@ msgid ""
 "Notice in the previous example that our immediate reaction to calling `parse` "
 "is to `map` the error from a library error into a boxed error:"
 msgstr ""
-"注意在前面的例子中，我们对调用 `parse` 的直接反应是将库错误 `map` 到一个装箱的错误中："
+"注意在前面的例子中，我们对调用 `parse` 的直接反应是将库错误通过 `map` 转换为一个装箱的错误："
 
 #: src/error/multiple_error_types/reenter_question_mark.md:12
 msgid ""
@@ -12365,8 +12461,8 @@ msgid ""
 "could be elided. Alas, because `and_then` is not sufficiently flexible, it "
 "cannot. However, we can instead use `?`."
 msgstr ""
-"因为这个操作很简单常见，如果有省略写法就好了。可惜的是，因为 `and_then` 不够灵活，所以实现不了。"
-"不过，我们可以使用 `?` 来代替。"
+"由于这是一个简单且常见的操作，如果能够省略就会很方便。可惜的是，由于 `and_then` 不够灵活，"
+"所以无法实现这一点。不过，我们可以使用 `?` 来替代。"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:16
 msgid ""
@@ -12376,9 +12472,9 @@ msgid ""
 "types, this means that if you `?` where the error is convertible to the "
 "return type, it will convert automatically."
 msgstr ""
-"`?` 之前被解释为 `unwrap` 或 `return Err(err)`。这只是大部分正确。它实际上意味着 `unwrap` 或 "
+"之前我们将 `?` 解释为 `unwrap` 或 `return Err(err)`。这只是大致正确。实际上，它的含义是 `unwrap` 或 "
 "`return Err(From::from(err))`。由于 `From::from` 是不同类型之间的转换工具，这意味着如果你在错误可转换为返回类型的地方使用 `?`，"
-"它将自动转换。"
+"它将自动进行转换。"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:22
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -8838,7 +8838,7 @@ msgstr ""
 
 #: src/scope/move/mut.md:14
 msgid "// *Move* the box, changing the ownership (and mutability)\n"
-msgstr "// *移动* box，改变所有权（和可变性）\n"
+msgstr "// *移动*盒子，改变所有权（和可变性）\n"
 
 #: src/scope/move/mut.md:17
 msgid "\"mutable_box contains {}\""
@@ -8846,7 +8846,7 @@ msgstr "\"mutable_box 包含 {}\""
 
 #: src/scope/move/mut.md:19
 msgid "// Modify the contents of the box\n"
-msgstr "// 修改 box 的内容\n"
+msgstr "// 修改盒子的内容\n"
 
 #: src/scope/move/mut.md:22
 msgid "\"mutable_box now contains {}\""
@@ -8874,25 +8874,25 @@ msgstr "\"此人的年龄是 {}\""
 
 #: src/scope/move/partial_move.md:29
 msgid "\"The person's name is {}\""
-msgstr "\"此人的名字是 {}\""
+msgstr "\"此人的姓名是 {}\""
 
 #: src/scope/move/partial_move.md:31
 msgid ""
 "// Error! borrow of partially moved value: `person` partial move occurs\n"
 "    //println!(\"The person struct is {:?}\", person);\n"
 msgstr ""
-"// 错误！借用了部分移动的值：`person` 发生了部分移动\n"
-"    //println!(\"此人的结构体是 {:?}\", person);\n"
+"// 错误！借用部分移动的值：`person` 发生部分移动\n"
+"    //println!(\"person 结构体是 {:?}\", person);\n"
 
 #: src/scope/move/partial_move.md:34
 msgid ""
 "// `person` cannot be used but `person.age` can be used as it is not moved\n"
 msgstr ""
-"// `person` 不能被使用，但 `person.age` 可以使用，因为它没有被移动\n"
+"// `person` 不能使用，但 `person.age` 可以使用，因为它没有被移动\n"
 
 #: src/scope/move/partial_move.md:35
 msgid "\"The person's age from person struct is {}\""
-msgstr "\"从 person 结构体中获取的此人年龄是 {}\""
+msgstr "\"从 person 结构体中获取的年龄是 {}\""
 
 #: src/scope/move/partial_move.md:38
 msgid ""
@@ -8922,19 +8922,19 @@ msgid ""
 "_always_ point to valid objects. That is, while references to an object "
 "exist, the object cannot be destroyed."
 msgstr ""
-"编译器通过其借用检查器静态地保证引用**始终**指向有效的对象。也就是说，当存在引用指向一个对象时，该对象就不能被销毁。"
+"编译器通过其借用检查器静态地保证引用**始终**指向有效的对象。也就是说，当存在指向一个对象的引用时，该对象就不能被销毁。"
 
 #: src/scope/borrow.md:12
 msgid "// This function takes ownership of a box and destroys it\n"
-msgstr "// 这个函数获取一个 box 的所有权并销毁它\n"
+msgstr "// 此函数获取一个盒子的所有权并销毁它\n"
 
 #: src/scope/borrow.md:14
 msgid "\"Destroying box that contains {}\""
-msgstr "\"销毁包含 {} 的 box\""
+msgstr "\"正在销毁包含 {} 的盒子\""
 
 #: src/scope/borrow.md:16
 msgid "// This function borrows an i32\n"
-msgstr "// 这个函数借用一个 i32\n"
+msgstr "// 此函数借用一个 i32\n"
 
 #: src/scope/borrow.md:19
 msgid "\"This int is: {}\""
@@ -8948,7 +8948,7 @@ msgid ""
 "    // 5_i32 is the same as 5i32\n"
 msgstr ""
 "// 在堆上创建一个装箱的 i32，在栈上创建一个 i32\n"
-"    // 注：数字可以添加任意下划线以提高可读性\n"
+"    // 注意：数字可以添加任意下划线以提高可读性\n"
 "    // 5_i32 与 5i32 相同\n"
 
 #: src/scope/borrow.md:29
@@ -8956,12 +8956,12 @@ msgid ""
 "// Borrow the contents of the box. Ownership is not taken,\n"
 "    // so the contents can be borrowed again.\n"
 msgstr ""
-"// 借用 box 的数据。所有权未被获取，\n"
+"// 借用盒子的数据。所有权未被获取，\n"
 "    // 所以数据可以再次被借用。\n"
 
 #: src/scope/borrow.md:35
 msgid "// Take a reference to the data contained inside the box\n"
-msgstr "// 获取 box 内数据的引用\n"
+msgstr "// 获取盒子内数据的引用\n"
 
 #: src/scope/borrow.md:38
 msgid ""
@@ -8993,7 +8993,7 @@ msgid ""
 "`&T` borrows the data via an immutable reference, and the borrower can read "
 "the data but not modify it:"
 msgstr ""
-"可变数据可以使用 `&mut T` 进行可变借用。这被称为**可变引用**，并给予借用者读/写访问权。相比之下，`&T` 通过不可变引用借用数据，借用者可以读取数据但不能修改它："
+"可变数据可以使用 `&mut T` 进行可变借用。这被称为**可变引用**，并给予借用者读写访问权。相比之下，`&T` 通过不可变引用借用数据，借用者可以读取数据但不能修改它："
 
 #: src/scope/borrow/mut.md:12
 msgid ""
@@ -9003,26 +9003,26 @@ msgstr ""
 
 #: src/scope/borrow/mut.md:17
 msgid "// This function takes a reference to a book\n"
-msgstr "// 这个函数接受一个对 Book 类型数据的引用\n"
+msgstr "// 此函数接受一个对 Book 类型的引用\n"
 
 #: src/scope/borrow/mut.md:20
 msgid "\"I immutably borrowed {} - {} edition\""
-msgstr "\"我不可变地借用了 {} - {} 版\""
+msgstr "\"我不可变地借用了《{}》- {} 版\""
 
 #: src/scope/borrow/mut.md:22
 msgid ""
 "// This function takes a reference to a mutable book and changes `year` to "
 "2014\n"
 msgstr ""
-"// 这个函数接受一个对可变书的引用，并将 `year` 改为 2014\n"
+"// 此函数接受一个对可变 Book 的引用，并将 `year` 改为 2014\n"
 
 #: src/scope/borrow/mut.md:26
 msgid "\"I mutably borrowed {} - {} edition\""
-msgstr "\"我可变地借用了 {} - {} 版\""
+msgstr "\"我可变地借用了《{}》- {} 版\""
 
 #: src/scope/borrow/mut.md:30
 msgid "// Create an immutable Book named `immutabook`\n"
-msgstr "// 创建一个名为 `immutabook` 的不可变 Book\n"
+msgstr "// 创建一个名为 `immutabook` 的不可变 Book 实例\n"
 
 #: src/scope/borrow/mut.md:32
 msgid "// string literals have type `&'static str`\n"
@@ -9034,11 +9034,11 @@ msgstr "\"Douglas Hofstadter\""
 
 #: src/scope/borrow/mut.md:34
 msgid "\"Gödel, Escher, Bach\""
-msgstr "\"Gödel, Escher, Bach\""
+msgstr "\"哥德尔、埃舍尔、巴赫\""
 
 #: src/scope/borrow/mut.md:38
 msgid "// Create a mutable copy of `immutabook` and call it `mutabook`\n"
-msgstr "// 创建 `immutabook` 的一个可变副本，并将其命名为 `mutabook`\n"
+msgstr "// 创建 `immutabook` 的可变副本，并命名为 `mutabook`\n"
 
 #: src/scope/borrow/mut.md:41
 msgid "// Immutably borrow an immutable object\n"
@@ -9054,7 +9054,7 @@ msgstr "// 可变地借用一个可变对象\n"
 
 #: src/scope/borrow/mut.md:50
 msgid "// Error! Cannot borrow an immutable object as mutable\n"
-msgstr "// 错误！不能可变地借用一个不可变对象\n"
+msgstr "// 错误！不能将不可变对象作为可变对象借用\n"
 
 #: src/scope/borrow/mut.md:57
 msgid "[`static`](../lifetime/static_lifetime.md)"
@@ -9068,7 +9068,7 @@ msgid ""
 "borrowed again only _after_ the mutable reference has been used for the last "
 "time."
 msgstr ""
-"数据可以被不可变地借用任意次数，但在不可变借用期间，原始数据不能被可变地借用。另一方面，同一时间只允许**一个**可变借用。只有在可变引用最后一次使用之后，原始数据才能再次被借用。"
+"数据可以被不可变借用任意次数，但在不可变借用期间，原始数据不能被可变借用。另一方面，同一时间只允许**一个**可变借用。只有在可变引用最后一次使用之后，原始数据才能再次被借用。"
 
 #: src/scope/borrow/alias.md:17
 msgid "// Data can be accessed via the references and the original owner\n"
@@ -9077,7 +9077,7 @@ msgstr "// 可以通过引用和原始所有者访问数据\n"
 #: src/scope/borrow/alias.md:18 src/scope/borrow/alias.md:27
 #: src/scope/borrow/alias.md:49
 msgid "\"Point has coordinates: ({}, {}, {})\""
-msgstr "\"Point has coordinates: ({}, {}, {})\""
+msgstr "\"点的坐标为：({}, {}, {})\""
 
 #: src/scope/borrow/alias.md:21
 msgid ""
@@ -9100,11 +9100,11 @@ msgid ""
 "    // it is possible to reborrow with a mutable reference.\n"
 msgstr ""
 "// 不可变引用在代码的剩余部分不再使用\n"
-"    // 所以可以用可变引用重新借用。\n"
+"    // 因此可以用可变引用重新借用。\n"
 
 #: src/scope/borrow/alias.md:34
 msgid "// Change data via mutable reference\n"
-msgstr "// 通过可变引用改变数据\n"
+msgstr "// 通过可变引用修改数据\n"
 
 #: src/scope/borrow/alias.md:39
 msgid ""
@@ -9123,13 +9123,13 @@ msgid ""
 "    // println!(\"Point Z coordinate is {}\", point.z);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 错误！不能打印，因为 `println!` 用到了一个不可变引用。\n"
-"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"// 错误！无法打印，因为 `println!` 需要一个不可变引用。\n"
+"    // println!(\"点的 Z 坐标是 {}\", point.z);\n"
 "    // TODO ^ 尝试取消注释此行\n"
 
 #: src/scope/borrow/alias.md:48
 msgid "// Ok! Mutable references can be passed as immutable to `println!`\n"
-msgstr "// 可以！可变引用可以作为不可变引用传递给 `println!`\n"
+msgstr "// 正确！可变引用可以作为不可变引用传递给 `println!`\n"
 
 #: src/scope/borrow/alias.md:52
 msgid ""
@@ -9140,7 +9140,7 @@ msgstr ""
 
 #: src/scope/borrow/alias.md:55
 msgid "\"Point now has coordinates: ({}, {}, {})\""
-msgstr "\"Point now has coordinates: ({}, {}, {})\""
+msgstr "\"点现在的坐标为：({}, {}, {})\""
 
 #: src/scope/borrow/ref.md:3
 msgid ""
@@ -9148,7 +9148,7 @@ msgid ""
 "keyword can be used to take references to the fields of a struct/tuple. The "
 "example below shows a few instances where this can be useful:"
 msgstr ""
-"在通过 `let` 绑定进行模式匹配或解构时，可以使用 `ref` 关键字来获取结构体/元组字段的引用。下面的例子展示了几个这种用法有用的情况："
+"在使用 `let` 绑定进行模式匹配或解构时，可以使用 `ref` 关键字来获取结构体或元组字段的引用。以下示例展示了几个这种用法有用的场景："
 
 #: src/scope/borrow/ref.md:14
 msgid ""
@@ -9159,7 +9159,7 @@ msgstr ""
 
 #: src/scope/borrow/ref.md:19
 msgid "\"ref_c1 equals ref_c2: {}\""
-msgstr "\"ref_c1 equals ref_c2: {}\""
+msgstr "\"ref_c1 等于 ref_c2：{}\""
 
 #: src/scope/borrow/ref.md:23
 msgid "// `ref` is also valid when destructuring a struct.\n"
@@ -9171,15 +9171,15 @@ msgstr "// `ref_to_x` 是 `point` 的 `x` 字段的引用。\n"
 
 #: src/scope/borrow/ref.md:28
 msgid "// Return a copy of the `x` field of `point`.\n"
-msgstr "// 返回 `point` 的 `x` 字段的拷贝。\n"
+msgstr "// 返回 `point` 的 `x` 字段的副本。\n"
 
 #: src/scope/borrow/ref.md:32
 msgid "// A mutable copy of `point`\n"
-msgstr "// `point` 的可变拷贝\n"
+msgstr "// `point` 的可变副本\n"
 
 #: src/scope/borrow/ref.md:36
 msgid "// `ref` can be paired with `mut` to take mutable references.\n"
-msgstr "// `ref` 可以与 `mut` 配对来获取可变引用。\n"
+msgstr "// `ref` 可以与 `mut` 配合使用来获取可变引用。\n"
 
 #: src/scope/borrow/ref.md:39
 msgid "// Mutate the `y` field of `mutable_point` via a mutable reference.\n"
@@ -9187,11 +9187,11 @@ msgstr "// 通过可变引用修改 `mutable_point` 的 `y` 字段。\n"
 
 #: src/scope/borrow/ref.md:43
 msgid "\"point is ({}, {})\""
-msgstr "\"point is ({}, {})\""
+msgstr "\"point 的坐标是 ({}, {})\""
 
 #: src/scope/borrow/ref.md:44
 msgid "\"mutable_point is ({}, {})\""
-msgstr "\"mutable_point is ({}, {})\""
+msgstr "\"mutable_point 的坐标是 ({}, {})\""
 
 #: src/scope/borrow/ref.md:46
 msgid "// A mutable tuple that includes a pointer\n"
@@ -9199,11 +9199,11 @@ msgstr "// 包含指针的可变元组\n"
 
 #: src/scope/borrow/ref.md:50
 msgid "// Destructure `mutable_tuple` to change the value of `last`.\n"
-msgstr "// 解构 `mutable_tuple` 以改变 `last` 的值。\n"
+msgstr "// 解构 `mutable_tuple` 以修改 `last` 的值。\n"
 
 #: src/scope/borrow/ref.md:55
 msgid "\"tuple is {:?}\""
-msgstr "\"tuple is {:?}\""
+msgstr "\"元组是 {:?}\""
 
 #: src/scope/lifetime.md:3
 msgid ""
@@ -9212,7 +9212,7 @@ msgid ""
 "lifetime begins when it is created and ends when it is destroyed. While "
 "lifetimes and scopes are often referred to together, they are not the same."
 msgstr ""
-"**生命周期**是编译器（更具体地说是其**借用检查器**）用来确保所有借用都是有效的一个构造。具体来说，变量的生命周期从创建时开始，到销毁时结束。虽然生命周期和作用域经常被一起提到，但它们并不相同。"
+"**生命周期**是编译器（更具体地说是其**借用检查器**）用来确保所有借用都有效的一种机制。具体来说，变量的生命周期从创建时开始，到销毁时结束。虽然生命周期和作用域经常被一起提到，但它们并不相同。"
 
 #: src/scope/lifetime.md:8
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2025,56 +2025,56 @@ msgstr "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
 #: src/primitives.md:3
 msgid ""
 "Rust provides access to a wide variety of `primitives`. A sample includes:"
-msgstr ""
+msgstr "Rust 提供了多种 `原生类型`（primitive）。以下是一些示例："
 
 #: src/primitives.md:5
 msgid "Scalar Types"
-msgstr ""
+msgstr "标量类型"
 
 #: src/primitives.md:7
 msgid ""
 "Signed integers: `i8`, `i16`, `i32`, `i64`, `i128` and `isize` (pointer size)"
-msgstr ""
+msgstr "有符号整数：`i8`、`i16`、`i32`、`i64`、`i128` 和 `isize`（指针大小）"
 
 #: src/primitives.md:8
 msgid ""
 "Unsigned integers: `u8`, `u16`, `u32`, `u64`, `u128` and `usize` (pointer "
 "size)"
-msgstr ""
+msgstr "无符号整数：`u8`、`u16`、`u32`、`u64`、`u128` 和 `usize`（指针大小）"
 
 #: src/primitives.md:10
 msgid "Floating point: `f32`, `f64`"
-msgstr ""
+msgstr "浮点数：`f32`、`f64`"
 
 #: src/primitives.md:11
 msgid "`char` Unicode scalar values like `'a'`, `'α'` and `'∞'` (4 bytes each)"
-msgstr ""
+msgstr "`char` Unicode 标量值，如 `'a'`、`'α'` 和 `'∞'`（每个都是 4 字节）"
 
 #: src/primitives.md:12
 msgid "`bool` either `true` or `false`"
-msgstr ""
+msgstr "`bool` 值为 `true` 或 `false`"
 
 #: src/primitives.md:13
 msgid "The unit type `()`, whose only possible value is an empty tuple: `()`"
-msgstr ""
+msgstr "单元类型 `()`，其唯一可能的值是空元组：`()`"
 
 #: src/primitives.md:15
 msgid ""
 "Despite the value of a unit type being a tuple, it is not considered a "
 "compound type because it does not contain multiple values."
-msgstr ""
+msgstr "尽管单元类型的值是一个元组，但它不被视为复合类型，因为它不包含多个值。"
 
 #: src/primitives.md:18
 msgid "Compound Types"
-msgstr ""
+msgstr "复合类型"
 
 #: src/primitives.md:20
 msgid "Arrays like `[1, 2, 3]`"
-msgstr ""
+msgstr "数组，如 `[1, 2, 3]`"
 
 #: src/primitives.md:21
 msgid "Tuples like `(1, true)`"
-msgstr ""
+msgstr "元组，如 `(1, true)`"
 
 #: src/primitives.md:23
 msgid ""
@@ -2082,54 +2082,56 @@ msgid ""
 "annotated via a _suffix_ or _by default_. Integers default to `i32` and "
 "floats to `f64`. Note that Rust can also infer types from context."
 msgstr ""
+"变量总是可以进行_类型标注_。数字还可以通过_后缀_或_默认方式_来标注。"
+"整数默认为 `i32` 类型，浮点数默认为 `f64` 类型。请注意，Rust 也可以从上下文中推断类型。"
 
 #: src/primitives.md:29
 msgid "// Variables can be type annotated.\n"
-msgstr ""
+msgstr "// 变量可以被类型标注。\n"
 
 #: src/primitives.md:32
 msgid "// Regular annotation\n"
-msgstr ""
+msgstr "// 常规标注\n"
 
 #: src/primitives.md:33
 msgid "// Suffix annotation\n"
-msgstr ""
+msgstr "// 后缀标注\n"
 
 #: src/primitives.md:35
 msgid "// Or a default will be used.\n"
-msgstr ""
+msgstr "// 或者使用默认类型。\n"
 
 #: src/primitives.md:36
 msgid "// `f64`\n"
-msgstr ""
+msgstr "// `f64`\n"
 
 #: src/primitives.md:37
 msgid "// `i32`\n"
-msgstr ""
+msgstr "// `i32`\n"
 
 #: src/primitives.md:39
 msgid "// A type can also be inferred from context.\n"
-msgstr ""
+msgstr "// 类型也可以从上下文中推断。\n"
 
 #: src/primitives.md:40
 msgid "// Type i64 is inferred from another line.\n"
-msgstr ""
+msgstr "// 从另一行推断出类型为 i64。\n"
 
 #: src/primitives.md:43
 msgid "// A mutable variable's value can be changed.\n"
-msgstr ""
+msgstr "// 可变变量的值可以改变。\n"
 
 #: src/primitives.md:44
 msgid "// Mutable `i32`\n"
-msgstr ""
+msgstr "// 可变的 `i32`\n"
 
 #: src/primitives.md:47
 msgid "// Error! The type of a variable can't be changed.\n"
-msgstr ""
+msgstr "// 错误！变量的类型不能改变。\n"
 
 #: src/primitives.md:50
 msgid "// Variables can be overwritten with shadowing.\n"
-msgstr ""
+msgstr "// 变量可以通过遮蔽（shadowing）来覆盖。\n"
 
 #: src/primitives.md:57
 msgid ""
@@ -2137,24 +2139,32 @@ msgid ""
 "(variable_bindings/mut.md), [`inference`](types/inference.md), and "
 "[`shadowing`](variable_bindings/scope.md)"
 msgstr ""
+"[`std` 库](https://doc.rust-lang.org/std/)、[`mut`]"
+"(variable_bindings/mut.md)、[`inference`](types/inference.md) 和 "
+"[`shadowing`](variable_bindings/scope.md)"
 
 #: src/primitives/literals.md:3
 msgid ""
 "Integers `1`, floats `1.2`, characters `'a'`, strings `\"abc\"`, booleans "
 "`true` and the unit type `()` can be expressed using literals."
 msgstr ""
+"整数 `1`、浮点数 `1.2`、字符 `'a'`、字符串 `\"abc\"`、布尔值 `true` "
+"和单元类型 `()` 可以用字面值表示。"
 
 #: src/primitives/literals.md:6
 msgid ""
 "Integers can, alternatively, be expressed using hexadecimal, octal or binary "
 "notation using these prefixes respectively: `0x`, `0o` or `0b`."
 msgstr ""
+"整数也可以使用十六进制、八进制或二进制表示法，分别使用这些前缀：`0x`、`0o` 或 `0b`。"
 
 #: src/primitives/literals.md:9
 msgid ""
 "Underscores can be inserted in numeric literals to improve readability, e.g. "
 "`1_000` is the same as `1000`, and `0.000_001` is the same as `0.000001`."
 msgstr ""
+"可以在数字字面值中插入下划线以提高可读性，例如 `1_000` 与 `1000` 相同，"
+"`0.000_001` 与 `0.000001` 相同。"
 
 #: src/primitives/literals.md:12
 msgid ""
@@ -2162,6 +2172,8 @@ msgid ""
 "Scientific_notation#E_notation), e.g. `1e6`, `7.6e-4`. The associated type is "
 "`f64`."
 msgstr ""
+"Rust 还支持科学计数法 [E-notation](https://en.wikipedia.org/wiki/"
+"Scientific_notation#E_notation)，例如 `1e6`、`7.6e-4`。相关类型是 `f64`。"
 
 #: src/primitives/literals.md:15
 msgid ""
@@ -2169,6 +2181,8 @@ msgid ""
 "use the `u32` suffix to indicate that the literal is an unsigned 32-bit "
 "integer, and the `i32` suffix to indicate that it's a signed 32-bit integer."
 msgstr ""
+"我们需要告诉编译器我们使用的字面值的类型。现在，我们将使用 `u32` 后缀来表示该字面值是一个无符号 32 位整数，"
+"使用 `i32` 后缀来表示它是一个有符号 32 位整数。"
 
 #: src/primitives/literals.md:19
 msgid ""
@@ -2177,83 +2191,87 @@ msgid ""
 "like languages](https://en.wikipedia.org/wiki/"
 "Operator_precedence#Programming_languages)."
 msgstr ""
+"[Rust 中](https://doc.rust-lang.org/reference/expressions.html#expression-precedence)"
+"可用的运算符及其优先级与其他 [类 C 语言](https://en.wikipedia.org/wiki/"
+"Operator_precedence#Programming_languages) 类似。"
 
 #: src/primitives/literals.md:24
 msgid "// Integer addition\n"
-msgstr ""
+msgstr "// 整数加法\n"
 
 #: src/primitives/literals.md:25
 msgid "\"1 + 2 = {}\""
-msgstr ""
+msgstr "\"1 + 2 = {}\""
 
 #: src/primitives/literals.md:27
 msgid "// Integer subtraction\n"
-msgstr ""
+msgstr "// 整数减法\n"
 
 #: src/primitives/literals.md:28
 msgid "\"1 - 2 = {}\""
-msgstr ""
+msgstr "\"1 - 2 = {}\""
 
 #: src/primitives/literals.md:29
 msgid ""
 "// TODO ^ Try changing `1i32` to `1u32` to see why the type is important\n"
 msgstr ""
+"// TODO ^ 尝试将 `1i32` 改为 `1u32`，看看为什么类型很重要\n"
 
 #: src/primitives/literals.md:31
 msgid "// Scientific notation\n"
-msgstr ""
+msgstr "// 科学记数法\n"
 
 #: src/primitives/literals.md:32
 msgid "\"1e4 is {}, -2.5e-3 is {}\""
-msgstr ""
+msgstr "\"1e4 is {}, -2.5e-3 is {}\""
 
 #: src/primitives/literals.md:34
 msgid "// Short-circuiting boolean logic\n"
-msgstr ""
+msgstr "// 短路布尔逻辑\n"
 
 #: src/primitives/literals.md:35
 msgid "\"true AND false is {}\""
-msgstr ""
+msgstr "\"true AND false is {}\""
 
 #: src/primitives/literals.md:36
 msgid "\"true OR false is {}\""
-msgstr ""
+msgstr "\"true OR false is {}\""
 
 #: src/primitives/literals.md:37
 msgid "\"NOT true is {}\""
-msgstr ""
+msgstr "\"NOT true is {}\""
 
 #: src/primitives/literals.md:39
 msgid "// Bitwise operations\n"
-msgstr ""
+msgstr "// 位运算\n"
 
 #: src/primitives/literals.md:40
 msgid "\"0011 AND 0101 is {:04b}\""
-msgstr ""
+msgstr "\"0011 AND 0101 is {:04b}\""
 
 #: src/primitives/literals.md:41
 msgid "\"0011 OR 0101 is {:04b}\""
-msgstr ""
+msgstr "\"0011 OR 0101 is {:04b}\""
 
 #: src/primitives/literals.md:42
 msgid "\"0011 XOR 0101 is {:04b}\""
-msgstr ""
+msgstr "\"0011 XOR 0101 is {:04b}\""
 
 #: src/primitives/literals.md:43
 msgid "\"1 << 5 is {}\""
-msgstr ""
+msgstr "\"1 << 5 is {}\""
 
 #: src/primitives/literals.md:44
 msgid "\"0x80 >> 2 is 0x{:x}\""
-msgstr ""
+msgstr "\"0x80 >> 2 is 0x{:x}\""
 
 #: src/primitives/literals.md:46
 msgid "// Use underscores to improve readability!\n"
-msgstr ""
+msgstr "// 使用下划线来提高可读性！\n"
 
 #: src/primitives/literals.md:47
 msgid "\"One million is written as {}\""
-msgstr ""
+msgstr "\"One million is written as {}\""
 
 #: src/primitives/tuples.md:3
 msgid ""
@@ -2262,51 +2280,53 @@ msgid ""
 "`(T1, T2, ...)`, where `T1`, `T2` are the types of its members. Functions can "
 "use tuples to return multiple values, as tuples can hold any number of values."
 msgstr ""
+"元组是一个可以包含各种类型的值的集合。元组使用圆括号 `()` 来构造，而且每个元组本身是一个类型标记为 "
+"`(T1, T2, ...)` 的值，其中 `T1`、`T2` 是其成员的类型。函数可以使用元组来返回多个值，因为元组可以存储任意数量的值。"
 
 #: src/primitives/tuples.md:9
 msgid "// Tuples can be used as function arguments and as return values.\n"
-msgstr ""
+msgstr "// 元组可以用作函数参数和返回值。\n"
 
 #: src/primitives/tuples.md:11
 msgid "// `let` can be used to bind the members of a tuple to variables.\n"
-msgstr ""
+msgstr "// `let` 可以用来把元组的成员绑定到变量。\n"
 
 #: src/primitives/tuples.md:16
 msgid "// The following struct is for the activity.\n"
-msgstr ""
+msgstr "// 在 “动手试一试” 的练习中要用到下面这个结构体。\n"
 
 #: src/primitives/tuples.md:22
 msgid "// A tuple with a bunch of different types.\n"
-msgstr ""
+msgstr "// 一个包含多种不同类型的元组。\n"
 
 #: src/primitives/tuples.md:26 src/generics.md:50 src/generics.md:55
 #: src/generics/gen_fn.md:47
 msgid "'a'"
-msgstr ""
+msgstr "'a'"
 
 #: src/primitives/tuples.md:28
 msgid "// Values can be extracted from the tuple using tuple indexing.\n"
-msgstr ""
+msgstr "// 可以使用元组索引来提取元组中的值。\n"
 
 #: src/primitives/tuples.md:29
 msgid "\"Long tuple first value: {}\""
-msgstr ""
+msgstr "\"Long tuple first value: {}\""
 
 #: src/primitives/tuples.md:30
 msgid "\"Long tuple second value: {}\""
-msgstr ""
+msgstr "\"Long tuple second value: {}\""
 
 #: src/primitives/tuples.md:32
 msgid "// Tuples can be tuple members.\n"
-msgstr ""
+msgstr "// 元组可以作为元组的成员。\n"
 
 #: src/primitives/tuples.md:35
 msgid "// Tuples are printable.\n"
-msgstr ""
+msgstr "// 元组是可打印的。\n"
 
 #: src/primitives/tuples.md:36
 msgid "\"tuple of tuples: {:?}\""
-msgstr ""
+msgstr "\"tuple of tuples: {:?}\""
 
 #: src/primitives/tuples.md:38
 msgid ""
@@ -2315,41 +2335,46 @@ msgid ""
 "    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
 "    // TODO ^ Uncomment the above 2 lines to see the compiler error\n"
 msgstr ""
+"// 但是长元组（超过 12 个元素）不能被打印。\n"
+"    //let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
+"    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
+"    // TODO ^ 取消上面两行的注释，查看编译器错误\n"
 
 #: src/primitives/tuples.md:44
 msgid "\"Pair is {:?}\""
-msgstr ""
+msgstr "\"Pair is {:?}\""
 
 #: src/primitives/tuples.md:46
 msgid "\"The reversed pair is {:?}\""
-msgstr ""
+msgstr "\"The reversed pair is {:?}\""
 
 #: src/primitives/tuples.md:48
 msgid ""
 "// To create one element tuples, the comma is required to tell them apart\n"
 "    // from a literal surrounded by parentheses.\n"
 msgstr ""
+"// 创建单元素元组需要一个逗号，以区别被括号包围的字面量。\n"
 
 #: src/primitives/tuples.md:50
 msgid "\"One element tuple: {:?}\""
-msgstr ""
+msgstr "\"One element tuple: {:?}\""
 
 #: src/primitives/tuples.md:51
 msgid "\"Just an integer: {:?}\""
-msgstr ""
+msgstr "\"Just an integer: {:?}\""
 
 #: src/primitives/tuples.md:53
 msgid "// Tuples can be destructured to create bindings.\n"
-msgstr ""
+msgstr "// 元组可以被解构，以创建绑定。\n"
 
 #: src/primitives/tuples.md:54 src/conversion/from_into.md:17
 #: src/fn/closures/input_parameters.md:52 src/std_misc/fs.md:51
 msgid "\"hello\""
-msgstr ""
+msgstr "\"hello\""
 
 #: src/primitives/tuples.md:57
 msgid "\"{:?}, {:?}, {:?}, {:?}\""
-msgstr ""
+msgstr "\"{:?}, {:?}, {:?}, {:?}\""
 
 #: src/primitives/tuples.md:66
 msgid ""
@@ -2357,12 +2382,15 @@ msgid ""
 "example, so that if you switch from printing the debug format `{:?}` to the "
 "display format `{}`, you see the following output:"
 msgstr ""
+"**复习**：在上面的例子中为 `Matrix` 结构体添加 `fmt::Display` trait，这样当你从打印调试格式 `{:?}` "
+"切换到显示格式 `{}` 时，你会看到以下输出："
 
 #: src/primitives/tuples.md:75
 msgid ""
 "You may want to refer back to the example for [print display](../hello/print/"
 "print_display.md)."
 msgstr ""
+"你可能想回顾一下[输出显示（Display）](../hello/print/print_display.md) 的例子。"
 
 #: src/primitives/tuples.md:76
 msgid ""
@@ -2370,18 +2398,20 @@ msgid ""
 "accepts a matrix as an argument, and returns a matrix in which two elements "
 "have been swapped. For example:"
 msgstr ""
+"添加一个 `transpose` 函数，使用 `reverse` 函数作为模板，该函数接受一个矩阵作为参数，"
+"并返回一个两个元素已交换的矩阵。例如："
 
 #: src/primitives/tuples.md:81
 msgid "\"Matrix:\\n{}\""
-msgstr ""
+msgstr "\"矩阵：\\n{}\""
 
 #: src/primitives/tuples.md:82
 msgid "\"Transpose:\\n{}\""
-msgstr ""
+msgstr "\"转置：\\n{}\""
 
 #: src/primitives/tuples.md:85
 msgid "Results in the output:"
-msgstr ""
+msgstr "得到的输出为："
 
 #: src/primitives/array.md:3
 msgid ""
@@ -2389,6 +2419,8 @@ msgid ""
 "contiguous memory. Arrays are created using brackets `[]`, and their length, "
 "which is known at compile time, is part of their type signature `[T; length]`."
 msgstr ""
+"数组（array）是一个存储在连续内存中的相同类型 `T` 的对象集合。数组使用方括号 `[]` 来创建，"
+"其长度在编译时是已知的，是它们类型签名 `[T; length]` 的一部分。"
 
 #: src/primitives/array.md:7
 msgid ""
@@ -2399,62 +2431,65 @@ msgid ""
 "x86-64. Slices can be used to borrow a section of an array and have the type "
 "signature `&[T]`."
 msgstr ""
+"切片（slice）与数组类似，但其长度在编译时是未知的。实际上，切片是一个双字对象（two-word object）；第一个字是指向数据的指针，"
+"第二个字是切片的长度。字的大小与 usize 相同，由处理器架构决定，例如在 x86-64 上是 64 位。"
+"切片可以用来借用数组的一部分，其类型签名为 `&[T]`。"
 
 #: src/primitives/array.md:15
 msgid "// This function borrows a slice.\n"
-msgstr ""
+msgstr "// 这个函数借用一个切片。\n"
 
 #: src/primitives/array.md:18
 msgid "\"First element of the slice: {}\""
-msgstr ""
+msgstr "\"First element of the slice: {}\""
 
 #: src/primitives/array.md:19
 msgid "\"The slice has {} elements\""
-msgstr ""
+msgstr "\"The slice has {} elements\""
 
 #: src/primitives/array.md:23
 msgid "// Fixed-size array (type signature is superfluous).\n"
-msgstr ""
+msgstr "// 固定大小的数组（类型签名是多余的）。\n"
 
 #: src/primitives/array.md:26
 msgid "// All elements can be initialized to the same value.\n"
-msgstr ""
+msgstr "// 所有元素可以被初始化为相同的值。\n"
 
 #: src/primitives/array.md:29
 msgid "// Indexing starts at 0.\n"
-msgstr ""
+msgstr "// 索引从 0 开始。\n"
 
 #: src/primitives/array.md:30
 msgid "\"First element of the array: {}\""
-msgstr ""
+msgstr "\"First element of the array: {}\""
 
 #: src/primitives/array.md:31
 msgid "\"Second element of the array: {}\""
-msgstr ""
+msgstr "\"Second element of the array: {}\""
 
 #: src/primitives/array.md:33
 msgid "// `len` returns the count of elements in the array.\n"
-msgstr ""
+msgstr "// `len` 返回数组中元素的数量。\n"
 
 #: src/primitives/array.md:34
 msgid "\"Number of elements in array: {}\""
-msgstr ""
+msgstr "\"Number of elements in array: {}\""
 
 #: src/primitives/array.md:36
 msgid "// Arrays are stack allocated.\n"
-msgstr ""
+msgstr "// 数组是栈分配的。\n"
 
 #: src/primitives/array.md:37
 msgid "\"Array occupies {} bytes\""
-msgstr ""
+msgstr "\"Array occupies {} bytes\""
 
 #: src/primitives/array.md:39
 msgid "// Arrays can be automatically borrowed as slices.\n"
-msgstr ""
+msgstr "// 数组可以自动借用为切片。\n"
 
 #: src/primitives/array.md:40
 msgid "\"Borrow the whole array as a slice.\""
-msgstr ""
+msgstr "\"Borrow the whole array as a slice.\""
 
 #: src/primitives/array.md:43
 msgid ""
@@ -2463,18 +2498,22 @@ msgid ""
 "    // `starting_index` is the first position in the slice.\n"
 "    // `ending_index` is one more than the last position in the slice.\n"
 msgstr ""
+"// 切片可以指向数组的一部分。\n"
+"    // 它们的形式是 [starting_index..ending_index]。\n"
+"    // `starting_index` 是切片中的第一个位置。\n"
+"    // `ending_index` 是切片中最后一个位置的后一个位置。\n"
 
 #: src/primitives/array.md:47
 msgid "\"Borrow a section of the array as a slice.\""
-msgstr ""
+msgstr "\"Borrow a section of the array as a slice.\""
 
 #: src/primitives/array.md:50
 msgid "// Example of empty slice `&[]`:\n"
-msgstr ""
+msgstr "// 空切片 `&[]` 的例子：\n"
 
 #: src/primitives/array.md:53
 msgid "// Same but more verbose\n"
-msgstr ""
+msgstr "// 同样的操作，但更冗长\n"
 
 #: src/primitives/array.md:55
 msgid ""
@@ -2483,18 +2522,21 @@ msgid ""
 "    // `.expect()` if you would like the program to exit with a nice\n"
 "    // message instead of happily continue.\n"
 msgstr ""
+"// 可以使用 `.get` 安全地访问数组，它返回一个 `Option`。\n"
+"    // 可以像下面这样对其进行匹配，或者使用 `.expect()`，\n"
+"    // 如果你希望程序在访问越界时适当地退出，而不是继续执行。\n"
 
 #: src/primitives/array.md:59
 msgid "// Oops, one element too far!\n"
-msgstr ""
+msgstr "// 哎呀，越界访问了元素！\n"
 
 #: src/primitives/array.md:61
 msgid "\"{}: {}\""
-msgstr ""
+msgstr "\"{}: {}\""
 
 #: src/primitives/array.md:62
 msgid "\"Slow down! {} is too far!\""
-msgstr ""
+msgstr "\"Slow down! {} is too far!\""
 
 #: src/primitives/array.md:66
 msgid ""
@@ -2503,6 +2545,10 @@ msgid ""
 "    // Out of bound indexing on slice causes runtime error.\n"
 "    //println!(\"{}\", xs[..][5]);\n"
 msgstr ""
+"// 对数组的越界索引会导致编译时错误。\n"
+"    //println!(\"{}\", xs[5]);\n"
+"    // 对切片的越界索引会导致运行时错误。\n"
+"    //println!(\"{}\", xs[..][5]);\n"
 
 #: src/custom_types.md:3
 msgid "Rust custom data types are formed mainly through the two keywords:"

--- a/po/zh.po
+++ b/po/zh.po
@@ -13464,7 +13464,7 @@ msgid ""
 "Consider a `HashSet` as a `HashMap` where we just care about the keys "
 "( `HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`)."
 msgstr ""
-"可以将 `HashSet` 视为一个只关心键的 `HashMap`（实际上，`HashSet<T>` 只是 `HashMap<T, ()>` 的一个封装）。"
+"可以将 `HashSet` 当作一个只关心键的 `HashMap`（实际上，`HashSet<T>` 只是 `HashMap<T, ()>` 的一个封装）。"
 
 #: src/std/hash/hashset.md:6
 msgid ""
@@ -13480,7 +13480,7 @@ msgid ""
 "just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/"
 "std/collections/struct.BTreeSet.html))"
 msgstr ""
-"`HashSet` 的独特之处在于它保证不会有重复的元素。这是任何集合类型都应该满足的契约。`HashSet` 只是其中一种实现。（另见：[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
+"`HashSet` 的独特之处在于它保证不会有重复的元素。这是任何集合（Set）类型都应该满足的契约。`HashSet` 只是其中一种实现。（另见：[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
 
 #: src/std/hash/hashset.md:13
 msgid ""
@@ -13510,27 +13510,27 @@ msgstr ""
 
 #: src/std/hash/hashset.md:24
 msgid "`union`: get all the unique elements in both sets."
-msgstr "`union`：获取两个集合中的所有唯一元素。"
+msgstr "并集（`union`）：获取两个集合中的所有唯一元素。"
 
 #: src/std/hash/hashset.md:26
 msgid ""
 "`difference`: get all the elements that are in the first set but not the "
 "second."
-msgstr "`difference`：获取存在于第一个集合但不在第二个集合中的所有元素。"
+msgstr "差集（`difference`）：获取存在于第一个集合但不在第二个集合中的所有元素。"
 
 #: src/std/hash/hashset.md:28
 msgid "`intersection`: get all the elements that are only in _both_ sets."
-msgstr "`intersection`：获取**同时**存在于两个集合中的所有元素。"
+msgstr "交集（`intersection`）：获取**同时**存在于两个集合中的所有元素。"
 
 #: src/std/hash/hashset.md:30
 msgid ""
 "`symmetric_difference`: get all the elements that are in one set or the "
 "other, but _not_ both."
-msgstr "`symmetric_difference`：获取存在于其中一个集合中，但**不**同时存在于两个集合中的所有元素。"
+msgstr "对称差（`symmetric_difference`）：获取存在于其中一个集合中，但**不**同时存在于两个集合中的所有元素。"
 
 #: src/std/hash/hashset.md:33
 msgid "Try all of these in the following example:"
-msgstr "在下面的例子中尝试所有这些操作："
+msgstr "在下面的例子中尝试这些操作："
 
 #: src/std/hash/hashset.md:45
 msgid ""
@@ -13606,7 +13606,7 @@ msgid ""
 "keeps track of the number of the references which means the number of owners "
 "of the value wrapped inside an `Rc`."
 msgstr ""
-"当需要多重所有权时，可以使用 `Rc`（引用计数）。`Rc` 会跟踪引用的数量，也就是包裹在 `Rc` 内部的值的所有者数量。"
+"当需要多个所有权时，可以使用 `Rc`（Reference Counting, 引用计数）。`Rc` 会跟踪引用的数量，也就是包裹在 `Rc` 内部的值的所有者数量。"
 
 #: src/std/rc.md:5
 msgid ""
@@ -13615,7 +13615,7 @@ msgid ""
 "`Rc`'s reference count becomes zero (which means there are no remaining "
 "owners), both the `Rc` and the value are all dropped."
 msgstr ""
-"每当克隆一个 `Rc` 时，引用计数就会增加 1，每当一个克隆的 `Rc` 离开作用域时，引用计数就会减少 1。当 `Rc` 的引用计数变为零（这意味着没有剩余的所有者）时，`Rc` 和其中的值都会被丢弃。"
+"每当克隆一个 `Rc` 时，引用计数就会增加 1，每当一个克隆的 `Rc` 离开作用域时，引用计数就会减少 1。当 `Rc` 的引用计数变为零（这意味着已经没有所有者了）时，`Rc` 和其中的值都会被丢弃。"
 
 #: src/std/rc.md:7
 msgid ""
@@ -13705,7 +13705,7 @@ msgid ""
 "when the last reference pointer to a value is out of scope, the variable is "
 "dropped."
 msgstr ""
-"当需要在线程间共享所有权时，可以使用 `Arc`（原子引用计数）。这个结构体通过 `Clone` 实现可以为内存堆中值的位置创建一个引用指针，同时增加引用计数。由于它在线程间共享所有权，当最后一个指向某个值的引用指针离开作用域时，该变量就会被丢弃。"
+"当需要在线程间共享所有权时，可以使用 `Arc`（Atomically Reference Counted，原子引用计数）。这个结构体通过 `Clone` 实现可以为内存堆中值的位置创建一个引用指针，同时增加引用计数。由于它在线程间共享所有权，当最后一个指向某个值的引用指针离开作用域时，该变量就会被释放。"
 
 #: src/std/arc.md:15
 msgid "// This variable declaration is where its value is specified.\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -12437,32 +12437,34 @@ msgid ""
 "The `std` library provides many custom types which expands drastically on the "
 "`primitives`. Some of these include:"
 msgstr ""
+"`std` 库提供了许多自定义类型，这些类型大大扩展了`原始类型`。其中包括："
 
 #: src/std.md:6
 msgid "growable `String`s like: `\"hello world\"`"
-msgstr ""
+msgstr "可增长的 `String`，如：`\"hello world\"`"
 
 #: src/std.md:7
 msgid "growable vectors: `[1, 2, 3]`"
-msgstr ""
+msgstr "可增长的向量：`[1, 2, 3]`"
 
 #: src/std.md:8
 msgid "optional types: `Option<i32>`"
-msgstr ""
+msgstr "可选类型：`Option<i32>`"
 
 #: src/std.md:9
 msgid "error handling types: `Result<i32, i32>`"
-msgstr ""
+msgstr "错误处理类型：`Result<i32, i32>`"
 
 #: src/std.md:10
 msgid "heap allocated pointers: `Box<i32>`"
-msgstr ""
+msgstr "堆分配的指针：`Box<i32>`"
 
 #: src/std.md:14 src/std_misc.md:14
 msgid ""
 "[primitives](primitives.md) and [the std library](https://doc.rust-lang.org/"
 "std/)"
 msgstr ""
+"[原始类型](primitives.md) 和 [std 库](https://doc.rust-lang.org/std/)"
 
 #: src/std/box.md:3
 msgid ""
@@ -12472,72 +12474,79 @@ msgid ""
 "destructor is called, the inner object is destroyed, and the memory on the "
 "heap is freed."
 msgstr ""
+"在 Rust 中，所有值默认都是栈分配的。通过创建 `Box<T>`，可以将值**装箱**（在堆上分配）。"
+"Box 是指向堆分配的 `T` 类型值的智能指针。当 box 离开作用域时，它的析构函数被调用，"
+"内部对象被销毁，堆上的内存被释放。"
 
 #: src/std/box.md:8
 msgid ""
 "Boxed values can be dereferenced using the `*` operator; this removes one "
 "layer of indirection."
 msgstr ""
+"可以使用 `*` 运算符解引用装箱的值；这会移除一层间接引用。"
 
 #: src/std/box.md:20
 msgid ""
 "// A Rectangle can be specified by where its top left and bottom right \n"
 "// corners are in space\n"
 msgstr ""
+"// 可以通过指定左上角和右下角在空间中的位置来定义一个矩形\n"
 
 #: src/std/box.md:34
 msgid "// Allocate this point on the heap, and return a pointer to it\n"
-msgstr ""
+msgstr "// 在堆上分配这个点，并返回指向它的指针\n"
 
 #: src/std/box.md:39
 msgid ""
 "// (all the type annotations are superfluous)\n"
 "    // Stack allocated variables\n"
 msgstr ""
+"// （所有的类型注解都不是必须的）\n"
+"    // 栈分配的变量\n"
 
 #: src/std/box.md:47
 msgid "// Heap allocated rectangle\n"
-msgstr ""
+msgstr "// 堆分配的矩形\n"
 
 #: src/std/box.md:53
 msgid "// The output of functions can be boxed\n"
-msgstr ""
+msgstr "// 函数的输出可以被装箱\n"
 
 #: src/std/box.md:56
 msgid "// Double indirection\n"
-msgstr ""
+msgstr "// 两层装箱\n"
 
 #: src/std/box.md:59
 msgid "\"Point occupies {} bytes on the stack\""
-msgstr ""
+msgstr "\"Point 在栈上占用 {} 字节\""
 
 #: src/std/box.md:61
 msgid "\"Rectangle occupies {} bytes on the stack\""
-msgstr ""
+msgstr "\"Rectangle 在栈上占用 {} 字节\""
 
 #: src/std/box.md:64
 msgid "// box size == pointer size\n"
-msgstr ""
+msgstr "// box 大小 == 指针大小\n"
 
 #: src/std/box.md:65
 msgid "\"Boxed point occupies {} bytes on the stack\""
-msgstr ""
+msgstr "\"装箱的 point 在栈上占用 {} 字节\""
 
 #: src/std/box.md:67
 msgid "\"Boxed rectangle occupies {} bytes on the stack\""
-msgstr ""
+msgstr "\"装箱的 rectangle 在栈上占用 {} 字节\""
 
 #: src/std/box.md:69
 msgid "\"Boxed box occupies {} bytes on the stack\""
-msgstr ""
+msgstr "\"装箱的 box 在栈上占用 {} 字节\""
 
 #: src/std/box.md:72
 msgid "// Copy the data contained in `boxed_point` into `unboxed_point`\n"
-msgstr ""
+msgstr "// 将 `boxed_point` 中包含的数据复制到 `unboxed_point`\n"
 
 #: src/std/box.md:74
 msgid "\"Unboxed point occupies {} bytes on the stack\""
-msgstr ""
+msgstr "\"未装箱的 point 在栈上占用 {} 字节\""
 
 #: src/std/vec.md:3
 msgid ""
@@ -12545,18 +12554,20 @@ msgid ""
 "compile time, but they can grow or shrink at any time. A vector is "
 "represented using 3 parameters:"
 msgstr ""
+"向量（Vector）是可调整大小的数组。和切片（Slice）类似，它们的大小在编译时是未知的，但可以随时增长或缩小。"
+"向量使用 3 个参数表示："
 
 #: src/std/vec.md:6
 msgid "pointer to the data"
-msgstr ""
+msgstr "指向数据的指针"
 
 #: src/std/vec.md:7
 msgid "length"
-msgstr ""
+msgstr "长度"
 
 #: src/std/vec.md:8
 msgid "capacity"
-msgstr ""
+msgstr "容量"
 
 #: src/std/vec.md:10
 msgid ""
@@ -12565,110 +12576,117 @@ msgid ""
 "threshold needs to be surpassed, the vector is reallocated with a larger "
 "capacity."
 msgstr ""
+"容量表示为向量保留了多少内存。只要长度小于容量，向量就可以增长。当需要超过这个阈值时，"
+"向量会被重新分配更大的容量。"
 
 #: src/std/vec.md:16
 msgid "// Iterators can be collected into vectors\n"
-msgstr ""
+msgstr "// 迭代器可以被收集到向量中\n"
 
 #: src/std/vec.md:18
 msgid "\"Collected (0..10) into: {:?}\""
-msgstr ""
+msgstr "\"收集 (0..10) 到：{:?}\""
 
 #: src/std/vec.md:20
 msgid "// The `vec!` macro can be used to initialize a vector\n"
-msgstr ""
+msgstr "// `vec!` 宏可以用来初始化一个向量\n"
 
 #: src/std/vec.md:22
 msgid "\"Initial vector: {:?}\""
-msgstr ""
+msgstr "\"初始向量：{:?}\""
 
 #: src/std/vec.md:24
 msgid "// Insert new element at the end of the vector\n"
-msgstr ""
+msgstr "// 在向量的末尾插入新元素\n"
 
 #: src/std/vec.md:25
 msgid "\"Push 4 into the vector\""
-msgstr ""
+msgstr "\"将 4 推入向量\""
 
 #: src/std/vec.md:27
 msgid "\"Vector: {:?}\""
-msgstr ""
+msgstr "\"向量：{:?}\""
 
 #: src/std/vec.md:29
 msgid "// Error! Immutable vectors can't grow\n"
-msgstr ""
+msgstr "// 错误！不可变向量不能增长\n"
 
 #: src/std/vec.md:33
 msgid ""
 "// The `len` method yields the number of elements currently stored in a "
 "vector\n"
-msgstr ""
+msgstr "// `len` 方法返回当前存储在向量中的元素数量\n"
 
 #: src/std/vec.md:34
 msgid "\"Vector length: {}\""
-msgstr ""
+msgstr "\"向量长度：{}\""
 
 #: src/std/vec.md:36
 msgid "// Indexing is done using the square brackets (indexing starts at 0)\n"
-msgstr ""
+msgstr "// 使用方括号进行索引（索引从 0 开始）\n"
 
 #: src/std/vec.md:37
 msgid "\"Second element: {}\""
-msgstr ""
+msgstr "\"第二个元素：{}\""
 
 #: src/std/vec.md:39
 msgid "// `pop` removes the last element from the vector and returns it\n"
-msgstr ""
+msgstr "// `pop` 移除向量的最后一个元素并返回它\n"
 
 #: src/std/vec.md:40
 msgid "\"Pop last element: {:?}\""
-msgstr ""
+msgstr "\"弹出最后一个元素：{:?}\""
 
 #: src/std/vec.md:42
 msgid "// Out of bounds indexing yields a panic\n"
-msgstr ""
+msgstr "// 越界索引会导致 panic\n"
 
 #: src/std/vec.md:43
 msgid "\"Fourth element: {}\""
-msgstr ""
+msgstr "\"第四个元素：{}\""
 
 #: src/std/vec.md:46
 msgid "// `Vector`s can be easily iterated over\n"
-msgstr ""
+msgstr "// `Vector` 可以很容易地被迭代\n"
 
 #: src/std/vec.md:47
 msgid "\"Contents of xs:\""
-msgstr ""
+msgstr "\"xs 的内容：\""
 
 #: src/std/vec.md:52
 msgid ""
 "// A `Vector` can also be iterated over while the iteration\n"
 "    // count is enumerated in a separate variable (`i`)\n"
 msgstr ""
+"// `Vector` 也可以被迭代，同时迭代计数\n"
+"    // 被枚举在一个单独的变量中（`i`）\n"
 
 #: src/std/vec.md:55
 msgid "\"In position {} we have value {}\""
-msgstr ""
+msgstr "\"在位置 {} 我们有值 {}\""
 
 #: src/std/vec.md:58
 msgid ""
 "// Thanks to `iter_mut`, mutable `Vector`s can also be iterated\n"
 "    // over in a way that allows modifying each value\n"
 msgstr ""
+"// 多亏了 `iter_mut`，可变的 `Vector` 也可以被迭代\n"
+"    // 以一种允许修改每个值的方式\n"
 
 #: src/std/vec.md:63
 msgid "\"Updated vector: {:?}\""
-msgstr ""
+msgstr "\"更新后的向量：{:?}\""
 
 #: src/std/vec.md:67
 msgid ""
 "More `Vec` methods can be found under the [std::vec](https://doc.rust-lang."
 "org/std/vec/) module"
 msgstr ""
+"更多 `Vec` 方法可以在 [std::vec](https://doc.rust-lang.org/std/vec/) 模块中找到"
 
 #: src/std/str.md:3
 msgid "The two most used string types in Rust are `String` and `&str`."
-msgstr ""
+msgstr "Rust 中最常用的两种字符串类型是 `String` 和 `&str`。"
 
 #: src/std/str.md:5
 msgid ""
@@ -12676,88 +12694,93 @@ msgid ""
 "always be a valid UTF-8 sequence. `String` is heap allocated, growable and "
 "not null terminated."
 msgstr ""
+"`String` 存储为字节向量（`Vec<u8>`），但保证了是有效的 UTF-8 序列。`String` 是堆分配的，可增长的，且不以 null 结尾。"
 
 #: src/std/str.md:9
 msgid ""
 "`&str` is a slice (`&[u8]`) that always points to a valid UTF-8 sequence, and "
 "can be used to view into a `String`, just like `&[T]` is a view into `Vec<T>`."
 msgstr ""
+"`&str` 是一个切片（`&[u8]`），它始终指向一个有效的 UTF-8 序列，可以用来查看 `String`，就像 `&[T]` 是 `Vec<T>` 的一个视图一样。"
 
 #: src/std/str.md:14
 msgid ""
 "// (all the type annotations are superfluous)\n"
 "    // A reference to a string allocated in read only memory\n"
 msgstr ""
+"// （所有的类型注解都是多余的）\n"
+"    // 一个指向只读内存中分配的字符串的引用\n"
 
 #: src/std/str.md:16
 msgid "\"the quick brown fox jumps over the lazy dog\""
-msgstr ""
+msgstr "\"the quick brown fox jumps over the lazy dog\""
 
 #: src/std/str.md:17
 msgid "\"Pangram: {}\""
-msgstr ""
+msgstr "\"Pangram: {}\""
 
 #: src/std/str.md:19
 msgid "// Iterate over words in reverse, no new string is allocated\n"
-msgstr ""
+msgstr "// 逆序迭代单词，不会分配新的字符串\n"
 
 #: src/std/str.md:20
 msgid "\"Words in reverse\""
-msgstr ""
+msgstr "\"反向的单词\""
 
 #: src/std/str.md:25
 msgid "// Copy chars into a vector, sort and remove duplicates\n"
-msgstr ""
+msgstr "// 将字符复制到向量中，排序并移除重复项\n"
 
 #: src/std/str.md:30
 msgid "// Create an empty and growable `String`\n"
-msgstr ""
+msgstr "// 创建一个空的可增长的 `String`\n"
 
 #: src/std/str.md:33
 msgid "// Insert a char at the end of string\n"
-msgstr ""
+msgstr "// 在字符串末尾插入一个字符\n"
 
 #: src/std/str.md:35
 msgid "// Insert a string at the end of string\n"
-msgstr ""
+msgstr "// 在字符串末尾插入一个字符串\n"
 
 #: src/std/str.md:39
 msgid ""
 "// The trimmed string is a slice to the original string, hence no new\n"
 "    // allocation is performed\n"
 msgstr ""
+"// 修剪后的字符串是原始字符串的一个切片，因此不会进行新的分配\n"
 
 #: src/std/str.md:43
 msgid "\"Used characters: {}\""
-msgstr ""
+msgstr "\"使用的字符：{}\""
 
 #: src/std/str.md:45
 msgid "// Heap allocate a string\n"
-msgstr ""
+msgstr "// 在堆上分配一个字符串\n"
 
 #: src/std/str.md:46
 msgid "\"I like dogs\""
-msgstr ""
+msgstr "\"I like dogs\""
 
 #: src/std/str.md:47
 msgid "// Allocate new memory and store the modified string there\n"
-msgstr ""
+msgstr "// 分配新的内存并在那里存储修改后的字符串\n"
 
 #: src/std/str.md:48
 msgid "\"dog\""
-msgstr ""
+msgstr "\"dog\""
 
 #: src/std/str.md:48
 msgid "\"cat\""
-msgstr ""
+msgstr "\"cat\""
 
 #: src/std/str.md:50
 msgid "\"Alice says: {}\""
-msgstr ""
+msgstr "\"Alice 说：{}\""
 
 #: src/std/str.md:51
 msgid "\"Bob says: {}\""
-msgstr ""
+msgstr "\"Bob 说：{}\""
 
 #: src/std/str.md:55
 msgid ""
@@ -12765,10 +12788,11 @@ msgid ""
 "rust-lang.org/std/str/) and [std::string](https://doc.rust-lang.org/std/"
 "string/) modules"
 msgstr ""
+"更多 `str`/`String` 方法可以在 [std::str](https://doc.rust-lang.org/std/str/) 和 [std::string](https://doc.rust-lang.org/std/string/) 模块中找到"
 
 #: src/std/str.md:60
 msgid "Literals and escapes"
-msgstr ""
+msgstr "字面值和转义"
 
 #: src/std/str.md:62
 msgid ""
@@ -12777,6 +12801,7 @@ msgid ""
 "most convenient to write. Similarly there are multiple ways to write byte "
 "string literals, which all result in `&[u8; N]`."
 msgstr ""
+"有多种方式可以编写包含特殊字符的字符串字面值。所有方式都会产生类似的 `&str`，所以最好使用最方便编写的形式。同样，也有多种方式可以编写字节字符串字面值，它们都会产生 `&[u8; N]`。"
 
 #: src/std/str.md:67
 msgid ""
@@ -12785,40 +12810,42 @@ msgid ""
 "ones that you don't know how to type. If you want a literal backslash, escape "
 "it with another one: `\\\\`"
 msgstr ""
+"通常特殊字符用反斜杠字符转义：`\\`。这样你可以在字符串中添加任何字符，甚至是不可打印的字符和你不知道如何输入的字符。如果你想要一个字面的反斜杠，用另一个反斜杠转义它：`\\\\`"
 
 #: src/std/str.md:72
 msgid ""
 "String or character literal delimiters occurring within a literal must be "
 "escaped: `\"\\\"\"`, `'\\''`."
 msgstr ""
+"出现在字面值内的字符串或字符字面值分隔符必须被转义：`\"\\\"\"`, `'\\''`。"
 
 #: src/std/str.md:76
 msgid "// You can use escapes to write bytes by their hexadecimal values...\n"
-msgstr ""
+msgstr "// 你可以使用转义来通过它们的十六进制值写入字节...\n"
 
 #: src/std/str.md:77
 msgid "\"I'm writing \\x52\\x75\\x73\\x74!\""
-msgstr ""
+msgstr "\"I'm writing \\x52\\x75\\x73\\x74!\""
 
 #: src/std/str.md:78
 msgid "\"What are you doing\\x3F (\\\\x3F means ?) {}\""
-msgstr ""
+msgstr "\"What are you doing\\x3F (\\\\x3F 表示 ?) {}\""
 
 #: src/std/str.md:80
 msgid "// ...or Unicode code points.\n"
-msgstr ""
+msgstr "// ...或 Unicode 码点。\n"
 
 #: src/std/str.md:81
 msgid "\"\\u{211D}\""
-msgstr ""
+msgstr "\"\\u{211D}\""
 
 #: src/std/str.md:82
 msgid "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
-msgstr ""
+msgstr "\"\\\"DOUBLE-STRUCK CAPITAL R\\\"\""
 
 #: src/std/str.md:84
 msgid "\"Unicode character {} (U+211D) is called {}\""
-msgstr ""
+msgstr "\"Unicode 字符 {} (U+211D) 被称为 {}\""
 
 #: src/std/str.md:88
 msgid ""
@@ -12827,6 +12854,10 @@ msgid ""
 "                        The linebreak and indentation here ->\\\n"
 "                        <- can be escaped too!\""
 msgstr ""
+"\"字符串字面值\n"
+"                        可以跨越多行。\n"
+"                        这里的换行和缩进 ->\\\n"
+"                        <- 也可以被转义！\""
 
 #: src/std/str.md:96
 msgid ""
@@ -12834,28 +12865,31 @@ msgid ""
 "just much more convenient to write a string out as-is. This is where raw "
 "string literals come into play."
 msgstr ""
+"有时需要转义的字符太多，或者直接按原样写出字符串会更方便。这就是原始字符串字面值发挥作用的地方。"
 
 #: src/std/str.md:101
 msgid "r\"Escapes don't work here: \\x3F \\u{211D}\""
-msgstr ""
+msgstr "r\"转义在这里不起作用：\\x3F \\u{211D}\""
 
 #: src/std/str.md:104
 msgid "// If you need quotes in a raw string, add a pair of #s\n"
-msgstr ""
+msgstr "// 如果你需要在原始字符串中使用引号，添加一对 #\n"
 
 #: src/std/str.md:105
 msgid "r#\"And then I said: \"There is no escape!\"\"#"
-msgstr ""
+msgstr "r#\"然后我说：\"没有转义！\"\"#"
 
 #: src/std/str.md:108
 msgid ""
 "// If you need \"# in your string, just use more #s in the delimiter.\n"
 "    // You can use up to 255 #s.\n"
 msgstr ""
+"// 如果你需要在字符串中使用 \"#，只需在分隔符中使用更多的 #。\n"
+"    // 你可以使用最多 255 个 #。\n"
 
 #: src/std/str.md:110
 msgid "r###\"A string with \"# in it. And even \"##!\"###"
-msgstr ""
+msgstr "r###\"一个包含 \"# 的字符串。甚至还有 \"##！\"###"
 
 #: src/std/str.md:115
 msgid ""
@@ -12863,94 +12897,101 @@ msgid ""
 "UTF-8). Or maybe you want an array of bytes that's mostly text? Byte strings "
 "to the rescue!"
 msgstr ""
+"想要一个非 UTF-8 的字符串？（记住，`str` 和 `String` 必须是有效的 UTF-8）。或者你想要一个主要是文本的字节数组？字节字符串来救场！"
 
 #: src/std/str.md:122
 msgid "// Note that this is not actually a `&str`\n"
-msgstr ""
+msgstr "// 注意这实际上不是一个 `&str`\n"
 
 #: src/std/str.md:123
 msgid "b\"this is a byte string\""
-msgstr ""
+msgstr "b\"this is a byte string\""
 
 #: src/std/str.md:125
 msgid ""
 "// Byte arrays don't have the `Display` trait, so printing them is a bit "
 "limited\n"
 msgstr ""
+"// 字节数组没有 `Display` trait，所以打印它们有一些限制\n"
 
 #: src/std/str.md:126
 msgid "\"A byte string: {:?}\""
-msgstr ""
+msgstr "\"一个字节字符串：{:?}\""
 
 #: src/std/str.md:128
 msgid "// Byte strings can have byte escapes...\n"
-msgstr ""
+msgstr "// 字节字符串可以有字节转义...\n"
 
 #: src/std/str.md:129
 msgid "b\"\\x52\\x75\\x73\\x74 as bytes\""
-msgstr ""
+msgstr "b\"\\x52\\x75\\x73\\x74 as bytes\""
 
 #: src/std/str.md:130
 msgid ""
 "// ...but no unicode escapes\n"
 "    // let escaped = b\"\\u{211D} is not allowed\";\n"
 msgstr ""
+"// ...但不允许 unicode 转义\n"
+"    // let escaped = b\"\\u{211D} is not allowed\";\n"
 
 #: src/std/str.md:132
 msgid "\"Some escaped bytes: {:?}\""
-msgstr ""
+msgstr "\"一些转义的字节：{:?}\""
 
 #: src/std/str.md:135
 msgid "// Raw byte strings work just like raw strings\n"
-msgstr ""
+msgstr "// 原始字节字符串的工作方式就像原始字符串\n"
 
 #: src/std/str.md:136
 msgid "br\"\\u{211D} is not escaped here\""
-msgstr ""
+msgstr "br\"\\u{211D} is not escaped here\""
 
 #: src/std/str.md:139
 msgid "// Converting a byte array to `str` can fail\n"
-msgstr ""
+msgstr "// 将字节数组转换为 `str` 可能会失败\n"
 
 #: src/std/str.md:141
 msgid "\"And the same as text: '{}'\""
-msgstr ""
+msgstr "\"同样作为文本：'{}'\""
 
 #: src/std/str.md:144
 msgid ""
 "br#\"You can also use \"fancier\" formatting, \\\n"
 "                    like with normal raw strings\"#"
 msgstr ""
+"br#\"你也可以使用"更花哨的"格式化，\\\n"
+"                    就像普通的原始字符串一样\"#"
 
 #: src/std/str.md:147
 msgid "// Byte strings don't have to be UTF-8\n"
-msgstr ""
+msgstr "// 字节字符串不必是 UTF-8\n"
 
 #: src/std/str.md:148
 msgid "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
-msgstr ""
+msgstr "b\"\\x82\\xe6\\x82\\xa8\\x82\\xb1\\x82\\xbb\""
 
 #: src/std/str.md:148
 msgid "// \"ようこそ\" in SHIFT-JIS\n"
-msgstr ""
+msgstr "// SHIFT-JIS 编码的 \"ようこそ\"\n"
 
 #: src/std/str.md:150
 msgid "// But then they can't always be converted to `str`\n"
-msgstr ""
+msgstr "// 但是它们并不总是能被转换为 `str`\n"
 
 #: src/std/str.md:152
 msgid "\"Conversion successful: '{}'\""
-msgstr ""
+msgstr "\"转换成功：'{}'\""
 
 #: src/std/str.md:153
 msgid "\"Conversion failed: {:?}\""
-msgstr ""
+msgstr "\"转换失败：{:?}\""
 
 #: src/std/str.md:158
 msgid ""
 "For conversions between character encodings check out the [encoding](https://"
 "crates.io/crates/encoding) crate."
 msgstr ""
+"对于字符编码之间的转换，请查看 [encoding](https://crates.io/crates/encoding) crate。"
 
 #: src/std/str.md:160
 msgid ""
@@ -12958,6 +12999,8 @@ msgid ""
 "characters is given in the ['Tokens' chapter](https://doc.rust-lang.org/"
 "reference/tokens.html) of the Rust Reference."
 msgstr ""
+"关于编写字符串字面量和转义字符的更详细列表，请参阅 Rust 参考手册的 ['Tokens' 章节](https://doc.rust-lang.org/"
+"reference/tokens.html)。"
 
 #: src/std/option.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -1451,6 +1451,8 @@ msgid ""
 "for types such as in the `std` library. All others _must_ be manually "
 "implemented somehow."
 msgstr ""
+"所有的类型，若想用 `std::fmt` 的格式化打印，都要实现至少一个可打印的 `traits`。"
+"自动实现只为 `std` 库中的类型提供。所有其他类型都**必须**以某种方式手动实现。"
 
 #: src/hello/print/print_debug.md:8
 msgid ""
@@ -1458,94 +1460,108 @@ msgid ""
 "`derive` (automatically create) the `fmt::Debug` implementation. This is not "
 "true for `fmt::Display` which must be manually implemented."
 msgstr ""
+"`fmt::Debug` `trait` 使这变得非常简单。**所有**类型都可以 `derive`（自动创建）"
+"`fmt::Debug` 实现。但这对 `fmt::Display` 不适用，后者必须手动实现。"
 
 #: src/hello/print/print_debug.md:13
 msgid ""
 "// This structure cannot be printed either with `fmt::Display` or\n"
 "// with `fmt::Debug`.\n"
 msgstr ""
+"// 这个结构体既不能用 `fmt::Display` 打印\n"
+"// 也不能用 `fmt::Debug` 打印。\n"
 
 #: src/hello/print/print_debug.md:16
 msgid ""
 "// The `derive` attribute automatically creates the implementation\n"
 "// required to make this `struct` printable with `fmt::Debug`.\n"
 msgstr ""
+"// `derive` 属性自动创建所需的实现\n"
+"// 使这个 `struct` 可以用 `fmt::Debug` 打印。\n"
 
 #: src/hello/print/print_debug.md:23
 msgid "All `std` library types are automatically printable with `{:?}` too:"
-msgstr ""
+msgstr "所有 `std` 库类型也可以自动用 `{:?}` 打印："
 
 #: src/hello/print/print_debug.md:26
 msgid ""
 "// Derive the `fmt::Debug` implementation for `Structure`. `Structure`\n"
 "// is a structure which contains a single `i32`.\n"
 msgstr ""
+"// 为 `Structure` 派生 `fmt::Debug` 实现。`Structure`\n"
+"// 是一个包含单个 `i32` 的结构体。\n"
 
 #: src/hello/print/print_debug.md:30
 msgid ""
 "// Put a `Structure` inside of the structure `Deep`. Make it printable\n"
 "// also.\n"
 msgstr ""
+"// 将一个 `Structure` 放在 `Deep` 结构体内。也让它可打印。\n"
+"\n"
 
 #: src/hello/print/print_debug.md:37
 msgid "// Printing with `{:?}` is similar to with `{}`.\n"
-msgstr ""
+msgstr "// 用 `{:?}` 打印类似于用 `{}`。\n"
 
 #: src/hello/print/print_debug.md:38
 msgid "\"{:?} months in a year.\""
-msgstr ""
+msgstr "\"{:?} months in a year.\""
 
 #: src/hello/print/print_debug.md:39
 msgid "\"{1:?} {0:?} is the {actor:?} name.\""
-msgstr ""
+msgstr "\"{1:?} {0:?} is the {actor:?} name.\""
 
 #: src/hello/print/print_debug.md:40
 msgid "\"Slater\""
-msgstr ""
+msgstr "\"Slater\""
 
 #: src/hello/print/print_debug.md:41
 msgid "\"Christian\""
-msgstr ""
+msgstr "\"Christian\""
 
 #: src/hello/print/print_debug.md:42
 msgid "\"actor's\""
-msgstr ""
+msgstr "\"actor's\""
 
 #: src/hello/print/print_debug.md:44
 msgid "// `Structure` is printable!\n"
-msgstr ""
+msgstr "// `Structure` is printable!\n"
 
 #: src/hello/print/print_debug.md:45 src/hello/print/print_debug.md:49
 msgid "\"Now {:?} will print!\""
-msgstr ""
+msgstr "\"Now {:?} will print!\""
 
 #: src/hello/print/print_debug.md:47
 msgid ""
 "// The problem with `derive` is there is no control over how\n"
 "    // the results look. What if I want this to just show a `7`?\n"
 msgstr ""
+"// `derive` 的问题是无法控制输出的形式\n"
+"    // 假如我只想显示一个 `7` 怎么办？\n"
 
 #: src/hello/print/print_debug.md:53
 msgid ""
 "So `fmt::Debug` definitely makes this printable but sacrifices some elegance. "
 "Rust also provides \"pretty printing\" with `{:#?}`."
 msgstr ""
+"所以 `fmt::Debug` 确实使其可打印，但牺牲了一些优雅。"
+"Rust 还提供了使用 `{:#?}` 的"美化打印"。"
 
 #: src/hello/print/print_debug.md:64 src/custom_types/structs.md:42
 msgid "\"Peter\""
-msgstr ""
+msgstr "\"Peter\""
 
 #: src/hello/print/print_debug.md:68
 msgid "// Pretty print\n"
-msgstr ""
+msgstr "// 美化打印\n"
 
 #: src/hello/print/print_debug.md:69
 msgid "\"{:#?}\""
-msgstr ""
+msgstr "\"{:#?}\""
 
 #: src/hello/print/print_debug.md:73
 msgid "One can manually implement `fmt::Display` to control the display."
-msgstr ""
+msgstr "可以手动实现 `fmt::Display` 来控制显示。"
 
 #: src/hello/print/print_debug.md:77
 msgid ""
@@ -1553,6 +1569,9 @@ msgid ""
 "[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/std/"
 "fmt/), and [`struct`](../../custom_types/structs.md)"
 msgstr ""
+"[`attributes`](https://doc.rust-lang.org/reference/attributes.html)、"
+"[`derive`](../../trait/derive.md)、[`std::fmt`](https://doc.rust-lang.org/std/fmt/) "
+"和 [`struct`](../../custom_types/structs.md)"
 
 #: src/hello/print/print_display.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -771,7 +771,7 @@ msgstr "Playground"
 
 #: src/index.md:1
 msgid "Rust by Example"
-msgstr "通过例子学 Rust"
+msgstr "Rust by Example"
 
 #: src/index.md:3
 msgid ""
@@ -779,7 +779,7 @@ msgid ""
 "focusing on safety, speed, and concurrency. It accomplishes these goals by "
 "being memory safe without using garbage collection."
 msgstr ""
-"[Rust](https://www.rust-lang.org/) 是一种现代的系统编程语言，专注于安全性、速度和并发性。它通过不使用垃圾回收来实现这些目标，确保了内存安全。"
+"[Rust](https://www.rust-lang.org/) 是一门现代系统编程语言，专注于安全性、速度和并发性。通过内存安全而不使用垃圾回收来实现这些目标。"
 
 #: src/index.md:7
 msgid ""
@@ -790,7 +790,7 @@ msgid ""
 "std/). Additionally for the curious, you can also [check out the source code "
 "for this site](https://github.com/rust-lang/rust-by-example)."
 msgstr ""
-"《通过例子学 Rust》（Rust By Example, RBE）是一系列可运行的实例，它们展示了各种 Rust 概念和标准库。为了更好地利用这些实例，请不要忘记[本地安装 Rust](https://www.rust-lang.org/tools/install)并查看[官方文档](https://doc.rust-lang.org/)。此外，对于好奇的人来说，你也可以[查看这个网站的源代码](https://github.com/rust-lang/rust-by-example)。"
+"《通过例子学 Rust》（Rust By Example, RBE）是一系列可运行的示例，它们展示了各种 Rust 概念和标准库。为了更好地利用这些示例，请不要忘记[本地安装 Rust](https://www.rust-lang.org/tools/install)并查看[官方文档](https://doc.rust-lang.org/)。此外，好奇的话，你也可以[查看这个网站的源代码](https://github.com/rust-lang/rust-by-example)。"
 
 #: src/index.md:12
 msgid "Now let's begin!"
@@ -798,13 +798,13 @@ msgstr "现在让我们开始吧！"
 
 #: src/index.md:14
 msgid "[Hello World](hello.md) - Start with a traditional Hello World program."
-msgstr "[Hello World](hello.md) - 从一个传统的 Hello World 程序开始。"
+msgstr "[Hello World](hello.md) - 从一个经典的 Hello World 程序开始。"
 
 #: src/index.md:16
 msgid ""
 "[Primitives](primitives.md) - Learn about signed integers, unsigned integers "
 "and other primitives."
-msgstr "[Primitives](primitives.md) - 学习有关有符号整数、无符号整数和其他原生类型的信息。"
+msgstr "[Primitives](primitives.md) - 学习有符号整数、无符号整数和其他原生类型。"
 
 #: src/index.md:18
 msgid "[Custom Types](custom_types.md) - `struct` and `enum`."
@@ -854,13 +854,13 @@ msgstr "[Crates](crates.md) - Crate 是 Rust 中的编译单元。学习如何�
 msgid ""
 "[Cargo](cargo.md) - Go through some basic features of the official Rust "
 "package management tool."
-msgstr "[Cargo](cargo.md) - 了解官方 Rust 包管理工具的一些基本特性。"
+msgstr "[Cargo](cargo.md) - 了解官方 Rust 包管理工具的一些基本功能。"
 
 #: src/index.md:38
 msgid ""
 "[Attributes](attribute.md) - An attribute is metadata applied to some module, "
 "crate or item."
-msgstr "[属性](attribute.md) - 属性是应用于某些模块、crate 或项目项的元数据。"
+msgstr "[属性](attribute.md) - 属性是应用于某些模块、crate 或项的元数据。"
 
 #: src/index.md:40
 msgid ""
@@ -872,19 +872,19 @@ msgstr "[泛型](generics.md) - 学习编写可以适用于多种类型参数的
 msgid ""
 "[Scoping rules](scope.md) - Scopes play an important part in ownership, "
 "borrowing, and lifetimes."
-msgstr "[作用域规则](scope.md) - 作用域在所有权(ownership)、借用(borrowing)和生命周期(lifetime)中扮演重要角色。"
+msgstr "[作用域规则](scope.md) - 作用域在所有权（ownership）、借用（borrowing）和生命周期（lifetime）中扮演重要角色。"
 
 #: src/index.md:44
 msgid ""
 "[Traits](trait.md) - A trait is a collection of methods defined for an "
 "unknown type: `Self`"
-msgstr "[特质](trait.md) - 特质(trait)是为未知类型 `Self` 定义的一组方法。"
+msgstr "[特质](trait.md) - 特质（trait）是为未知类型 `Self` 定义的一组方法。"
 
 #: src/index.md:46
 msgid ""
 "[Macros](macros.md) - Macros are a way of writing code that writes other "
 "code, which is known as metaprogramming."
-msgstr "[宏](macros.md) - 宏是一种编写代码以生成其他代码的方式，这被称为元编程。"
+msgstr "[宏](macros.md) - 宏是一种编写代码以生成其他代码的方式，也被称为元编程。"
 
 #: src/index.md:48
 msgid "[Error handling](error.md) - Learn Rust way of handling failures."
@@ -894,27 +894,27 @@ msgstr "[错误处理](error.md) - 学习 Rust 处理失败的方式。"
 msgid ""
 "[Std library types](std.md) - Learn about some custom types provided by `std` "
 "library."
-msgstr "[标准库类型](std.md) - 学习 `std` 标准库提供的某些自定义类型。"
+msgstr "[标准库类型](std.md) - 学习 `std` 标准库提供的一些自定义类型。"
 
 #: src/index.md:52
 msgid "[Std misc](std_misc.md) - More custom types for file handling, threads."
-msgstr "[标准库中的其他内容](std_misc.md) - 文件处理、线程的更多自定义类型。"
+msgstr "[标准库中的其他内容](std_misc.md) - 更多关于文件处理、线程的自定义类型。"
 
 #: src/index.md:54
 msgid "[Testing](testing.md) - All sorts of testing in Rust."
-msgstr "[测试](testing.md) - Rust 中的各种测试。"
+msgstr "[测试](testing.md) - Rust 中的各种测试方法。"
 
 #: src/index.md:56
 msgid ""
 "[Unsafe Operations](unsafe.md) - Learn about entering a block of unsafe "
 "operations."
-msgstr "[不安全操作](unsafe.md) - 学习进入不安全操作块。"
+msgstr "[不安全操作](unsafe.md) - 学习如何编写和使用不安全代码块。"
 
 #: src/index.md:58
 msgid ""
 "[Compatibility](compatibility.md) - Handling Rust's evolution and potential "
 "compatibility issues."
-msgstr "[兼容性](compatibility.md) - 处理 Rust 的发展和潜在的兼容性问题。"
+msgstr "[兼容性](compatibility.md) - 应对 Rust 语言的演进及可能出现的兼容性问题。"
 
 #: src/index.md:60
 msgid "[Meta](meta.md) - Documentation, Benchmarking."

--- a/po/zh.po
+++ b/po/zh.po
@@ -9212,7 +9212,7 @@ msgid ""
 "lifetime begins when it is created and ends when it is destroyed. While "
 "lifetimes and scopes are often referred to together, they are not the same."
 msgstr ""
-"**生命周期**是编译器（更具体地说是其**借用检查器**）用来确保所有借用都有效的一种机制。具体来说，变量的生命周期从创建时开始，到销毁时结束。虽然生命周期和作用域经常被一起提到，但它们并不相同。"
+"**生命周期**是编译器（更具体地说是其**借用检查器**）用来确保所有借用都有效的一种机制。具体来说，变量的生命周期从创建时开始，到销毁时结束。尽管生命周期和作用域经常被一同提及，但它们并不完全相同。"
 
 #: src/scope/lifetime.md:8
 msgid ""
@@ -9221,14 +9221,14 @@ msgid ""
 "borrow is valid as long as it ends before the lender is destroyed. However, "
 "the scope of the borrow is determined by where the reference is used."
 msgstr ""
-"例如，考虑我们通过 `&` 借用一个变量的情况。借用的生命周期由其声明的位置决定。因此，只要借用在出借者被销毁之前结束，它就是有效的。然而，借用的作用域由引用使用的位置决定。"
+"举个例子，当我们通过 `&` 借用一个变量时，这个借用的生命周期由其声明位置决定。因此，只要借用在出借者被销毁之前结束，它就是有效的。然而，借用的作用域则由引用使用的位置决定。"
 
 #: src/scope/lifetime.md:13
 msgid ""
 "In the following example and in the rest of this section, we will see how "
 "lifetimes relate to scopes, as well as how the two differ."
 msgstr ""
-"在下面的例子和本节的其余部分中，我们将看到生命周期如何与作用域相关，以及两者有何不同。"
+"在接下来的例子和本节的其余部分中，我们将看到生命周期如何与作用域相关联，以及两者之间的区别。"
 
 #: src/scope/lifetime.md:17
 msgid ""
@@ -9310,7 +9310,7 @@ msgid ""
 "Note that no names or types are assigned to label lifetimes. This restricts "
 "how lifetimes will be able to be used as we will see."
 msgstr ""
-"请注意，没有名称或类型被分配给标记生命周期。这限制了生命周期的使用方式，我们将在后面看到。"
+"请注意，生命周期标签没有被赋予名称或类型。这限制了生命周期的使用方式，我们将在后面看到这一点。"
 
 #: src/scope/lifetime/explicit.md:3
 msgid ""
@@ -9320,7 +9320,7 @@ msgid ""
 "should be. The syntax for explicitly annotating a lifetime uses an apostrophe "
 "character as follows:"
 msgstr ""
-"借用检查器使用显式生命周期注解来确定引用应该有效多长时间。在生命周期没有被省略[^1]的情况下，Rust 需要显式注解来确定引用的生命周期应该是怎样的。显式注解生命周期的语法使用撇号字符，如下所示："
+"借用检查器使用显式生命周期注解来确定引用应该有效多长时间。在生命周期没有被省略[^1]的情况下，Rust 需要显式注解来确定引用的生命周期。显式注解生命周期的语法使用撇号字符，如下所示："
 
 #: src/scope/lifetime/explicit.md:10
 msgid "// `foo` has a lifetime parameter `'a`\n"
@@ -9365,16 +9365,18 @@ msgstr ""
 
 #: src/scope/lifetime/explicit.md:35
 msgid "\"x is {} and y is {}\""
-msgstr "\"x is {} and y is {}\""
+msgstr "\"x 是 {}，y 是 {}\""
 
 #: src/scope/lifetime/explicit.md:37
 msgid ""
 "// A function which takes no arguments, but has a lifetime parameter `'a`.\n"
-msgstr "// 一个没有参数但有生命周期参数 `'a` 的函数。\n"
+msgstr ""
+"// 一个没有参数但有生命周期参数 `'a` 的函数。\n"
 
 #: src/scope/lifetime/explicit.md:42
 msgid "// ERROR: `_x` does not live long enough\n"
-msgstr "// 错误：`_x` 的生命周期不够长\n"
+msgstr ""
+"// 错误：`_x` 的生命周期不够长\n"
 
 #: src/scope/lifetime/explicit.md:44
 msgid ""
@@ -9384,17 +9386,19 @@ msgid ""
 "    // than that of `_y`. A short lifetime cannot be coerced into a longer "
 "one.\n"
 msgstr ""
-"// 尝试在函数内部使用生命周期 `'a` 作为显式类型标注\n"
-"    // 会失败，因为 `&_x` 的生命周期比 `_y` 的短。\n"
-"    // 短生命周期不能被强制转换为长生命周期。\n"
+"// 尝试在函数内部使用生命周期 `'a` 作为显式类型标注会失败，\n"
+"    // 因为 `&_x` 的生命周期比 `_y` 的短。\n"
+"    // 短生命周期无法强制转换为长生命周期。\n"
 
 #: src/scope/lifetime/explicit.md:50
 msgid "// Create variables to be borrowed below.\n"
-msgstr "// 创建将要被借用的变量。\n"
+msgstr ""
+"// 创建将要被借用的变量。\n"
 
 #: src/scope/lifetime/explicit.md:53
 msgid "// Borrows (`&`) of both variables are passed into the function.\n"
-msgstr "// 两个变量的借用（`&`）被传递给函数。\n"
+msgstr ""
+"// 将两个变量的借用（`&`）传递给函数。\n"
 
 #: src/scope/lifetime/explicit.md:55
 msgid ""
@@ -9412,34 +9416,39 @@ msgid ""
 "    // longer than the lifetime of the function, but `'a` is longer.\n"
 "    // Because the lifetime is never constrained, it defaults to `'static`.\n"
 msgstr ""
-"// `failed_borrow` 不包含任何引用来强制 `'a` 比\n"
-"    // 函数的生命周期更长，但 `'a` 确实更长。\n"
+"// `failed_borrow` 不包含任何引用来强制 `'a` 比函数的生命周期更长，\n"
+"    // 但 `'a` 实际上更长。\n"
 "    // 因为生命周期从未被约束，它默认为 `'static`。\n"
 
 #: src/scope/lifetime/explicit.md:66
 msgid ""
 "[elision](elision.md) implicitly annotates lifetimes and so is different."
-msgstr "[省略](elision.md)隐式地注解生命周期，因此是不同的。"
+msgstr ""
+"[省略（elision）](elision.md)隐式地注解生命周期，因此与显式注解不同。"
 
 #: src/scope/lifetime/explicit.md:70
 msgid "[generics](../../generics.md) and [closures](../../fn/closures.md)"
-msgstr "[泛型](../../generics.md)和[闭包](../../fn/closures.md)"
+msgstr ""
+"[泛型（generics）](../../generics.md)和[闭包（closures）](../../fn/closures.md)"
 
 #: src/scope/lifetime/fn.md:3
 msgid ""
 "Ignoring [elision](elision.md), function signatures with lifetimes have a few "
 "constraints:"
-msgstr "排除[省略](elision.md)的情况，带有生命周期的函数签名有一些限制："
+msgstr ""
+"排除[省略（elision）](elision.md)的情况，带有生命周期的函数签名有以下几个约束："
 
 #: src/scope/lifetime/fn.md:5
 msgid "any reference _must_ have an annotated lifetime."
-msgstr "任何引用**必须**有一个标注了的生命周期。"
+msgstr ""
+"任何引用**必须**有一个标注的生命周期。"
 
 #: src/scope/lifetime/fn.md:6
 msgid ""
 "any reference being returned _must_ have the same lifetime as an input or be "
 "`static`."
-msgstr "任何被返回的引用**必须**具有与输入相同的生命周期或者是 `static`。"
+msgstr ""
+"任何被返回的引用**必须**具有与输入相同的生命周期或者是 `static`。"
 
 #: src/scope/lifetime/fn.md:9
 msgid ""
@@ -9447,22 +9456,24 @@ msgid ""
 "would result in returning references to invalid data. The following example "
 "shows off some valid forms of functions with lifetimes:"
 msgstr ""
-"此外，请注意，如果返回引用却没有输入，会导致返回无效数据的引用，这是被禁止的。以下示例展示了一些带有生命周期的函数："
+"此外，请注意，如果返回引用而没有输入会导致返回指向无效数据的引用，这是被禁止的。以下示例展示了一些带有生命周期的有效函数形式："
 
 #: src/scope/lifetime/fn.md:14
 msgid ""
 "// One input reference with lifetime `'a` which must live\n"
 "// at least as long as the function.\n"
 msgstr ""
-"// 一个具有生命周期 `'a` 的输入引用，它的存活至少和函数一样长。\n"
+"// 一个具有生命周期 `'a` 的输入引用，它必须至少与函数存活一样长。\n"
 
 #: src/scope/lifetime/fn.md:17
 msgid "\"`print_one`: x is {}\""
-msgstr "\"`print_one`: x is {}\""
+msgstr ""
+"\"`print_one`：x 是 {}\""
 
 #: src/scope/lifetime/fn.md:19
 msgid "// Mutable references are possible with lifetimes as well.\n"
-msgstr "// 可变引用也可以有生命周期。\n"
+msgstr ""
+"// 可变引用也可以有生命周期。\n"
 
 #: src/scope/lifetime/fn.md:24
 msgid ""
@@ -9476,7 +9487,8 @@ msgstr ""
 
 #: src/scope/lifetime/fn.md:29
 msgid "\"`print_multi`: x is {}, y is {}\""
-msgstr "\"`print_multi`: x is {}, y is {}\""
+msgstr ""
+"\"`print_multi`：x 是 {}，y 是 {}\""
 
 #: src/scope/lifetime/fn.md:31
 msgid ""
@@ -9495,79 +9507,94 @@ msgid ""
 "// a reference to invalid data to be returned.\n"
 msgstr ""
 "//fn invalid_output<'a>() -> &'a String { &String::from(\"foo\") }\n"
-"// 上面的代码是无效的：`'a` 的存活时间必须比函数更长。\n"
-"// 这里的 `&String::from(\"foo\")` 会创建一个 `String`，再引用它。 \n"
-"// 然后在退出作用域时数据被丢弃，返回一个指向无效数据的引用"
+"// 上面的代码是无效的：`'a` 必须比函数存活更长。\n"
+"// 这里的 `&String::from(\"foo\")` 会创建一个 `String`，然后创建一个引用。\n"
+"// 接着，在退出作用域时数据被丢弃，导致返回一个指向无效数据的引用。\n"
 
 #: src/scope/lifetime/fn.md:60
 msgid "[Functions](../../fn.md)"
-msgstr "[函数](../../fn.md)"
+msgstr ""
+"[函数](../../fn.md)"
 
 #: src/scope/lifetime/methods.md:3
 msgid "Methods are annotated similarly to functions:"
-msgstr "方法的注解和函数类似："
+msgstr ""
+"方法的生命周期注解与函数类似："
 
 #: src/scope/lifetime/methods.md:9
 msgid "// Annotate lifetimes as in a standalone function.\n"
-msgstr "// 像独立函数一样注解生命周期。\n"
+msgstr ""
+"// 像独立函数一样注解生命周期。\n"
 
 #: src/scope/lifetime/methods.md:12
 msgid "\"`print`: {}\""
-msgstr "\"`print`: {}\""
+msgstr ""
+"\"`print`：{}\""
 
 #: src/scope/lifetime/methods.md:26
 msgid "[methods](../../fn/methods.md)"
-msgstr "[方法](../../fn/methods.md)"
+msgstr ""
+"[方法](../../fn/methods.md)"
 
 #: src/scope/lifetime/struct.md:3
 msgid "Annotation of lifetimes in structures are also similar to functions:"
-msgstr "结构体中生命周期的注解也和函数类似："
+msgstr ""
+"结构体中生命周期的注解也与函数类似："
 
 #: src/scope/lifetime/struct.md:6
 msgid ""
 "// A type `Borrowed` which houses a reference to an\n"
 "// `i32`. The reference to `i32` must outlive `Borrowed`.\n"
 msgstr ""
-"// 一个包含 `i32` 引用的 `Borrowed` 类型。\n"
-"// 对 `i32` 的引用必须比 `Borrowed` 存活更久。\n"
+"// `Borrowed` 类型包含一个 `i32` 的引用。\n"
+"// 这个 `i32` 的引用必须比 `Borrowed` 存活更久。\n"
 
 #: src/scope/lifetime/struct.md:10
 msgid "// Similarly, both references here must outlive this structure.\n"
-msgstr "// 同样，这里的两个引用都必须比这个结构体存活更久。\n"
+msgstr ""
+"// 同样，这里的两个引用都必须比这个结构体存活更久。\n"
 
 #: src/scope/lifetime/struct.md:17
 msgid "// An enum which is either an `i32` or a reference to one.\n"
-msgstr "// 一个枚举，表示 `i32`，或者 `i32` 的引用。\n"
+msgstr ""
+"// 一个枚举，可以是 `i32`，或者是 `i32` 的引用。\n"
 
 #: src/scope/lifetime/struct.md:34 src/scope/lifetime/struct.md:36
 msgid "\"x is borrowed in {:?}\""
-msgstr "\"x 在 {:?} 中被借用\""
+msgstr ""
+"\"x 在 {:?} 中被借用\""
 
 #: src/scope/lifetime/struct.md:35
 msgid "\"x and y are borrowed in {:?}\""
-msgstr "\"x 和 y 在 {:?} 中被借用\""
+msgstr ""
+"\"x 和 y 在 {:?} 中被借用\""
 
 #: src/scope/lifetime/struct.md:37
 msgid "\"y is *not* borrowed in {:?}\""
-msgstr "\"y 在 {:?} 中**没有**被借用\""
+msgstr ""
+"\"y 在 {:?} 中**没有**被借用\""
 
 #: src/scope/lifetime/struct.md:43
 msgid "[`struct`s](../../custom_types/structs.md)"
-msgstr "[`struct`](../../custom_types/structs.md)"
+msgstr ""
+"[`struct`（结构体）](../../custom_types/structs.md)"
 
 #: src/scope/lifetime/trait.md:3
 msgid ""
 "Annotation of lifetimes in trait methods basically are similar to functions. "
 "Note that `impl` may have annotation of lifetimes too."
-msgstr "trait 方法中的生命周期注解基本上与函数类似。注意 `impl` 也可能有生命周期注解。"
+msgstr ""
+"trait 方法中的生命周期注解基本上与函数类似。注意，`impl` 也可能需要生命周期注解。"
 
 #: src/scope/lifetime/trait.md:7
 msgid "// A struct with annotation of lifetimes.\n"
-msgstr "// 一个带有生命周期注解的结构体。\n"
+msgstr ""
+"// 一个带有生命周期注解的结构体。\n"
 
 #: src/scope/lifetime/trait.md:12
 msgid "// Annotate lifetimes to impl.\n"
-msgstr "// 为 impl 注解生命周期。\n"
+msgstr ""
+"// 为 impl 添加生命周期注解。\n"
 
 #: src/scope/lifetime/trait.md:24
 msgid "\"b is {:?}\""
@@ -9582,7 +9609,9 @@ msgid ""
 "Just like generic types can be bounded, lifetimes (themselves generic) use "
 "bounds as well. The `:` character has a slightly different meaning here, but "
 "`+` is the same. Note how the following read:"
-msgstr "就像泛型类型可以被约束一样，生命周期（本身就是泛型）也可以使用约束。这里 `:` 字符的含义略有不同，但 `+` 是相同的。注意下面说明："
+msgstr ""
+"正如泛型类型可以被约束一样，生命周期（本身也是泛型）也可以使用约束。"
+"这里的 `:` 符号含义略有不同，但 `+` 的用法相同。请注意以下表达的含义："
 
 #: src/scope/lifetime/lifetime_bounds.md:7
 msgid "`T: 'a`: _All_ references in `T` must outlive lifetime `'a`."
@@ -9610,9 +9639,9 @@ msgid ""
 "// *references* in `T` must outlive `'a`. Additionally, the lifetime\n"
 "// of `Ref` may not exceed `'a`.\n"
 msgstr ""
-"// `Ref` 包含一个指向泛型类型 `T` 的引用，其中 `T` 拥有一个未知的\n"
-"// 生命周期 `'a`。`T` 被约束，使得 `T` 中的任何*引用*必须\n"
-"// 比 `'a` 存活更久。此外，`Ref` 的生命周期不能超过 `'a`。\n"
+"// `Ref` 包含一个指向泛型类型 `T` 的引用，`T` 具有一个 `Ref` 未知的\n"
+"// 生命周期 `'a`。`T` 受到约束，使得 `T` 中的任何*引用*必须比 `'a` 存活更久。\n"
+"// 此外，`Ref` 的生命周期不能超过 `'a`。\n"
 
 #: src/scope/lifetime/lifetime_bounds.md:22
 msgid "// A generic function which prints using the `Debug` trait.\n"
@@ -9640,7 +9669,8 @@ msgstr "\"`print_ref`: t 是 {:?}\""
 msgid ""
 "[generics](../../generics.md), [bounds in generics](../../generics/bounds."
 "md), and [multiple bounds in generics](../../generics/multi_bounds.md)"
-msgstr "[泛型](../../generics.md)，[泛型中的约束](../../generics/bounds.md)，以及[泛型中的多重约束](../../generics/multi_bounds.md)"
+msgstr ""
+"[泛型](../../generics.md)、[泛型中的约束](../../generics/bounds.md)和[泛型中的多重约束](../../generics/multi_bounds.md)"
 
 #: src/scope/lifetime/lifetime_coercion.md:3
 msgid ""
@@ -9648,7 +9678,9 @@ msgid ""
 "scope it normally wouldn't work in. This comes in the form of inferred "
 "coercion by the Rust compiler, and also in the form of declaring a lifetime "
 "difference:"
-msgstr "一个较长的生命周期可以被强制转换为一个较短的生命周期，以便它在通常不能工作的作用域内工作。强制转换可由编译器隐式地推导并执行，也可以通过声明不同的生命周期的形式实现："
+msgstr ""
+"一个较长的生命周期可以被强制转换为一个较短的生命周期，使其能在通常无法工作的作用域内工作。"
+"这种转换可以通过 Rust 编译器的推断自动完成，也可以通过声明不同的生命周期的形式实现："
 
 #: src/scope/lifetime/lifetime_coercion.md:9
 msgid ""
@@ -9687,15 +9719,16 @@ msgstr "\"{} 是第一个\""
 msgid ""
 "Rust has a few reserved lifetime names. One of those is `'static`. You might "
 "encounter it in two situations:"
-msgstr "Rust 有几个保留的生命周期名称。其中之一是 `'static`。你可能在两种情况下遇到它："
+msgstr ""
+"Rust 有几个保留的生命周期名称。其中之一是 `'static`。你可能在两种情况下遇到它："
 
 #: src/scope/lifetime/static_lifetime.md:7
 msgid "// A reference with 'static lifetime:\n"
-msgstr "// 一个带有 'static 生命周期的引用：\n"
+msgstr "// 具有 'static 生命周期的引用：\n"
 
 #: src/scope/lifetime/static_lifetime.md:8
 msgid "\"hello world\""
-msgstr "\"hello world\""
+msgstr "\"你好，世界\""
 
 #: src/scope/lifetime/static_lifetime.md:9
 msgid "// 'static as part of a trait bound:\n"
@@ -9705,7 +9738,8 @@ msgstr "// 'static 作为 trait 约束的一部分：\n"
 msgid ""
 "Both are related but subtly different and this is a common source for "
 "confusion when learning Rust. Here are some examples for each situation:"
-msgstr "两者相关但有微妙的区别，这是学习 Rust 时常见的困惑来源。以下是每种情况的一些例子："
+msgstr ""
+"这两种情况虽然相关但有微妙的区别，这也是学习 Rust 时常见的困惑来源。以下是每种情况的一些例子："
 
 #: src/scope/lifetime/static_lifetime.md:17
 msgid "Reference lifetime"
@@ -9716,13 +9750,16 @@ msgid ""
 "As a reference lifetime `'static` indicates that the data pointed to by the "
 "reference lives for the remaining lifetime of the running program. It can "
 "still be coerced to a shorter lifetime."
-msgstr "作为引用生命周期，`'static` 表示该引用指向的数据在程序的剩余生命周期内都存在。它仍然可以被强制转换为更短的生命周期。"
+msgstr ""
+"作为引用生命周期，`'static` 表示该引用指向的数据在程序的整个剩余运行期间都有效。"
+"它仍然可以被强制转换为更短的生命周期。"
 
 #: src/scope/lifetime/static_lifetime.md:23
 msgid ""
 "There are two common ways to make a variable with `'static` lifetime, and "
 "both are stored in the read-only memory of the binary:"
-msgstr "有两种常见的方法可以创建具有 `'static` 生命周期的变量，它们都存储在二进制文件的只读内存中："
+msgstr ""
+"有两种常见的方法可以创建具有 `'static` 生命周期的变量，它们都存储在二进制文件的只读内存中："
 
 #: src/scope/lifetime/static_lifetime.md:26
 msgid "Make a constant with the `static` declaration."
@@ -9730,7 +9767,7 @@ msgstr "使用 `static` 声明创建一个常量。"
 
 #: src/scope/lifetime/static_lifetime.md:27
 msgid "Make a `string` literal which has type: `&'static str`."
-msgstr "创建一个 `string` 字面量，类型为：`&'static str`。"
+msgstr "创建一个字符串字面量，其类型为：`&'static str`。"
 
 #: src/scope/lifetime/static_lifetime.md:29
 msgid "See the following example for a display of each method:"
@@ -9745,20 +9782,20 @@ msgid ""
 "// Returns a reference to `NUM` where its `'static`\n"
 "// lifetime is coerced to that of the input argument.\n"
 msgstr ""
-"// 返回一个对 `NUM` 的引用，其中它的 `'static`\n"
-"// 生命周期被强制转换为输入参数的生命周期。\n"
+"// 返回一个指向 `NUM` 的引用，其中 `'static` 生命周期\n"
+"// 被强制转换为输入参数的生命周期。\n"
 
 #: src/scope/lifetime/static_lifetime.md:43
 msgid "// Make a `string` literal and print it:\n"
-msgstr "// 创建一个 `string` 字面量并打印它：\n"
+msgstr "// 创建一个字符串字面量并打印它：\n"
 
 #: src/scope/lifetime/static_lifetime.md:44
 msgid "\"I'm in read-only memory\""
-msgstr "\"我在只读内存中\""
+msgstr "\"我存储在只读内存中\""
 
 #: src/scope/lifetime/static_lifetime.md:45
 msgid "\"static_string: {}\""
-msgstr "\"static_string: {}\""
+msgstr "\"static_string 的值：{}\""
 
 #: src/scope/lifetime/static_lifetime.md:47
 msgid ""
@@ -9770,7 +9807,7 @@ msgstr ""
 
 #: src/scope/lifetime/static_lifetime.md:52
 msgid "// Make an integer to use for `coerce_static`:\n"
-msgstr "// 创建一个整数用于 `coerce_static`：\n"
+msgstr "// 创建一个整数用于 `coerce_static` 函数：\n"
 
 #: src/scope/lifetime/static_lifetime.md:55
 msgid "// Coerce `NUM` to lifetime of `lifetime_num`:\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -15594,7 +15594,7 @@ msgid ""
 "invariants. The instructions to be inserted are listed in the first argument "
 "of the `asm!` macro as a string literal."
 msgstr ""
-"这将在编译器生成的汇编中插入一条 NOP（无操作）指令。注意，所有 `asm!` 调用都必须在 `unsafe` 块内，因为它们可能插入任意指令并破坏各种不变量。要插入的指令作为字符串字面量列在 `asm!` 宏的第一个参数中。"
+"这将在编译器生成的汇编中插入一条 NOP（无操作）指令。注意，所有 `asm!` 调用都必须在 `unsafe` 块内，因为它们可能插入任意指令并破坏各种假设。要插入的指令作为字符串字面量列在 `asm!` 宏的第一个参数中。"
 
 #: src/unsafe/asm.md:35
 msgid "Inputs and outputs"
@@ -15605,7 +15605,7 @@ msgid ""
 "Now inserting an instruction that does nothing is rather boring. Let us do "
 "something that actually acts on data:"
 msgstr ""
-"现在插入一个什么都不做的指令相当无聊。让我们做一些实际操作数据的事情："
+"插入一个什么都不做的指令相当无聊。现在让我们做一些实际操作数据的事情："
 
 #: src/unsafe/asm.md:46
 msgid "\"mov {}, 5\""
@@ -15747,22 +15747,25 @@ msgid ""
 "initial load from variable `c`. This is in contrast to how using `inout(reg) "
 "a` ensures a separate register is allocated for `a`."
 msgstr ""
+"这是因为在优化情况下，编译器可以自由地为输入 `b` 和 `c` 分配相同的寄存器，因为它知道它们具有相同的值。此外，当使用 `inlateout` 时，`a` 和 `c` 可能被分配到同一个寄存器，在这种情况下，第一条 `add` 指令会覆盖从变量 `c` 初始加载的值。这与使用 `inout(reg) a` 确保为 `a` 分配单独的寄存器形成对比。"
 
 #: src/unsafe/asm.md:171
 msgid ""
 "However, the following example can use `inlateout` since the output is only "
 "modified after all input registers have been read:"
 msgstr ""
+"然而，以下示例可以使用 `inlateout`，因为输出仅在所有输入寄存器被读取后才被修改："
 
 #: src/unsafe/asm.md:186
 msgid ""
 "As you can see, this assembly fragment will still work correctly if `a` and "
 "`b` are assigned to the same register."
 msgstr ""
+"如你所见，即使 `a` 和 `b` 被分配到同一个寄存器，这段汇编代码片段仍然能正确工作。"
 
 #: src/unsafe/asm.md:188
 msgid "Explicit register operands"
-msgstr ""
+msgstr "显式寄存器操作数"
 
 #: src/unsafe/asm.md:190
 msgid ""
@@ -15773,14 +15776,15 @@ msgid ""
 "registers `eax`, `ebx`, `ecx`, `edx`, `ebp`, `esi`, and `edi` among others "
 "can be addressed by their name."
 msgstr ""
+"某些指令要求操作数必须在特定的寄存器中。因此，Rust 内联汇编提供了一些更具体的约束说明符。虽然 `reg` 通常在任何架构上都可用，但显式寄存器是高度特定于架构的。例如，对于 x86，通用寄存器 `eax`、`ebx`、`ecx`、`edx`、`ebp`、`esi` 和 `edi` 等可以通过它们的名称来寻址。"
 
 #: src/unsafe/asm.md:200
 msgid "\"out 0x64, eax\""
-msgstr ""
+msgstr "\"out 0x64, eax\""
 
 #: src/unsafe/asm.md:200 src/unsafe/asm.md:276
 msgid "\"eax\""
-msgstr ""
+msgstr "\"eax\""
 
 #: src/unsafe/asm.md:205
 msgid ""
@@ -15789,6 +15793,7 @@ msgid ""
 "(and its sub registers) as operand we had to use the `eax` constraint "
 "specifier."
 msgstr ""
+"在这个例子中，我们调用 `out` 指令将 `cmd` 变量的内容输出到端口 `0x64`。由于 `out` 指令只接受 `eax`（及其子寄存器）作为操作数，我们必须使用 `eax` 约束说明符。"
 
 #: src/unsafe/asm.md:207
 msgid ""
@@ -15797,10 +15802,11 @@ msgid ""
 "name directly instead. Also, they must appear at the end of the operand list "
 "after all other operand types."
 msgstr ""
+"**注意**：与其他操作数类型不同，显式寄存器操作数不能在模板字符串中使用：你不能使用 `{}`，而应该直接写寄存器名称。此外，它们必须出现在操作数列表的末尾，在所有其他操作数类型之后。"
 
 #: src/unsafe/asm.md:209
 msgid "Consider this example which uses the x86 `mul` instruction:"
-msgstr ""
+msgstr "考虑这个使用 x86 `mul` 指令的例子："
 
 #: src/unsafe/asm.md:221
 msgid ""
@@ -15808,14 +15814,17 @@ msgid ""
 "            // the 128-bit result of the multiplication to rax:rdx.\n"
 "            \"mul {}\""
 msgstr ""
+"// x86 mul 指令将 rax 作为隐式输入，并将\n"
+"            // 乘法的 128 位结果写入 rax:rdx。\n"
+"            \"mul {}\""
 
 #: src/unsafe/asm.md:225 src/unsafe/asm.md:347
 msgid "\"rax\""
-msgstr ""
+msgstr "\"rax\""
 
 #: src/unsafe/asm.md:226
 msgid "\"rdx\""
-msgstr ""
+msgstr "\"rdx\""
 
 #: src/unsafe/asm.md:235
 msgid ""
@@ -15826,10 +15835,11 @@ msgid ""
 "stored in `rax` from which we fill the variable `lo`. The higher 64 bits are "
 "stored in `rdx` from which we fill the variable `hi`."
 msgstr ""
+"这里使用 `mul` 指令将两个 64 位输入相乘，得到一个 128 位的结果。唯一的显式操作数是一个寄存器，我们用变量 `a` 填充它。第二个操作数是隐式的，必须是 `rax` 寄存器，我们用变量 `b` 填充它。结果的低 64 位存储在 `rax` 中，我们用它填充变量 `lo`。高 64 位存储在 `rdx` 中，我们用它填充变量 `hi`。"
 
 #: src/unsafe/asm.md:241
 msgid "Clobbered registers"
-msgstr ""
+msgstr "被破坏的寄存器"
 
 #: src/unsafe/asm.md:243
 msgid ""
@@ -15840,10 +15850,11 @@ msgid ""
 "We need to tell the compiler about this since it may need to save and restore "
 "this state around the inline assembly block."
 msgstr ""
+"在许多情况下，内联汇编会修改不需要作为输出的状态。通常这是因为我们必须在汇编中使用临时寄存器，或者因为指令修改了我们不需要进一步检查的状态。这种状态通常被称为"被破坏"。我们需要告诉编译器这一点，因为它可能需要在内联汇编块周围保存和恢复这种状态。"
 
 #: src/unsafe/asm.md:253
 msgid "// three entries of four bytes each\n"
-msgstr ""
+msgstr "// 三个条目，每个四字节\n"
 
 #: src/unsafe/asm.md:255
 msgid ""
@@ -15854,30 +15865,35 @@ msgid ""
 "    // 32 bit registers (like ebx), so we have to use the extended rbx "
 "register instead.\n"
 msgstr ""
+"// 字符串按顺序以 ASCII 格式存储在 ebx、edx、ecx 中\n"
+"    // 因为 ebx 是保留的，汇编需要保留它的值。\n"
+"    // 所以我们在主要汇编代码前后进行 push 和 pop 操作。\n"
+"    // 64 位处理器的 64 位模式不允许推入/弹出 32 位寄存器（如 ebx），\n"
+"    // 所以我们必须使用扩展的 rbx 寄存器。\n"
 
 #: src/unsafe/asm.md:263
 msgid "\"push rbx\""
-msgstr ""
+msgstr "\"push rbx\""
 
 #: src/unsafe/asm.md:264
 msgid "\"cpuid\""
-msgstr ""
+msgstr "\"cpuid\""
 
 #: src/unsafe/asm.md:265
 msgid "\"mov [rdi], ebx\""
-msgstr ""
+msgstr "\"mov [rdi], ebx\""
 
 #: src/unsafe/asm.md:266
 msgid "\"mov [rdi + 4], edx\""
-msgstr ""
+msgstr "\"mov [rdi + 4], edx\""
 
 #: src/unsafe/asm.md:267
 msgid "\"mov [rdi + 8], ecx\""
-msgstr ""
+msgstr "\"mov [rdi + 8], ecx\""
 
 #: src/unsafe/asm.md:268
 msgid "\"pop rbx\""
-msgstr ""
+msgstr "\"pop rbx\""
 
 #: src/unsafe/asm.md:269
 msgid ""
@@ -15889,30 +15905,35 @@ msgid ""
 "            // The *pointer itself* is only an input even though it's written "
 "behind\n"
 msgstr ""
+"// 我们使用指向数组的指针来存储值，以简化\n"
+"            // Rust 代码，代价是多了几条汇编指令\n"
+"            // 然而，这更明确地展示了汇编的工作方式，与\n"
+"            // 显式寄存器输出（如 `out(\"ecx\") val`）相比\n"
+"            // *指针本身*只是一个输入，尽管它在背后被写入\n"
 
 #: src/unsafe/asm.md:274 src/unsafe/asm.md:345
 msgid "\"rdi\""
-msgstr ""
+msgstr "\"rdi\""
 
 #: src/unsafe/asm.md:275
 msgid "// select cpuid 0, also specify eax as clobbered\n"
-msgstr ""
+msgstr "// 选择 cpuid 0，同时指定 eax 为被破坏\n"
 
 #: src/unsafe/asm.md:277
 msgid "// cpuid clobbers these registers too\n"
-msgstr ""
+msgstr "// cpuid 也破坏这些寄存器\n"
 
 #: src/unsafe/asm.md:278
 msgid "\"ecx\""
-msgstr ""
+msgstr "\"ecx\""
 
 #: src/unsafe/asm.md:279
 msgid "\"edx\""
-msgstr ""
+msgstr "\"edx\""
 
 #: src/unsafe/asm.md:284
 msgid "\"CPU Manufacturer ID: {}\""
-msgstr ""
+msgstr "\"CPU 制造商 ID：{}\""
 
 #: src/unsafe/asm.md:291
 msgid ""
@@ -15921,6 +15942,7 @@ msgid ""
 "`cpuid` argument and `ebx`, `edx`, and `ecx` with the CPU manufacturer ID as "
 "ASCII bytes in that order."
 msgstr ""
+"在上面的例子中，我们使用 `cpuid` 指令来读取 CPU 制造商 ID。这条指令将最大支持的 `cpuid` 参数写入 `eax`，并按顺序将 CPU 制造商 ID 作为 ASCII 字节写入 `ebx`、`edx` 和 `ecx`。"
 
 #: src/unsafe/asm.md:294
 msgid ""
@@ -15930,6 +15952,7 @@ msgid ""
 "but with `_` instead of a variable name, which indicates that the output "
 "value is to be discarded."
 msgstr ""
+"尽管 `eax` 从未被读取，我们仍然需要告诉编译器该寄存器已被修改，这样编译器就可以保存在汇编之前这些寄存器中的任何值。这是通过将其声明为输出来完成的，但使用 `_` 而不是变量名，这表示输出值将被丢弃。"
 
 #: src/unsafe/asm.md:296
 msgid ""
@@ -15941,6 +15964,7 @@ msgid ""
 "`reg` operands dangerous when using reserved registers as we could "
 "unknowingly corrupt our input or output because they share the same register."
 msgstr ""
+"这段代码还解决了 `ebx` 是 LLVM 保留寄存器的限制。这意味着 LLVM 假定它对该寄存器有完全控制权，并且必须在退出汇编块之前将其恢复到原始状态，所以它不能用作输入或输出，**除非**编译器使用它来满足通用寄存器类（例如 `in(reg)`）。这使得在使用保留寄存器时，`reg` 操作数变得危险，因为我们可能会在不知情的情况下破坏我们的输入或输出，因为它们共享同一个寄存器。"
 
 #: src/unsafe/asm.md:298
 msgid ""
@@ -15951,36 +15975,38 @@ msgid ""
 "register is saved. On 32 bit targets the code would instead use `ebx` in the "
 "`push`/`pop`."
 msgstr ""
+"为了解决这个问题，我们使用 `rdi` 来存储输出数组的指针，通过 `push` 保存 `ebx`，在汇编块内从 `ebx` 读取到数组中，然后通过 `pop` 将 `ebx` 恢复到原始状态。`push` 和 `pop` 使用完整的 64 位 `rbx` 版本的寄存器，以确保整个寄存器被保存。在 32 位目标上，代码会在 `push`/`pop` 中使用 `ebx`。"
 
 #: src/unsafe/asm.md:300
 msgid ""
 "This can also be used with a general register class to obtain a scratch "
 "register for use inside the asm code:"
 msgstr ""
+"这也可以与通用寄存器类一起使用，以获得一个临时寄存器在汇编代码内使用："
 
 #: src/unsafe/asm.md:305
 msgid "// Multiply x by 6 using shifts and adds\n"
-msgstr ""
+msgstr "// 使用移位和加法将 x 乘以 6\n"
 
 #: src/unsafe/asm.md:310
 msgid "\"mov {tmp}, {x}\""
-msgstr ""
+msgstr "\"mov {tmp}, {x}\""
 
 #: src/unsafe/asm.md:311
 msgid "\"shl {tmp}, 1\""
-msgstr ""
+msgstr "\"shl {tmp}, 1\""
 
 #: src/unsafe/asm.md:312
 msgid "\"shl {x}, 2\""
-msgstr ""
+msgstr "\"shl {x}, 2\""
 
 #: src/unsafe/asm.md:313
 msgid "\"add {x}, {tmp}\""
-msgstr ""
+msgstr "\"add {x}, {tmp}\""
 
 #: src/unsafe/asm.md:322
 msgid "Symbol operands and ABI clobbers"
-msgstr ""
+msgstr "符号操作数和 ABI 破坏"
 
 #: src/unsafe/asm.md:324
 msgid ""
@@ -15993,40 +16019,43 @@ msgid ""
 "Multiple `clobber_abi` arguments may be provided and all clobbers from all "
 "specified ABIs will be inserted."
 msgstr ""
+"默认情况下，`asm!` 假定任何未指定为输出的寄存器的内容都将被汇编代码保留。`asm!` 的 [`clobber_abi`](https://doc.rust-lang.org/stable/reference/inline-assembly.html#abi-clobbers) 参数告诉编译器根据给定的调用约定 ABI 自动插入必要的破坏操作数：任何在该 ABI 中未完全保留的寄存器都将被视为被破坏。可以提供多个 `clobber_abi` 参数，所有指定 ABI 的所有破坏都将被插入。"
 
 #: src/unsafe/asm.md:332 src/unsafe/asm.md:350
 msgid "\"C\""
-msgstr ""
+msgstr "\"C\""
 
 #: src/unsafe/asm.md:333
 msgid "\"arg = {}\""
-msgstr ""
+msgstr "\"arg = {}\""
 
 #: src/unsafe/asm.md:341
 msgid "\"call {}\""
-msgstr ""
+msgstr "\"call {}\""
 
 #: src/unsafe/asm.md:342
 msgid "// Function pointer to call\n"
-msgstr ""
+msgstr "// 要调用的函数指针\n"
 
 #: src/unsafe/asm.md:344
 msgid "// 1st argument in rdi\n"
-msgstr ""
+msgstr "// 第一个参数在 rdi 中\n"
 
 #: src/unsafe/asm.md:346
 msgid "// Return value in rax\n"
-msgstr ""
+msgstr "// 返回值在 rax 中\n"
 
 #: src/unsafe/asm.md:348
 msgid ""
 "// Mark all registers which are not preserved by the \"C\" calling\n"
 "            // convention as clobbered.\n"
 msgstr ""
+"// 将所有不被 \"C\" 调用约定保留的寄存器\n"
+"            // 标记为被破坏。\n"
 
 #: src/unsafe/asm.md:358
 msgid "Register template modifiers"
-msgstr ""
+msgstr "寄存器模板修饰符"
 
 #: src/unsafe/asm.md:360
 msgid ""
@@ -16036,22 +16065,25 @@ msgid ""
 "each typically being a \"view\" over a subset of the register (e.g. the low "
 "32 bits of a 64-bit register)."
 msgstr ""
+"在某些情况下，需要对寄存器名称插入模板字符串时的格式进行精细控制。当一个架构的汇编语言对同一个寄存器有几个名称时，这是必要的，每个名称通常是寄存器子集的一个"视图"（例如，64 位寄存器的低 32 位）。"
 
 #: src/unsafe/asm.md:362
 msgid ""
 "By default the compiler will always choose the name that refers to the full "
 "register size (e.g. `rax` on x86-64, `eax` on x86, etc)."
 msgstr ""
+"默认情况下，编译器总是会选择引用完整寄存器大小的名称（例如，在 x86-64 上是 `rax`，在 x86 上是 `eax` 等）。"
 
 #: src/unsafe/asm.md:364
 msgid ""
 "This default can be overridden by using modifiers on the template string "
 "operands, just like you would with format strings:"
 msgstr ""
+"这个默认设置可以通过在模板字符串操作数上使用修饰符来覆盖，就像你在格式字符串中使用的那样："
 
 #: src/unsafe/asm.md:373
 msgid "\"mov {0:h}, {0:l}\""
-msgstr ""
+msgstr "\"mov {0:h}, {0:l}\""
 
 #: src/unsafe/asm.md:380
 msgid ""
@@ -16059,6 +16091,7 @@ msgid ""
 "register allocator to the 4 legacy x86 registers (`ax`, `bx`, `cx`, `dx`) of "
 "which the first two bytes can be addressed independently."
 msgstr ""
+"在这个例子中，我们使用 `reg_abcd` 寄存器类来限制寄存器分配器使用 4 个传统的 x86 寄存器（`ax`、`bx`、`cx`、`dx`），其中前两个字节可以独立寻址。"
 
 #: src/unsafe/asm.md:382
 msgid ""
@@ -16068,6 +16101,7 @@ msgid ""
 "byte. The asm code will therefore be expanded as `mov ah, al` which copies "
 "the low byte of the value into the high byte."
 msgstr ""
+"假设寄存器分配器选择将 `x` 分配在 `ax` 寄存器中。`h` 修饰符将发出该寄存器高字节的寄存器名称，而 `l` 修饰符将发出低字节的寄存器名称。因此，汇编代码将被展开为 `mov ah, al`，这将值的低字节复制到高字节。"
 
 #: src/unsafe/asm.md:385
 msgid ""
@@ -16075,10 +16109,11 @@ msgid ""
 "template modifiers, the compiler will emit a warning and suggest the correct "
 "modifier to use."
 msgstr ""
+"如果你对操作数使用较小的数据类型（例如 `u16`）并忘记使用模板修饰符，编译器将发出警告并建议使用正确的修饰符。"
 
 #: src/unsafe/asm.md:387
 msgid "Memory address operands"
-msgstr ""
+msgstr "内存地址操作数"
 
 #: src/unsafe/asm.md:389
 msgid ""
@@ -16088,14 +16123,15 @@ msgid ""
 "assembly syntax, you should wrap inputs/outputs in `[]` to indicate they are "
 "memory operands:"
 msgstr ""
+"有时汇编指令需要通过内存地址/内存位置传递操作数。你必须手动使用目标架构指定的内存地址语法。例如，在使用 Intel 汇编语法的 x86/x86_64 上，你应该将输入/输出用 `[]` 包裹，以表明它们是内存操作数："
 
 #: src/unsafe/asm.md:399
 msgid "\"fldcw [{}]\""
-msgstr ""
+msgstr "\"fldcw [{}]\""
 
 #: src/unsafe/asm.md:405
 msgid "Labels"
-msgstr ""
+msgstr "标签"
 
 #: src/unsafe/asm.md:407
 msgid ""
@@ -16103,12 +16139,14 @@ msgid ""
 "linker error or may cause other strange behavior. Reuse of a named label can "
 "happen in a variety of ways including:"
 msgstr ""
+"任何命名标签的重用，无论是局部的还是其他的，都可能导致汇编器或链接器错误，或可能引起其他奇怪的行为。命名标签的重用可能以多种方式发生，包括："
 
 #: src/unsafe/asm.md:409
 msgid ""
 "explicitly: using a label more than once in one `asm!` block, or multiple "
 "times across blocks."
 msgstr ""
+"显式：在一个 `asm!` 块中多次使用一个标签，或在多个块之间多次使用。"
 
 #: src/unsafe/asm.md:410
 msgid ""
@@ -16116,12 +16154,14 @@ msgid ""
 "copies of an `asm!` block, for example when the function containing it is "
 "inlined in multiple places."
 msgstr ""
+"通过内联隐式：编译器允许实例化 `asm!` 块的多个副本，例如当包含它的函数在多个地方内联时。"
 
 #: src/unsafe/asm.md:411
 msgid ""
 "implicitly via LTO: LTO can cause code from _other crates_ to be placed in "
 "the same codegen unit, and so could bring in arbitrary labels."
 msgstr ""
+"通过 LTO 隐式：LTO 可能导致**其他 crate** 的代码被放置在同一个代码生成单元中，因此可能引入任意标签。"
 
 #: src/unsafe/asm.md:413
 msgid ""
@@ -16130,6 +16170,7 @@ msgid ""
 "inside inline assembly code. Defining symbols in assembly code may lead to "
 "assembler and/or linker errors due to duplicate symbol definitions."
 msgstr ""
+"因此，你应该只在内联汇编代码中使用 GNU 汇编器的**数字**[局部标签](https://sourceware.org/binutils/docs/as/Symbol-Names.html#Local-Labels)。在汇编代码中定义符号可能会由于重复的符号定义导致汇编器和/或链接器错误。"
 
 #: src/unsafe/asm.md:415
 msgid ""
@@ -16140,50 +16181,52 @@ msgid ""
 "will avoid any ambiguity, but that affects the syntax of the _entire_ `asm!` "
 "block. (See [Options](#options), below, for more on `options`.)"
 msgstr ""
+"此外，在 x86 上使用默认的 Intel 语法时，由于[一个 LLVM 的 bug](https://bugs.llvm.org/show_bug.cgi?id=36144)，你不应该使用仅由 `0` 和 `1` 数字组成的标签，例如 `0`、`11` 或 `101010`，因为它们可能最终被解释为二进制值。使用 `options(att_syntax)` 可以避免任何歧义，但这会影响**整个** `asm!` 块的语法。（有关 `options` 的更多信息，请参见下面的[选项](#options)。）"
 
 #: src/unsafe/asm.md:424
 msgid "\"mov {0}, 10\""
-msgstr ""
+msgstr "\"mov {0}, 10\""
 
 #: src/unsafe/asm.md:425 src/unsafe/asm.md:430
 msgid "\"2:\""
-msgstr ""
+msgstr "\"2:\""
 
 #: src/unsafe/asm.md:426
 msgid "\"sub {0}, 1\""
-msgstr ""
+msgstr "\"sub {0}, 1\""
 
 #: src/unsafe/asm.md:427
 msgid "\"cmp {0}, 3\""
-msgstr ""
+msgstr "\"cmp {0}, 3\""
 
 #: src/unsafe/asm.md:428
 msgid "\"jle 2f\""
-msgstr ""
+msgstr "\"jle 2f\""
 
 #: src/unsafe/asm.md:429
 msgid "\"jmp 2b\""
-msgstr ""
+msgstr "\"jmp 2b\""
 
 #: src/unsafe/asm.md:431
 msgid "\"add {0}, 2\""
-msgstr ""
+msgstr "\"add {0}, 2\""
 
 #: src/unsafe/asm.md:439
 msgid ""
 "This will decrement the `{0}` register value from 10 to 3, then add 2 and "
 "store it in `a`."
 msgstr ""
+"这将把 `{0}` 寄存器的值从 10 递减到 3，然后加 2 并存储在 `a` 中。"
 
 #: src/unsafe/asm.md:441
 msgid "This example shows a few things:"
-msgstr ""
+msgstr "这个例子展示了几点："
 
 #: src/unsafe/asm.md:443
 msgid ""
 "First, that the same number can be used as a label multiple times in the same "
 "inline block."
-msgstr ""
+msgstr "首先，同一个数字可以在同一个内联块中多次用作标签。"
 
 #: src/unsafe/asm.md:444
 msgid ""
@@ -16192,10 +16235,12 @@ msgid ""
 "should be added to the numeric label. It will then refer to the nearest label "
 "defined by this number in this direction."
 msgstr ""
+"其次，当数字标签被用作引用（例如作为指令操作数）时，应该在数字标签后添加后缀 "b"（"backward"，向后）或 "f"（"forward"，向前）。"
+"它将引用该方向上由这个数字定义的最近的标签。"
 
 #: src/unsafe/asm.md:449
 msgid "Options"
-msgstr ""
+msgstr "选项"
 
 #: src/unsafe/asm.md:451
 msgid ""
@@ -16205,16 +16250,18 @@ msgid ""
 "give the compiler more information about what the assembly code is actually "
 "doing so that it can optimize better."
 msgstr ""
+"默认情况下，内联汇编块的处理方式与具有自定义调用约定的外部 FFI 函数调用相同：它可能读/写内存，有可观察的副作用等。"
+"然而，在许多情况下，我们希望给编译器提供更多关于汇编代码实际在做什么的信息，以便它可以更好地优化。"
 
 #: src/unsafe/asm.md:453
 msgid "Let's take our previous example of an `add` instruction:"
-msgstr ""
+msgstr "让我们看看之前 `add` 指令的例子："
 
 #: src/unsafe/asm.md:472
 msgid ""
 "Options can be provided as an optional final argument to the `asm!` macro. We "
 "specified three options here:"
-msgstr ""
+msgstr "选项可以作为 `asm!` 宏的可选最终参数提供。我们在这里指定了三个选项："
 
 #: src/unsafe/asm.md:473
 msgid ""
@@ -16222,6 +16269,7 @@ msgid ""
 "output depends only on its inputs. This allows the compiler optimizer to call "
 "the inline asm fewer times or even eliminate it entirely."
 msgstr ""
+"`pure` 表示汇编代码没有可观察的副作用，其输出仅依赖于其输入。这允许编译器优化器减少调用内联汇编的次数，甚至完全消除它。"
 
 #: src/unsafe/asm.md:474
 msgid ""
@@ -16230,6 +16278,7 @@ msgid ""
 "address that is accessible to it (e.g. through a pointer passed as an "
 "operand, or a global)."
 msgstr ""
+"`nomem` 表示汇编代码不读取或写入内存。默认情况下，编译器会假设内联汇编可以读取或写入任何它可以访问的内存地址（例如，通过作为操作数传递的指针，或全局变量）。"
 
 #: src/unsafe/asm.md:475
 msgid ""
@@ -16237,18 +16286,21 @@ msgid ""
 "allows the compiler to use optimizations such as the stack red zone on x86-64 "
 "to avoid stack pointer adjustments."
 msgstr ""
+"`nostack` 表示汇编代码不会将任何数据压入栈中。这允许编译器使用诸如 x86-64 上的栈红区等优化来避免栈指针调整。"
 
 #: src/unsafe/asm.md:477
 msgid ""
 "These allow the compiler to better optimize code using `asm!`, for example by "
 "eliminating pure `asm!` blocks whose outputs are not needed."
 msgstr ""
+"这些选项允许编译器更好地优化使用 `asm!` 的代码，例如通过消除那些输出不被需要的纯 `asm!` 块。"
 
 #: src/unsafe/asm.md:479
 msgid ""
 "See the [reference](https://doc.rust-lang.org/stable/reference/inline-"
 "assembly.html) for the full list of available options and their effects."
 msgstr ""
+"查看[参考文档](https://doc.rust-lang.org/stable/reference/inline-assembly.html)以获取可用选项的完整列表及其效果。"
 
 #: src/compatibility.md:3
 msgid ""
@@ -16256,10 +16308,11 @@ msgid ""
 "compatibility issues can arise, despite efforts to ensure forwards-"
 "compatibility wherever possible."
 msgstr ""
+"Rust 语言正在快速发展，因此尽管努力确保尽可能的向前兼容性，某些兼容性问题仍可能出现。"
 
 #: src/compatibility.md:7
 msgid "[Raw identifiers](compatibility/raw_identifiers.md)"
-msgstr ""
+msgstr "[原始标识符](compatibility/raw_identifiers.md)"
 
 #: src/compatibility/raw_identifiers.md:3
 msgid ""
@@ -16271,6 +16324,8 @@ msgid ""
 "older edition of Rust has a variable or function with the same name as a "
 "keyword introduced in a newer edition."
 msgstr ""
+"Rust，像许多编程语言一样，有"关键字"的概念。这些标识符对语言来说有特殊含义，因此你不能在变量名、函数名和其他地方使用它们。"
+"原始标识符允许你在通常不允许使用关键字的地方使用它们。这在 Rust 引入新关键字，而使用旧版本 Rust 的库有一个与新版本中引入的关键字同名的变量或函数时特别有用。"
 
 #: src/compatibility/raw_identifiers.md:11
 msgid ""
@@ -16279,14 +16334,16 @@ msgid ""
 "feature in the 2018 edition, so without raw identifiers, we would have no way "
 "to name the function."
 msgstr ""
+"例如，设想一个使用 2015 版 Rust 编译的 crate `foo`，它导出了一个名为 `try` 的函数。这个关键字在 2018 版中被保留用于新特性，"
+"所以如果没有原始标识符，我们就无法命名这个函数。"
 
 #: src/compatibility/raw_identifiers.md:24
 msgid "You'll get this error:"
-msgstr ""
+msgstr "得到这个错误："
 
 #: src/compatibility/raw_identifiers.md:34
 msgid "You can write this with a raw identifier:"
-msgstr ""
+msgstr "可以使用原始标识符这样写："
 
 #: src/meta.md:3
 msgid ""
@@ -16294,39 +16351,45 @@ msgid ""
 "tooling or infrastructure support which just makes things better for "
 "everyone. These topics include:"
 msgstr ""
+"有些主题与程序本身如何运行并不直接相关，但它们提供了工具或基础设施支持，使得整个软件生态都变得更好。这些主题包括："
 
 #: src/meta.md:7
 msgid ""
 "[Documentation](meta/doc.md): Generate library documentation for users via "
 "the included `rustdoc`."
 msgstr ""
+"[文档](meta/doc.md)：通过包含的 `rustdoc` 为用户生成库文档。"
 
 #: src/meta.md:9
 msgid ""
 "[Playground](meta/playground.md): Integrate the Rust Playground in your "
 "documentation."
 msgstr ""
+"[Playground](meta/playground.md)：在你的文档中集成 Rust Playground。"
 
 #: src/meta/doc.md:3
 msgid ""
 "Use `cargo doc` to build documentation in `target/doc`, `cargo doc --open` "
 "will automatically open it in your web browser."
 msgstr ""
+"使用 `cargo doc` 在 `target/doc` 中构建文档，`cargo doc --open` 将在浏览器中自动打开。"
 
 #: src/meta/doc.md:6
 msgid ""
 "Use `cargo test` to run all tests (including documentation tests), and `cargo "
 "test --doc` to only run documentation tests."
 msgstr ""
+"使用 `cargo test` 运行所有测试（包括文档测试），使用 `cargo test --doc` 只运行文档测试。"
 
 #: src/meta/doc.md:9
 msgid ""
 "These commands will appropriately invoke `rustdoc` (and `rustc`) as required."
 msgstr ""
+"这些命令将根据需要适当地调用 `rustdoc`（和 `rustc`）。"
 
 #: src/meta/doc.md:11
 msgid "Doc comments"
-msgstr ""
+msgstr "文档注释"
 
 #: src/meta/doc.md:13
 msgid ""
@@ -16335,18 +16398,19 @@ msgid ""
 "documentation. They are denoted by a `///`, and support [Markdown](https://en."
 "wikipedia.org/wiki/Markdown)."
 msgstr ""
+"文档注释对于需要文档的大型项目非常有用。当运行 `rustdoc` 时，这些注释会被编译成文档。它们由 `///` 表示，并支持 [Markdown](https://en.wikipedia.org/wiki/Markdown)。"
 
 #: src/meta/doc.md:18
 msgid "\"doc\""
-msgstr ""
+msgstr "\"doc\""
 
 #: src/meta/doc.md:19
 msgid "/// A human being is represented here\n"
-msgstr ""
+msgstr "/// 这里表示一个人类\n"
 
 #: src/meta/doc.md:22
 msgid "/// A person must have a name, no matter how much Juliet may hate it\n"
-msgstr ""
+msgstr "/// 一个人必须有一个名字，不管朱丽叶有多讨厌它\n"
 
 #: src/meta/doc.md:27
 msgid ""
@@ -16361,6 +16425,16 @@ msgid ""
 "    /// let person = Person::new(\"name\");\n"
 "    /// ```\n"
 msgstr ""
+"/// 创建一个具有给定名字的人。\n"
+"    ///\n"
+"    /// # 示例\n"
+"    ///\n"
+"    /// ```\n"
+"    /// // 你可以在注释中的围栏之间放置 rust 代码\n"
+"    /// // 如果你向 `rustdoc` 传递 --test 参数，它甚至会为你测试这段代码！\n"
+"    /// use doc::Person;\n"
+"    /// let person = Person::new(\"name\");\n"
+"    /// ```\n"
 
 #: src/meta/doc.md:43
 msgid ""
@@ -16369,20 +16443,24 @@ msgid ""
 "    /// Says \"Hello, [name](Person::name)\" to the `Person` it is called "
 "on.\n"
 msgstr ""
+"/// 给出一个友好的问候！\n"
+"    ///\n"
+"    /// 对调用它的 `Person` 说 \"Hello, [name](Person::name)\"。\n"
 
 #: src/meta/doc.md:47
 msgid "\"Hello, {}!\""
-msgstr ""
+msgstr "\"Hello, {}!\""
 
 #: src/meta/doc.md:52
 msgid "\"John\""
-msgstr ""
+msgstr "\"John\""
 
 #: src/meta/doc.md:58
 msgid ""
 "To run the tests, first build the code as a library, then tell `rustdoc` "
 "where to find the library so it can link it into each doctest program:"
 msgstr ""
+"要运行测试，首先将代码构建为库，然后告诉 `rustdoc` 在哪里找到库，以便它可以将其链接到每个文档测试程序中："
 
 #: src/meta/doc.md:61
 msgid ""
@@ -16391,62 +16469,67 @@ msgid ""
 "$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
 "```"
 msgstr ""
+"```shell\n"
+"$ rustc doc.rs --crate-type lib\n"
+"$ rustdoc --test --extern doc=\"libdoc.rlib\" doc.rs\n"
+"```"
 
 #: src/meta/doc.md:66
 msgid "Doc attributes"
-msgstr ""
+msgstr "文档属性"
 
 #: src/meta/doc.md:68
 msgid ""
 "Below are a few examples of the most common `#[doc]` attributes used with "
 "`rustdoc`."
-msgstr ""
+msgstr "以下是与 `rustdoc` 一起使用的最常见的 `#[doc]` 属性的几个例子。"
 
 #: src/meta/doc.md:71
 msgid "`inline`"
-msgstr ""
+msgstr "`inline`"
 
 #: src/meta/doc.md:73
 msgid "Used to inline docs, instead of linking out to separate page."
-msgstr ""
+msgstr "用于内联文档，而不是链接到单独的页面。"
 
 #: src/meta/doc.md:78
 msgid "/// bar docs\n"
-msgstr ""
+msgstr "/// bar 文档\n"
 
 #: src/meta/doc.md:81
 msgid "/// the docs for Bar\n"
-msgstr ""
+msgstr "/// Bar 的文档\n"
 
 #: src/meta/doc.md:86
 msgid "`no_inline`"
-msgstr ""
+msgstr "`no_inline`"
 
 #: src/meta/doc.md:88
 msgid "Used to prevent linking out to separate page or anywhere."
-msgstr ""
+msgstr "用于防止链接到单独的页面或任何地方。"
 
 #: src/meta/doc.md:91
 msgid "// Example from libcore/prelude\n"
-msgstr ""
+msgstr "// libcore/prelude 中的示例\n"
 
 #: src/meta/doc.md:96
 msgid "`hidden`"
-msgstr ""
+msgstr "`hidden`"
 
 #: src/meta/doc.md:98
 msgid "Using this tells `rustdoc` not to include this in documentation:"
-msgstr ""
+msgstr "使用这个属性告诉 `rustdoc` 不要包含在文档中："
 
 #: src/meta/doc.md:101
 msgid "// Example from the futures-rs library\n"
-msgstr ""
+msgstr "// futures-rs 库中的示例\n"
 
 #: src/meta/doc.md:106
 msgid ""
 "For documentation, `rustdoc` is widely used by the community. It's what is "
 "used to generate the [std library docs](https://doc.rust-lang.org/std/)."
 msgstr ""
+"针对文档，`rustdoc` 被社区广泛使用。[标准库文档](https://doc.rust-lang.org/std/)就是用它来生成的。"
 
 #: src/meta/doc.md:111
 msgid ""
@@ -16454,16 +16537,18 @@ msgid ""
 "org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-"
 "comments)"
 msgstr ""
+"[Rust 程序设计语言: 编写有用的文档注释](https://doc.rust-lang.org/book/ch14-02-publishing-to-crates-io.html#making-useful-documentation-comments)"
 
 #: src/meta/doc.md:112
 msgid "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/index.html)"
-msgstr ""
+msgstr "[rustdoc 手册](https://doc.rust-lang.org/rustdoc/index.html)"
 
 #: src/meta/doc.md:113
 msgid ""
 "[The Reference: Doc comments](https://doc.rust-lang.org/stable/reference/"
 "comments.html#doc-comments)"
 msgstr ""
+"[参考手册: 文档注释](https://doc.rust-lang.org/stable/reference/comments.html#doc-comments)"
 
 #: src/meta/doc.md:114
 msgid ""
@@ -16471,34 +16556,39 @@ msgid ""
 "rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-"
 "text)"
 msgstr ""
+"[RFC 1574: API 文档约定](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text)"
 
 #: src/meta/doc.md:115
 msgid ""
 "[RFC 1946: Relative links to other items from doc comments (intra-rustdoc "
 "links)](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
 msgstr ""
+"[RFC 1946: 从文档注释到其他项目的相对链接（rustdoc 内部链接）](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html)"
 
 #: src/meta/doc.md:116
 msgid ""
 "[Is there any documentation style guide for comments? (reddit)](https://www."
 "reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
 msgstr ""
+"[有没有关于注释的文档风格指南？（reddit）](https://www.reddit.com/r/rust/comments/ahb50s/is_there_any_documentation_style_guide_for/)"
 
 #: src/meta/playground.md:3
 msgid ""
 "The [Rust Playground](https://play.rust-lang.org/) is a way to experiment "
 "with Rust code through a web interface."
 msgstr ""
+"[Rust Playground](https://play.rust-lang.org/) 是一种在线运行验证 Rust 代码的方式。"
 
 #: src/meta/playground.md:6
 msgid "Using it with `mdbook`"
-msgstr ""
+msgstr "在 `mdbook` 中使用"
 
 #: src/meta/playground.md:8
 msgid ""
 "In [`mdbook`](https://github.com/rust-lang/mdBook), you can make code "
 "examples playable and editable."
 msgstr ""
+"在 [`mdbook`](https://github.com/rust-lang/mdBook) 中，你可以使代码示例可运行和可编辑。"
 
 #: src/meta/playground.md:16
 msgid ""
@@ -16506,16 +16596,18 @@ msgid ""
 "tweak it. The key here is the adding of the word `editable` to your codefence "
 "block separated by a comma."
 msgstr ""
+"这允许读者既可以运行你的代码示例，也可以修改和调整它。这里的关键是在你的代码块标注中添加 `editable` 这个词，用逗号分隔。"
 
 #: src/meta/playground.md:26
 msgid ""
 "Additionally, you can add `ignore` if you want `mdbook` to skip your code "
 "when it builds and tests."
 msgstr ""
+"此外，如果你希望 `mdbook` 在构建和测试时跳过你的代码，你可以添加 `ignore`。"
 
 #: src/meta/playground.md:35
 msgid "Using it with docs"
-msgstr ""
+msgstr "在文档中使用"
 
 #: src/meta/playground.md:37
 msgid ""
@@ -16525,6 +16617,7 @@ msgid ""
 "attribute called [`html_playground_url`](https://doc.rust-lang.org/rustdoc/"
 "write-documentation/the-doc-attribute.html#html_playground_url)."
 msgstr ""
+"你可能已经注意到在一些 [官方 Rust 文档](https://doc.rust-lang.org/core/) 中有一个写着 \"Run\" 的按钮，它会在 Rust Playground 的新标签页中打开代码示例。使用名为 [`html_playground_url`](https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#html_playground_url) 的 `#[doc]` 属性，就可以启用这个功能。"
 
 #: src/meta/playground.md:42
 msgid ""
@@ -16535,18 +16628,26 @@ msgid ""
 "//! ```\n"
 "````"
 msgstr ""
+"````\n"
+"#![doc(html_playground_url = \"https://play.rust-lang.org/\")]\n"
+"//! ```\n"
+"//! println!(\"Hello World\");\n"
+"//! ```\n"
+"````"
 
 #: src/meta/playground.md:51
 msgid "[The Rust Playground](https://play.rust-lang.org/)"
-msgstr ""
+msgstr "[Rust Playground](https://play.rust-lang.org/)"
 
 #: src/meta/playground.md:52
 msgid ""
 "[The Rust Playground On Github](https://github.com/integer32llc/rust-"
 "playground/)"
 msgstr ""
+"[GitHub 上的 Rust Playground](https://github.com/integer32llc/rust-playground/)"
 
 #: src/meta/playground.md:53
 msgid ""
 "[The rustdoc Book](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)"
 msgstr ""
+"[rustdoc 手册](https://doc.rust-lang.org/rustdoc/what-is-rustdoc.html)"

--- a/po/zh.po
+++ b/po/zh.po
@@ -989,33 +989,33 @@ msgstr ""
 #: src/hello/comment.md:3
 msgid ""
 "Any program requires comments, and Rust supports a few different varieties:"
-msgstr ""
+msgstr "任何程序都需要注释，Rust 支持几种不同的注释类型："
 
 #: src/hello/comment.md:6
 msgid "_Regular comments_ which are ignored by the compiler:"
-msgstr ""
+msgstr "**普通注释**会被编译器会忽略的 ："
 
 #: src/hello/comment.md:7
 msgid "`// Line comments which go to the end of the line.`"
-msgstr ""
+msgstr "`// 行注释，直到行尾。`"
 
 #: src/hello/comment.md:8
 msgid "`/* Block comments which go to the closing delimiter. */`"
-msgstr ""
+msgstr "`/* 块注释，直到闭合分隔符。 */`"
 
 #: src/hello/comment.md:9
 msgid ""
 "_Doc comments_ which are parsed into HTML library [documentation](../meta/doc."
 "md):"
-msgstr ""
+msgstr "**文档注释**会被解析成 HTML 库[文档](../meta/doc.md)："
 
 #: src/hello/comment.md:10
 msgid "`/// Generate library docs for the following item.`"
-msgstr ""
+msgstr "`/// 为下一项生成库文档。`"
 
 #: src/hello/comment.md:11
 msgid "`//! Generate library docs for the enclosing item.`"
-msgstr ""
+msgstr "`//! 为所属项（译注：如 crate、模块或函数）生成库文档。`"
 
 #: src/hello/comment.md:15
 msgid ""
@@ -1023,14 +1023,17 @@ msgid ""
 "    // There are two slashes at the beginning of the line.\n"
 "    // And nothing written after these will be read by the compiler.\n"
 msgstr ""
+"// 这是一个行注释的例子。\n"
+"    // 行首有两个斜杠。\n"
+"    // 这些之后写的内容不会被编译器读取。\n"
 
 #: src/hello/comment.md:19
 msgid "// println!(\"Hello, world!\");\n"
-msgstr ""
+msgstr "// println!(\"Hello, world!\");\n"
 
 #: src/hello/comment.md:21
 msgid "// Run it. See? Now try deleting the two slashes, and run it again.\n"
-msgstr ""
+msgstr "// 运行它。看到了吗？现在尝试删除两个斜杠，再运行一次。\n"
 
 #: src/hello/comment.md:23
 msgid ""
@@ -1040,9 +1043,15 @@ msgid ""
 "     * are extremely useful for temporarily disabling chunks of code.\n"
 "     * /* Block comments can be /* nested, */ */ so it takes only a few\n"
 "     * keystrokes to comment out everything in this main() function.\n"
-"     * /*/*/* Try it yourself! */*/*/\n"
-"     */"
+"     * /*/*/* Try it yourself! */*/*/"
 msgstr ""
+"/*\n"
+"     * 这是另一种注释，块注释。通常，\n"
+"     * 推荐使用行注释风格。但块注释\n"
+"     * 非常适用于临时禁用代码块。\n"
+"     * /* 块注释可以 /* 嵌套， */ */ 所以只需要几个\n"
+"     * 按键就可以注释掉这个 main() 函数中的所有内容。\n"
+"     * /*/*/* 自己试试吧！ */*/*/"
 
 #: src/hello/comment.md:32
 msgid ""
@@ -1051,6 +1060,10 @@ msgid ""
 "    no actual need for it.\n"
 "    */"
 msgstr ""
+"/*\n"
+"    注意：前面的 `*` 列完全是出于风格考虑。实际上\n"
+"    并不需要它。\n"
+"    */"
 
 #: src/hello/comment.md:37
 msgid ""
@@ -1058,14 +1071,17 @@ msgid ""
 "    // than with line comments. Try deleting the comment delimiters\n"
 "    // to change the result:\n"
 msgstr ""
+"// 你可以使用块注释比行注释更容易地操作表达式\n"
+"    // 尝试删除注释分隔符\n"
+"    // 来改变结果：\n"
 
 #: src/hello/comment.md:40
 msgid "/* 90 + */"
-msgstr ""
+msgstr "/* 90 + */"
 
 #: src/hello/comment.md:41
 msgid "\"Is `x` 10 or 100? x = {}\""
-msgstr ""
+msgstr "\"`x` 是 10 还是 100？x = {}\""
 
 #: src/hello/comment.md:45 src/hello/print.md:103
 #: src/hello/print/print_debug.md:75 src/hello/print/print_display.md:118
@@ -1111,11 +1127,11 @@ msgstr ""
 #: src/std_misc/threads/testcase_mapreduce.md:128 src/std_misc/path.md:54
 #: src/std_misc/fs.md:150 src/meta/doc.md:109 src/meta/playground.md:49
 msgid "See also:"
-msgstr ""
+msgstr "另见："
 
 #: src/hello/comment.md:47
 msgid "[Library documentation](../meta/doc.md)"
-msgstr ""
+msgstr "[文档注释](../meta/doc.md)"
 
 #: src/hello/print.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -7538,6 +7538,9 @@ msgid ""
 "considered valid. The simplest and most common use of generics is for type "
 "parameters."
 msgstr ""
+"**泛型** 是关于将类型和函数扩展使其更通用的主题。这对于减少代码重复非常有用，"
+"但需要相对复杂的语法。也就是说，使用泛型需要非常小心地指定泛型类型在什么类型上实际有效。"
+"泛型最简单和最常见的用法是类型参数。"
 
 #: src/generics.md:10
 msgid ""
@@ -7548,12 +7551,16 @@ msgid ""
 "parameters `<T>`. Any type specified as a generic type parameter is generic, "
 "and everything else is concrete (non-generic)."
 msgstr ""
+"类型参数通过使用尖括号和大写 [驼峰命名法](https://en.wikipedia.org/wiki/CamelCase) 指定为泛型：`<Aaa, Bbb, ...>`。"
+"“泛型类型参数”通常表示为 `<T>`。在 Rust 中，“泛型”也描述了任何接受一个或多个泛型类型参数 `<T>` 的任何内容。"
+"任何指定为泛型类型参数的类型都是泛型的，其他所有类型都是具体的（非泛型）。"
 
 #: src/generics.md:16
 msgid ""
 "For example, defining a _generic function_ named `foo` that takes an argument "
 "`T` of any type:"
 msgstr ""
+"例如，定义一个名为 `foo` 的**泛型函数**，它接受一个任意类型的参数 `T`："
 
 #: src/generics.md:23
 msgid ""
@@ -7561,14 +7568,16 @@ msgid ""
 "considered generic when used here as `(arg: T)`. This is the case even if `T` "
 "has previously been defined as a `struct`."
 msgstr ""
+"因为 `T` 已经使用 `<T>` 指定为泛型类型参数，所以在这里用作 `(arg: T)` 时被认为是泛型的。"
+"即使 `T` 之前已被定义为 `struct`，也是如此。"
 
 #: src/generics.md:27
 msgid "This example shows some of the syntax in action:"
-msgstr ""
+msgstr "这个例子展示了泛型语法的使用："
 
 #: src/generics.md:30
 msgid "// A concrete type `A`.\n"
-msgstr ""
+msgstr "// 一个具体类型 `A`。\n"
 
 #: src/generics.md:32
 msgid ""
@@ -7576,10 +7585,12 @@ msgid ""
 "`<A>`.\n"
 "// Therefore, `Single` is a concrete type, and `A` is defined as above.\n"
 msgstr ""
+"// 在定义类型 `Single` 时，第一次使用 `A` 时没有前置 `<A>`。\n"
+"// 因此，`Single` 是一个具体类型，`A` 如上所述定义。\n"
 
 #: src/generics.md:35
 msgid "//            ^ Here is `Single`s first use of the type `A`.\n"
-msgstr ""
+msgstr "//            ^ 这里是 `Single` 第一次使用类型 `A`。\n"
 
 #: src/generics.md:37
 msgid ""
@@ -7589,10 +7600,13 @@ msgid ""
 "including\n"
 "// the concrete type `A` defined at the top.\n"
 msgstr ""
+"// 这里，`<T>` 在第一次使用 `T` 之前，因此 `SingleGen` 是一个泛型类型。\n"
+"// 因为类型参数 `T` 是泛型的，它可以是任何东西，包括\n"
+"// 上面定义的具体类型 `A`。\n"
 
 #: src/generics.md:44
 msgid "// `Single` is concrete and explicitly takes `A`.\n"
-msgstr ""
+msgstr "// `Single` 是具体的，并且明确地接受 `A`。\n"
 
 #: src/generics.md:47
 msgid ""
@@ -7600,32 +7614,36 @@ msgid ""
 "    // and give it the value `SingleGen('a')`.\n"
 "    // Here, `SingleGen` has a type parameter explicitly specified.\n"
 msgstr ""
+"// 创建一个类型为 `SingleGen<char>` 的变量 `_char`\n"
+"    // 并赋予它值 `SingleGen('a')`。\n"
+"    // 这里，`SingleGen` 有一个明确指定的类型参数。\n"
 
 #: src/generics.md:52
 msgid "// `SingleGen` can also have a type parameter implicitly specified:\n"
-msgstr ""
+msgstr "// `SingleGen` 也可以有一个隐式指定的类型参数：\n"
 
 #: src/generics.md:53
 msgid "// Uses `A` defined at the top.\n"
-msgstr ""
+msgstr "// 使用上面定义的 `A`。\n"
 
 #: src/generics.md:54
 msgid "// Uses `i32`.\n"
-msgstr ""
+msgstr "// 使用 `i32`。\n"
 
 #: src/generics.md:55
 msgid "// Uses `char`.\n"
-msgstr ""
+msgstr "// 使用 `char`。\n"
 
 #: src/generics.md:61
 msgid "[`structs`](custom_types/structs.md)"
-msgstr ""
+msgstr "[`结构体`](custom_types/structs.md)"
 
 #: src/generics/gen_fn.md:3
 msgid ""
 "The same set of rules can be applied to functions: a type `T` becomes generic "
 "when preceded by `<T>`."
 msgstr ""
+"同样的规则也适用于函数：当类型 `T` 前置 `<T>` 时，那么它就变成了泛型。"
 
 #: src/generics/gen_fn.md:6
 msgid ""
@@ -7634,36 +7652,42 @@ msgid ""
 "type is generic, or if the compiler doesn't have enough information to infer "
 "the necessary type parameters."
 msgstr ""
+"使用泛型函数有时需要明确指定类型参数。如果函数调用时返回类型是泛型，"
+"或者编译器没有足够的信息来推断必要的类型参数，可能会出现这种情况。"
 
 #: src/generics/gen_fn.md:11
 msgid ""
 "A function call with explicitly specified type parameters looks like: `fun::"
 "<A, B, ...>()`."
 msgstr ""
+"一个明确指定类型参数的函数调用看起来像这样：`fun::<A, B, ...>()`。"
 
 #: src/generics/gen_fn.md:15
 msgid "// Concrete type `A`.\n"
-msgstr ""
+msgstr "// 具体类型 `A`。\n"
 
 #: src/generics/gen_fn.md:16
 msgid "// Concrete type `S`.\n"
-msgstr ""
+msgstr "// 具体类型 `S`。\n"
 
 #: src/generics/gen_fn.md:17
 msgid "// Generic type `SGen`.\n"
-msgstr ""
+msgstr "// 泛型类型 `SGen`。\n"
 
 #: src/generics/gen_fn.md:18
 msgid ""
 "// The following functions all take ownership of the variable passed into\n"
 "// them and immediately go out of scope, freeing the variable.\n"
 msgstr ""
+"// 以下函数都获取传入的变量的所有权，并立即超出作用域，释放变量。\n"
 
 #: src/generics/gen_fn.md:21
 msgid ""
 "// Define a function `reg_fn` that takes an argument `_s` of type `S`.\n"
 "// This has no `<T>` so this is not a generic function.\n"
 msgstr ""
+"// 定义一个函数 `reg_fn`，它接受一个类型为 `S` 的参数 `_s`。\n"
+"// 这没有 `<T>`，所以这不是一个泛型函数。\n"
 
 #: src/generics/gen_fn.md:25
 msgid ""
@@ -7674,6 +7698,9 @@ msgid ""
 "// been specified as a generic type parameter for `gen_spec_t`, it is not "
 "generic.\n"
 msgstr ""
+"// 定义一个函数 `gen_spec_t`，它接受一个类型为 `SGen<T>` 的参数 `_s`。\n"
+"// 它被明确地赋予了类型参数 `A`，但因为 `A` 没有\n"
+"// 被指定为 `gen_spec_t` 的泛型类型参数，所以它不是泛型的。\n"
 
 #: src/generics/gen_fn.md:30
 msgid ""
@@ -7683,6 +7710,9 @@ msgid ""
 "type.\n"
 "// Because `i32` is not a generic type, this function is also not generic.\n"
 msgstr ""
+"// 定义一个函数 `gen_spec_i32`，它接受一个类型为 `SGen<i32>` 的参数 `_s`。\n"
+"// 它被明确地赋予了类型参数 `i32`，这是一个具体类型。\n"
+"// 因为 `i32` 不是泛型类型，所以这个函数也不是泛型的。\n"
 
 #: src/generics/gen_fn.md:35
 msgid ""
@@ -7691,116 +7721,125 @@ msgid ""
 "// Because `SGen<T>` is preceded by `<T>`, this function is generic over "
 "`T`.\n"
 msgstr ""
+"// 定义一个函数 `generic`，它接受一个类型为 `SGen<T>` 的参数 `_s`。\n"
+"// 因为 `SGen<T>` 前置 `<T>`，所以这个函数是泛型的。\n"
 
 #: src/generics/gen_fn.md:41
 msgid "// Using the non-generic functions\n"
-msgstr ""
+msgstr "// 使用非泛型函数\n"
 
 #: src/generics/gen_fn.md:42
 msgid "// Concrete type.\n"
-msgstr ""
+msgstr "// 具体类型。\n"
 
 #: src/generics/gen_fn.md:43
 msgid "// Implicitly specified type parameter `A`.\n"
-msgstr ""
+msgstr "// 隐式指定的类型参数 `A`。\n"
 
 #: src/generics/gen_fn.md:44
 msgid "// Implicitly specified type parameter `i32`.\n"
-msgstr ""
+msgstr "// 隐式指定的类型参数 `i32`。\n"
 
 #: src/generics/gen_fn.md:46
 msgid "// Explicitly specified type parameter `char` to `generic()`.\n"
-msgstr ""
+msgstr "// 明确指定的类型参数 `char` 给 `generic()`。\n"
 
 #: src/generics/gen_fn.md:49
 msgid "// Implicitly specified type parameter `char` to `generic()`.\n"
-msgstr ""
+msgstr "// 隐式指定的类型参数 `char` 给 `generic()`。\n"
 
 #: src/generics/gen_fn.md:50
 msgid "'c'"
-msgstr ""
+msgstr "'c'"
 
 #: src/generics/gen_fn.md:56
 msgid "[functions](../fn.md) and [`struct`s](../custom_types/structs.md)"
-msgstr ""
+msgstr "[函数](../fn.md) 和 [`结构体`](../custom_types/structs.md)"
 
 #: src/generics/impl.md:3
 msgid "Similar to functions, implementations require care to remain generic."
-msgstr ""
+msgstr "与函数类似，`impl` 实现部分使用泛型，也需要很仔细。"
 
 #: src/generics/impl.md:6
 msgid "// Concrete type `S`\n"
-msgstr ""
+msgstr "// 具体类型 `S`\n"
 
 #: src/generics/impl.md:7
 msgid "// Generic type `GenericVal`\n"
-msgstr ""
+msgstr "// 泛型类型 `GenericVal`\n"
 
 #: src/generics/impl.md:8
 msgid "// impl of GenericVal where we explicitly specify type parameters:\n"
-msgstr ""
+msgstr "// GenericVal 的实现，我们在这里显式指定类型参数：\n"
 
 #: src/generics/impl.md:10
 msgid "// Specify `f32`\n"
-msgstr ""
+msgstr "// 指定 `f32`\n"
 
 #: src/generics/impl.md:11
 msgid "// Specify `S` as defined above\n"
-msgstr ""
+msgstr "// 指定上面定义的 `S`\n"
 
 #: src/generics/impl.md:12
 msgid "// `<T>` Must precede the type to remain generic\n"
-msgstr ""
+msgstr "// `<T>` 必须在类型之前以保持泛型\n"
 
 #: src/generics/impl.md:25
 msgid "// impl of Val\n"
-msgstr ""
+msgstr "// Val 的实现\n"
 
 #: src/generics/impl.md:32
 msgid "// impl of GenVal for a generic type `T`\n"
-msgstr ""
+msgstr "// 为泛型类型 `T` 实现 GenVal\n"
 
 #: src/generics/impl.md:50
 msgid ""
 "[functions returning references](../scope/lifetime/fn.md), [`impl`](../fn/"
 "methods.md), and [`struct`](../custom_types/structs.md)"
 msgstr ""
+"[返回引用的函数](../scope/lifetime/fn.md)、[`impl`](../fn/methods.md) 和 [`结构体`](../custom_types/structs.md)"
 
 #: src/generics/gen_trait.md:3
 msgid ""
 "Of course `trait`s can also be generic. Here we define one which reimplements "
 "the `Drop` `trait` as a generic method to `drop` itself and an input."
 msgstr ""
+"当然 `trait` 也可以是泛型的。这里我们定义了一个重新实现 `Drop` `trait` 的泛型方法，用于 `drop` 自身和一个输入。"
 
 #: src/generics/gen_trait.md:7
 msgid "// Non-copyable types.\n"
-msgstr ""
+msgstr "// 不可复制的类型。\n"
 
 #: src/generics/gen_trait.md:10
 msgid "// A trait generic over `T`.\n"
-msgstr ""
+msgstr "// 一个泛型 `T` 的 trait。\n"
 
 #: src/generics/gen_trait.md:13
 msgid ""
 "// Define a method on the caller type which takes an\n"
 "    // additional single parameter `T` and does nothing with it.\n"
 msgstr ""
+"// 在调用者类型上定义一个方法，该方法接受一个\n"
+"    // 额外的单一参数 `T`，并且不对其做任何操作。\n"
 
 #: src/generics/gen_trait.md:17
 msgid ""
 "// Implement `DoubleDrop<T>` for any generic parameter `T` and\n"
 "// caller `U`.\n"
 msgstr ""
+"// 为任何泛型参数 `T` 和调用者 `U` 实现 `DoubleDrop<T>`。\n"
 
 #: src/generics/gen_trait.md:21
 msgid ""
 "// This method takes ownership of both passed arguments,\n"
 "    // deallocating both.\n"
 msgstr ""
+"// 此方法获取两个传入参数的所有权，\n"
+"    // 释放两者的内存。\n"
 
 #: src/generics/gen_trait.md:30
 msgid "// Deallocate `empty` and `null`.\n"
-msgstr ""
+msgstr "// 释放 `empty` 和 `null`。\n"
 
 #: src/generics/gen_trait.md:33
 msgid ""
@@ -7808,12 +7847,16 @@ msgid ""
 "    //null;\n"
 "    // ^ TODO: Try uncommenting these lines.\n"
 msgstr ""
+"//empty;\n"
+"    //null;\n"
+"    // ^ TODO：尝试取消这些行的注释。\n"
 
 #: src/generics/gen_trait.md:41
 msgid ""
 "[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html), [`struct`](../"
 "custom_types/structs.md), and [`trait`](../trait.md)"
 msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html)、[`结构体`](../custom_types/structs.md) 和 [`trait`](../trait.md)"
 
 #: src/generics/bounds.md:3
 msgid ""
@@ -7822,23 +7865,27 @@ msgid ""
 "following example uses the trait `Display` to print and so it requires `T` to "
 "be bound by `Display`; that is, `T` _must_ implement `Display`."
 msgstr ""
+"在使用泛型时，类型参数常常必须使用 trait 作为**约束**来规定类型实现了什么功能。例如，下面的例子使用 trait `Display` 来打印，因此它要求 `T` 被 `Display` 约束；也就是说，`T` **必须**实现 `Display`。"
 
 #: src/generics/bounds.md:9
 msgid ""
 "// Define a function `printer` that takes a generic type `T` which\n"
 "// must implement trait `Display`.\n"
 msgstr ""
+"// 定义一个函数 `printer`，它接受一个泛型类型 `T`，\n"
+"// 该类型必须实现 `Display` trait。\n"
 
 #: src/generics/bounds.md:16
 msgid ""
 "Bounding restricts the generic to types that conform to the bounds. That is:"
-msgstr ""
+msgstr "约束将泛型限制为符合约束的类型。也就是说："
 
 #: src/generics/bounds.md:20
 msgid ""
 "// Error! `Vec<T>` does not implement `Display`. This\n"
 "// specialization will fail.\n"
 msgstr ""
+"// 错误！`Vec<T>` 没有实现 `Display`。泛型特化失败。\n"
 
 #: src/generics/bounds.md:26
 msgid ""
@@ -7846,26 +7893,31 @@ msgid ""
 "the [methods](../fn/methods.md) of traits specified in the bounds. For "
 "example:"
 msgstr ""
+"约束的另一个作用是允许泛型实例访问在约束中指定的 trait 的[方法](../fn/methods.md)。例如："
 
 #: src/generics/bounds.md:30
 msgid "// A trait which implements the print marker: `{:?}`.\n"
-msgstr ""
+msgstr "// 这个 trait 用来实现打印标记：`{:?}`。\n"
 
 #: src/generics/bounds.md:45
 msgid ""
 "// The generic `T` must implement `Debug`. Regardless\n"
 "// of the type, this will work properly.\n"
 msgstr ""
+"// 泛型 `T` 必须实现 `Debug`。这样，无论是什么类型，\n"
+"// 都可以让下面函数正常工作。\n"
 
 #: src/generics/bounds.md:51
 msgid ""
 "// `T` must implement `HasArea`. Any type which meets\n"
 "// the bound can access `HasArea`'s function `area`.\n"
 msgstr ""
+"// `T` 必须实现 `HasArea`。任何符合这个约束的类型\n"
+"// 都可以访问 `HasArea` 的函数 `area`。\n"
 
 #: src/generics/bounds.md:61
 msgid "\"Area: {}\""
-msgstr ""
+msgstr "\"面积：{}\""
 
 #: src/generics/bounds.md:63
 msgid ""
@@ -7874,18 +7926,24 @@ msgid ""
 "    // ^ TODO: Try uncommenting these.\n"
 "    // | Error: Does not implement either `Debug` or `HasArea`. \n"
 msgstr ""
+"//print_debug(&_triangle);\n"
+"    //println!(\"面积：{}\", area(&_triangle));\n"
+"    // ^ TODO：尝试取消这些注释。\n"
+"    // | 错误：未实现 `Debug` 或 `HasArea`。\n"
 
 #: src/generics/bounds.md:70
 msgid ""
 "As an additional note, [`where`](../generics/where.md) clauses can also be "
 "used to apply bounds in some cases to be more expressive."
 msgstr ""
+"另外需要注意的是，在某些情况下可以使用 [`where`](../generics/where.md) 子句来应用约束，以使表达更加清晰。"
 
 #: src/generics/bounds.md:75
 msgid ""
 "[`std::fmt`](../hello/print.md), [`struct`s](../custom_types/structs.md), and "
 "[`trait`s](../trait.md)"
 msgstr ""
+"[`std::fmt`](../hello/print.md)、[`结构体`](../custom_types/structs.md) 和 [`trait`](../trait.md)"
 
 #: src/generics/bounds/testcase_empty.md:3
 msgid ""
@@ -7893,40 +7951,46 @@ msgid ""
 "any functionality, you can still use it as a bound. `Eq` and `Copy` are "
 "examples of such `trait`s from the `std` library."
 msgstr ""
+"约束的工作机制会产生这样的效果，即使一个 `trait` 不包含任何功能，你仍然可以将其用作约束。`Eq` 和 `Copy` 是 `std` 库中这类 `trait` 的例子。"
 
 #: src/generics/bounds/testcase_empty.md:17
 msgid ""
 "// These functions are only valid for types which implement these\n"
 "// traits. The fact that the traits are empty is irrelevant.\n"
 msgstr ""
+"// 这些函数只对实现了这些 trait 的类型有效。\n"
+"// 事实上这些 trait 内部是空的，但这没有关系。\n"
 
 #: src/generics/bounds/testcase_empty.md:20
 msgid "\"red\""
-msgstr ""
+msgstr "\"红色\""
 
 #: src/generics/bounds/testcase_empty.md:21
 msgid "\"blue\""
-msgstr ""
+msgstr "\"蓝色\""
 
 #: src/generics/bounds/testcase_empty.md:28
 msgid ""
 "// `red()` won't work on a blue jay nor vice versa\n"
 "    // because of the bounds.\n"
 msgstr ""
+"// 由于约束的存在，`red()` 不能用于蓝松鸟，反之亦然。\n"
 
 #: src/generics/bounds/testcase_empty.md:30
 msgid "\"A cardinal is {}\""
-msgstr ""
+msgstr "\"红雀是 {}\""
 
 #: src/generics/bounds/testcase_empty.md:31
 msgid "\"A blue jay is {}\""
-msgstr ""
+msgstr "\"蓝松鸟是 {}\""
 
 #: src/generics/bounds/testcase_empty.md:32
 msgid ""
 "//println!(\"A turkey is {}\", red(&_turkey));\n"
 "    // ^ TODO: Try uncommenting this line.\n"
 msgstr ""
+"//println!(\"火鸡是 {}\", red(&_turkey));\n"
+"    // ^ TODO：尝试取消这行的注释。\n"
 
 #: src/generics/bounds/testcase_empty.md:39
 msgid ""
@@ -7934,6 +7998,7 @@ msgid ""
 "marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html), and "
 "[`trait`s](../../trait.md)"
 msgstr ""
+"[`std::cmp::Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html)、[`std::marker::Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) 和 [`trait`](../../trait.md)"
 
 #: src/generics/multi_bounds.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -2552,155 +2552,160 @@ msgstr ""
 
 #: src/custom_types.md:3
 msgid "Rust custom data types are formed mainly through the two keywords:"
-msgstr ""
+msgstr "Rust 自定义数据类型主要通过以下两个关键字来创建："
 
 #: src/custom_types.md:5
 msgid "`struct`: define a structure"
-msgstr ""
+msgstr "`struct`：定义一个结构体"
 
 #: src/custom_types.md:6
 msgid "`enum`: define an enumeration"
-msgstr ""
+msgstr "`enum`：定义一个枚举"
 
 #: src/custom_types.md:8
 msgid "Constants can also be created via the `const` and `static` keywords."
-msgstr ""
+msgstr "常量也可以通过 `const` 和 `static` 关键字来创建。"
 
 #: src/custom_types/structs.md:3
 msgid ""
 "There are three types of structures (\"structs\") that can be created using "
 "the `struct` keyword:"
-msgstr ""
+msgstr "使用 `struct` 关键字可以创建三种类型的结构体（\"structs\"）："
 
 #: src/custom_types/structs.md:6
 msgid "Tuple structs, which are, basically, named tuples."
-msgstr ""
+msgstr "元组结构体，基本上就是具名元组。"
 
 #: src/custom_types/structs.md:7
 msgid ""
 "The classic [C structs](https://en.wikipedia.org/wiki/"
 "Struct_(C_programming_language))"
-msgstr ""
+msgstr "经典的 [C 语言风格结构体](https://en.wikipedia.org/wiki/Struct_(C_programming_language))"
 
 #: src/custom_types/structs.md:8
 msgid "Unit structs, which are field-less, are useful for generics."
-msgstr ""
+msgstr "单元结构体，不带字段，在泛型中很有用。"
 
 #: src/custom_types/structs.md:11 src/custom_types/enum/enum_use.md:6
 #: src/custom_types/enum/c_like.md:6
 msgid "// An attribute to hide warnings for unused code.\n"
-msgstr ""
+msgstr "// 这个属性用于隐藏未使用代码的警告。\n"
 
 #: src/custom_types/structs.md:19
 msgid "// A unit struct\n"
-msgstr ""
+msgstr "// 单元结构体\n"
 
 #: src/custom_types/structs.md:22
 msgid "// A tuple struct\n"
-msgstr ""
+msgstr "// 元组结构体\n"
 
 #: src/custom_types/structs.md:25
 msgid "// A struct with two fields\n"
-msgstr ""
+msgstr "// 一个有两个字段的结构体\n"
 
 #: src/custom_types/structs.md:31
 msgid "// Structs can be reused as fields of another struct\n"
-msgstr ""
+msgstr "// 结构体可以作为另一个结构体的字段来使用\n"
 
 #: src/custom_types/structs.md:34
 msgid ""
 "// A rectangle can be specified by where the top left and bottom right\n"
 "    // corners are in space.\n"
 msgstr ""
+"// 一个矩形可以通过指定它的左上角和右下角\n"
+"    // 在空间中的位置来定义。\n"
 
 #: src/custom_types/structs.md:41
 msgid "// Create struct with field init shorthand\n"
-msgstr ""
+msgstr "// 使用字段初始化简写语法创建结构体\n"
 
 #: src/custom_types/structs.md:46
 msgid "// Print debug struct\n"
-msgstr ""
+msgstr "// 打印调试的结构体\n"
 
 #: src/custom_types/structs.md:49
 msgid "// Instantiate a `Point`\n"
-msgstr ""
+msgstr "// 实例化一个 `Point`\n"
 
 #: src/custom_types/structs.md:53
 msgid "// Access the fields of the point\n"
-msgstr ""
+msgstr "// 访问 point 的字段\n"
 
 #: src/custom_types/structs.md:54
 msgid "\"point coordinates: ({}, {})\""
-msgstr ""
+msgstr "\"point coordinates: ({}, {})\""
 
 #: src/custom_types/structs.md:56
 msgid ""
 "// Make a new point by using struct update syntax to use the fields of our\n"
 "    // other one\n"
 msgstr ""
+"// 使用结构体更新语法创建新的点，\n"
+"    // 这里使用了我们之前创建的 point 的字段\n"
 
 #: src/custom_types/structs.md:60
 msgid ""
-"// `bottom_right.y` will be the same as `another_point.y` because we used "
-"that field\n"
+"// `bottom_right.y` will be the same as `another_point.y` because we used that field\n"
 "    // from `another_point`\n"
 msgstr ""
+"// `bottom_right.y` 与 `another_point.y` 一样\n"
+"    // 因为这个字段就是从 `another_point` 中来的\n"
 
 #: src/custom_types/structs.md:62
 msgid "\"second point: ({}, {})\""
-msgstr ""
+msgstr "\"second point: ({}, {})\""
 
 #: src/custom_types/structs.md:64
 msgid "// Destructure the point using a `let` binding\n"
-msgstr ""
+msgstr "// 使用 `let` 绑定来解构点\n"
 
 #: src/custom_types/structs.md:68
 msgid "// struct instantiation is an expression too\n"
-msgstr ""
+msgstr "// 结构体的实例化也是一个表达式\n"
 
 #: src/custom_types/structs.md:73
 msgid "// Instantiate a unit struct\n"
-msgstr ""
+msgstr "// 实例化一个单元结构体\n"
 
 #: src/custom_types/structs.md:76
 msgid "// Instantiate a tuple struct\n"
-msgstr ""
+msgstr "// 实例化一个元组结构体\n"
 
 #: src/custom_types/structs.md:79
 msgid "// Access the fields of a tuple struct\n"
-msgstr ""
+msgstr "// 访问元组结构体的字段\n"
 
 #: src/custom_types/structs.md:80 src/custom_types/structs.md:85
 msgid "\"pair contains {:?} and {:?}\""
-msgstr ""
+msgstr "\"pair contains {:?} and {:?}\""
 
 #: src/custom_types/structs.md:82
 msgid "// Destructure a tuple struct\n"
-msgstr ""
+msgstr "// 解构一个元组结构体\n"
 
 #: src/custom_types/structs.md:91
 msgid ""
 "Add a function `rect_area` which calculates the area of a `Rectangle` (try "
 "using nested destructuring)."
-msgstr ""
+msgstr "添加一个 `rect_area` 函数来计算 `Rectangle` 的面积（尝试使用嵌套解构）。"
 
 #: src/custom_types/structs.md:93
 msgid ""
 "Add a function `square` which takes a `Point` and a `f32` as arguments, and "
 "returns a `Rectangle` with its top left corner on the point, and a width and "
 "height corresponding to the `f32`."
-msgstr ""
+msgstr "添加一个 `square` 函数，它以一个 `Point` 和一个 `f32` 作为参数，并返回一个 `Rectangle`，其左上角在该点上，宽度和高度都等于 `f32` 参数。"
 
 #: src/custom_types/structs.md:97
 msgid "See also"
-msgstr ""
+msgstr "另见"
 
 #: src/custom_types/structs.md:99
 msgid ""
 "[`attributes`](../attribute.md), [raw identifiers](../compatibility/"
 "raw_identifiers.md) and [destructuring](../flow_control/match/destructuring."
 "md)"
-msgstr ""
+msgstr "[`attributes`](../attribute.md)、[原始标识符](../compatibility/raw_identifiers.md) 和 [解构](../flow_control/match/destructuring.md)"
 
 #: src/custom_types/enum.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -1127,7 +1127,7 @@ msgstr "\"`x` 是 10 还是 100？x = {}\""
 #: src/std_misc/threads/testcase_mapreduce.md:128 src/std_misc/path.md:54
 #: src/std_misc/fs.md:150 src/meta/doc.md:109 src/meta/playground.md:49
 msgid "See also:"
-msgstr "另见："
+msgstr "参见："
 
 #: src/hello/comment.md:47
 msgid "[Library documentation](../meta/doc.md)"
@@ -2698,7 +2698,7 @@ msgstr "添加一个 `square` 函数，它以一个 `Point` 和一个 `f32` 作�
 
 #: src/custom_types/structs.md:97
 msgid "See also"
-msgstr "另见"
+msgstr "参见"
 
 #: src/custom_types/structs.md:99
 msgid ""
@@ -10100,7 +10100,7 @@ msgstr "\"Bar + Foo = {:?}\""
 #: src/trait/ops.md:55 src/testing.md:16 src/testing/doc_testing.md:104
 #: src/testing/dev_dependencies.md:36
 msgid "See Also"
-msgstr "另见"
+msgstr "参见"
 
 #: src/trait/ops.md:57
 msgid ""
@@ -13480,7 +13480,7 @@ msgid ""
 "just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/"
 "std/collections/struct.BTreeSet.html))"
 msgstr ""
-"`HashSet` 的独特之处在于它保证不会有重复的元素。这是任何集合（Set）类型都应该满足的契约。`HashSet` 只是其中一种实现。（另见：[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
+"`HashSet` 的独特之处在于它保证不会有重复的元素。这是任何集合（Set）类型都应该满足的契约。`HashSet` 只是其中一种实现。（参见：[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
 
 #: src/std/hash/hashset.md:13
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -1638,9 +1638,9 @@ msgid ""
 "if the `std` library implemented a single style for all `Vec<T>`, what style "
 "should it be? Would it be either of these two?"
 msgstr ""
-"`fmt::Display` 可能比 `fmt::Debug` 更整洁，但这给 `std` 库带来了一个问题。"
-"应该如何显示含糊不清的类型？例如，如果 `std` 库为所有的 `Vec<T>` 实现了一种风格，"
-"那应该是什么风格？是下面两种中的哪一个？"
+"`fmt::Display` 可能比 `fmt::Debug` 更简洁，但这给 `std` 库带来了一个问题："
+"如何显示歧义类型？例如，如果 `std` 库为所有 `Vec<T>` 实现统一的样式，"
+"应该采用哪种样式？是以下两种之一吗？"
 
 #: src/hello/print/print_display.md:35
 msgid "`Vec<path>`: `/:/etc:/home/username:/bin` (split on `:`)"
@@ -1657,16 +1657,16 @@ msgid ""
 "`Vec<T>` or for any other generic containers. `fmt::Debug` must then be used "
 "for these generic cases."
 msgstr ""
-"答案是否定的，因为对于所有类型来说没有一种理想的风格，而且 `std` 库也不应该擅自规定一种风格。"
-"`fmt::Display` 没有为 `Vec<T>` 或其他任何泛型容器实现。"
-"因此，这些泛型的情况必须使用 `fmt::Debug`。"
+"答案是否定的。因为不存在适用于所有类型的理想样式，`std` 库也不应擅自规定一种。"
+"因此，`fmt::Display` 并未为 `Vec<T>` 或其他泛型容器实现。"
+"在这些泛型情况下，必须使用 `fmt::Debug`。"
 
 #: src/hello/print/print_display.md:43
 msgid ""
 "This is not a problem though because for any new _container_ type which is "
 "_not_ generic, `fmt::Display` can be implemented."
 msgstr ""
-"不过这不是问题，因为对于任何新的非泛型的容器类型，都可以实现 `fmt::Display`。"
+"不过，这不是问题。对于任何新的非泛型容器类型，都可以实现 `fmt::Display`。"
 
 #: src/hello/print/print_display.md:47
 msgid "// Import `fmt`\n"
@@ -1678,16 +1678,16 @@ msgid ""
 "can\n"
 "// be contrasted with `Display`.\n"
 msgstr ""
-"// 带有两个数字的结构体。推导出 `Debug`，以便\n"
-"// 与 `Display` 的输出进行比较。\n"
+"// 定义一个包含两个数字的结构体。派生 `Debug` 特性，\n"
+"// 以便与 `Display` 的结果进行对比。\n"
 
 #: src/hello/print/print_display.md:53
 msgid "// Implement `Display` for `MinMax`.\n"
-msgstr "// 为 `MinMax` 实现 `Display`。\n"
+msgstr "// 为 `MinMax` 实现 `Display` 特性。\n"
 
 #: src/hello/print/print_display.md:57
 msgid "// Use `self.number` to refer to each positional data point.\n"
-msgstr "// 使用 `self.number` 来表示每个数据点。\n"
+msgstr "// 使用 `self.number` 引用每个位置的数据点。\n"
 
 #: src/hello/print/print_display.md:58
 msgid "\"({}, {})\""
@@ -1695,15 +1695,15 @@ msgstr "\"({}, {})\""
 
 #: src/hello/print/print_display.md:61
 msgid "// Define a structure where the fields are nameable for comparison.\n"
-msgstr "// 定义一个结构体，使其字段可命名以进行比较。\n"
+msgstr "// 定义一个结构体，其字段可命名以便比较。\n"
 
 #: src/hello/print/print_display.md:68
 msgid "// Similarly, implement `Display` for `Point2D`.\n"
-msgstr "// 类似地，为 `Point2D` 实现 `Display`。\n"
+msgstr "// 同样，为 `Point2D` 实现 `Display` 特性。\n"
 
 #: src/hello/print/print_display.md:72
 msgid "// Customize so only `x` and `y` are denoted.\n"
-msgstr "// 自定义，使得只有 `x` 和 `y` 被表示。\n"
+msgstr "// 自定义实现，只显示 `x` 和 `y`。\n"
 
 #: src/hello/print/print_display.md:73
 msgid "\"x: {}, y: {}\""
@@ -1711,23 +1711,23 @@ msgstr "\"x: {}, y: {}\""
 
 #: src/hello/print/print_display.md:80
 msgid "\"Compare structures:\""
-msgstr "\"Compare structures:\""
+msgstr "\"比较结构体：\""
 
 #: src/hello/print/print_display.md:81 src/hello/print/print_display.md:94
 msgid "\"Display: {}\""
-msgstr "\"Display: {}\""
+msgstr "\"Display：{}\""
 
 #: src/hello/print/print_display.md:82 src/hello/print/print_display.md:95
 msgid "\"Debug: {:?}\""
-msgstr "\"Debug: {:?}\""
+msgstr "\"Debug：{:?}\""
 
 #: src/hello/print/print_display.md:87
 msgid "\"The big range is {big} and the small is {small}\""
-msgstr "\"The big range is {big} and the small is {small}\""
+msgstr "\"大范围是 {big}，小范围是 {small}\""
 
 #: src/hello/print/print_display.md:93
 msgid "\"Compare points:\""
-msgstr "\"Compare points:\""
+msgstr "\"比较点：\""
 
 #: src/hello/print/print_display.md:97
 msgid ""
@@ -1735,9 +1735,9 @@ msgid ""
 "    // requires `fmt::Binary` to be implemented. This will not work.\n"
 "    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
 msgstr ""
-"// 报错。`Debug` 和 `Display` 都已经实现，但 `{:b}` 需要\n"
-"    // `fmt::Binary` 得到实现。这行不通。\n"
-"    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
+"// 错误。虽然实现了 `Debug` 和 `Display`，但 `{:b}` 需要\n"
+"    // 实现 `fmt::Binary`。这行代码无法工作。\n"
+"    // println!(\"Point2D 的二进制表示是什么：{:b}？\", point);\n"
 
 #: src/hello/print/print_display.md:103
 msgid ""
@@ -1747,9 +1747,9 @@ msgid ""
 "implementation. This is detailed further in [`std::fmt`](https://doc.rust-"
 "lang.org/std/fmt/)."
 msgstr ""
-"因此，`fmt::Display` 已经实现，但 `fmt::Binary` 没有，所以不能使用。"
-"`std::fmt` 中有很多这样的 [`traits`](https://doc.rust-lang.org/std/fmt/#formatting-traits)，"
-"每个都需要自己的实现。这在 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) 中有更详细的说明。"
+"因此，虽然实现了 `fmt::Display`，但未实现 `fmt::Binary`，所以无法使用。"
+"`std::fmt` 包含许多这样的[`traits`](https://doc.rust-lang.org/std/fmt/#formatting-traits)，"
+"每个都需要单独实现。更多详情请参阅 [`std::fmt`](https://doc.rust-lang.org/std/fmt/)。"
 
 #: src/hello/print/print_display.md:109
 msgid ""
@@ -1757,8 +1757,8 @@ msgid ""
 "guide to add a `Complex` struct to the example. When printed in the same way, "
 "the output should be:"
 msgstr ""
-"在检查了上面例子的输出后，以 `Point2D` 结构体为示例，向例子中添加一个 `Complex` 结构体。"
-"当以相同方式打印时，输出应该是："
+"查看上述示例的输出后，参考 `Point2D` 结构体，向示例中添加一个 `Complex` 结构体。"
+"以相同方式打印时，输出应为："
 
 #: src/hello/print/print_display.md:120
 msgid ""
@@ -1778,27 +1778,28 @@ msgid ""
 "`fmt::Result`. Proper handling of this requires dealing with _all_ the "
 "results. Rust provides the `?` operator for exactly this purpose."
 msgstr ""
-"为一个结构体实现 `fmt::Display`，其中的元素必须依次处理，这是很棘手的。"
-"问题在于每个 `write!` 都会生成一个 `fmt::Result`。正确的方式需要处理**所有**结果。"
-"Rust 提供了 `?` 运算符来专门应对这个问题。"
+"为一个需要顺序处理元素的结构体实现 `fmt::Display` 是棘手的。"
+"问题在于每个 `write!` 都会生成一个 `fmt::Result`。"
+"正确处理这种情况需要处理所有的结果。"
+"Rust 提供了 `?` 运算符专门用于此目的。"
 
 #: src/hello/print/print_display/testcase_list.md:8
 msgid "Using `?` on `write!` looks like this:"
-msgstr "在 `write!` 上使用 `?` 看起来像这样："
+msgstr "在 `write!` 上使用 `?` 的示例如下："
 
 #: src/hello/print/print_display/testcase_list.md:11
 msgid ""
 "// Try `write!` to see if it errors. If it errors, return\n"
 "// the error. Otherwise continue.\n"
 msgstr ""
-"// 尝试执行 `write!`，看看它是否会报错。如果报错，就返回错误。\n"
+"// 尝试执行 `write!`，检查是否出错。如果出错，返回错误。\n"
 "// 否则继续执行。\n"
 
 #: src/hello/print/print_display/testcase_list.md:16
 msgid ""
 "With `?` available, implementing `fmt::Display` for a `Vec` is "
 "straightforward:"
-msgstr "有了 `?` 可用，为 `Vec` 实现 `fmt::Display` 就变得很直观了："
+msgstr "有了 `?` 运算符，为 `Vec` 实现 `fmt::Display` 就变得简单明了："
 
 #: src/hello/print/print_display/testcase_list.md:20
 msgid "// Import the `fmt` module.\n"
@@ -1806,7 +1807,7 @@ msgstr "// 导入 `fmt` 模块。\n"
 
 #: src/hello/print/print_display/testcase_list.md:21
 msgid "// Define a structure named `List` containing a `Vec`.\n"
-msgstr "// 定义一个包含 `Vec` 的结构体 `List`。\n"
+msgstr "// 定义一个名为 `List` 的结构体，包含一个 `Vec`。\n"
 
 #: src/hello/print/print_display/testcase_list.md:27
 msgid ""
@@ -1825,14 +1826,14 @@ msgid ""
 "// Iterate over `v` in `vec` while enumerating the iteration\n"
 "        // count in `count`.\n"
 msgstr ""
-"// 遍历 `vec` 中的 `v`，同时在 `count` 中记录迭代次数。\n"
+"// 遍历 `vec` 中的 `v`，同时用 `count` 记录迭代次数。\n"
 
 #: src/hello/print/print_display/testcase_list.md:36
 msgid ""
 "// For every element except the first, add a comma.\n"
 "            // Use the ? operator to return on errors.\n"
 msgstr ""
-"// 对除第一个元素外的每个元素，添加一个逗号。\n"
+"// 除第一个元素外，为每个元素添加逗号。\n"
 "            // 使用 ? 运算符在出错时返回。\n"
 
 #: src/hello/print/print_display/testcase_list.md:38 src/std/str.md:36
@@ -1841,7 +1842,7 @@ msgstr "\", \""
 
 #: src/hello/print/print_display/testcase_list.md:42
 msgid "// Close the opened bracket and return a fmt::Result value.\n"
-msgstr "// 关闭开括号并返回一个 fmt::Result 值。\n"
+msgstr "// 闭合左括号并返回 fmt::Result 值\n"
 
 #: src/hello/print/print_display/testcase_list.md:43
 msgid "\"]\""
@@ -1851,7 +1852,7 @@ msgstr "\"]\""
 msgid ""
 "Try changing the program so that the index of each element in the vector is "
 "also printed. The new output should look like this:"
-msgstr "尝试修改程序，使向量中每个元素的索引也被打印出来。新的输出应该看起来像这样："
+msgstr "尝试修改程序，使向量中每个元素的索引也被打印出来。新的输出应该如下所示："
 
 #: src/hello/print/print_display/testcase_list.md:64
 msgid ""
@@ -1866,7 +1867,7 @@ msgstr ""
 
 #: src/hello/print/fmt.md:3
 msgid "We've seen that formatting is specified via a _format string_:"
-msgstr "我们已经看到，格式化是通过**格式字符串**指定的："
+msgstr "我们已经看到，格式化是通过一个_格式字符串_来指定的："
 
 #: src/hello/print/fmt.md:5
 msgid "`format!(\"{}\", foo)` -> `\"3735928559\"`"
@@ -1889,7 +1890,7 @@ msgid ""
 "The same variable (`foo`) can be formatted differently depending on which "
 "_argument type_ is used: `X` vs `o` vs _unspecified_."
 msgstr ""
-"根据使用的**参数类型**是 `X`、`o` 还是**未指定**，同样的变量（`foo`）能够格式化成不同的形式。"
+"同一个变量（`foo`）可以根据使用的**参数类型**而有不同的格式化方式：`X`、`o` 或**未指定**。"
 
 #: src/hello/print/fmt.md:12
 msgid ""
@@ -1898,8 +1899,8 @@ msgid ""
 "which handles cases where the argument type is left unspecified: `{}` for "
 "instance."
 msgstr ""
-"这种格式化功能是通过 trait 实现的，每种参数类型都有一个对应的 trait。"
-"最常见的格式化 trait 是 `Display`，它处理参数类型未指定的情况：例如 `{}`。"
+"这种格式化功能是通过 trait 实现的，每种参数类型都对应一个 trait。"
+"最常用的格式化 trait 是 `Display`，它处理参数类型未指定的情况，例如 `{}`。"
 
 #: src/hello/print/fmt.md:21
 msgid "// Latitude\n"
@@ -1912,7 +1913,7 @@ msgstr "// 经度\n"
 #: src/hello/print/fmt.md:28
 msgid ""
 "// `f` is a buffer, and this method must write the formatted string into it.\n"
-msgstr "// `f` 是一个缓冲区，这个方法必须将格式化的字符串写入其中。\n"
+msgstr "// `f` 是一个缓冲区，此方法必须将格式化的字符串写入其中。\n"
 
 #: src/hello/print/fmt.md:30
 msgid "'N'"
@@ -1984,7 +1985,7 @@ msgstr ""
 msgid ""
 "Add an implementation of the `fmt::Display` trait for the `Color` struct "
 "above so that the output displays as:"
-msgstr "为上面的 `Color` 结构体添加 `fmt::Display` trait 的实现，使输出显示为："
+msgstr "为上面的 `Color` 结构体实现 `fmt::Display` trait，使输出显示如下："
 
 #: src/hello/print/fmt.md:81
 msgid "Three hints if you get stuck:"
@@ -1997,7 +1998,7 @@ msgid ""
 "see [RGB color format & calculation](https://www.rapidtables.com/web/color/"
 "RGB_Color.html#rgb-format)."
 msgstr ""
-"在 RGB 颜色空间中计算颜色的公式是：`RGB = (R*65536)+(G*256)+B，（其中 R 是红色，G 是绿色，B 是蓝色）`。"
+"RGB 颜色空间中颜色的计算公式是：`RGB = (R*65536)+(G*256)+B，（其中 R 是红色，G 是绿色，B 是蓝色）`。"
 "更多信息请参见 [RGB 颜色格式和计算](https://www.rapidtables.com/web/color/RGB_Color.html#rgb-format)。"
 
 #: src/hello/print/fmt.md:86
@@ -2019,7 +2020,7 @@ msgstr "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
 #: src/primitives.md:3
 msgid ""
 "Rust provides access to a wide variety of `primitives`. A sample includes:"
-msgstr "Rust 提供了多种 `原生类型`（primitive）。以下是一些示例："
+msgstr "Rust 提供了多种`原生类型`。以下是一些示例："
 
 #: src/primitives.md:5
 msgid "Scalar Types"
@@ -2076,7 +2077,7 @@ msgid ""
 "annotated via a _suffix_ or _by default_. Integers default to `i32` and "
 "floats to `f64`. Note that Rust can also infer types from context."
 msgstr ""
-"变量总是可以进行_类型标注_。数字还可以通过_后缀_或_默认方式_来标注。"
+"变量总是可以进行**类型标注**。数字还可以通过**后缀**或**默认方式**来标注。"
 "整数默认为 `i32` 类型，浮点数默认为 `f64` 类型。请注意，Rust 也可以从上下文中推断类型。"
 
 #: src/primitives.md:29
@@ -2304,11 +2305,11 @@ msgstr "// 可以使用元组索引来提取元组中的值。\n"
 
 #: src/primitives/tuples.md:29
 msgid "\"Long tuple first value: {}\""
-msgstr "\"Long tuple first value: {}\""
+msgstr "\"长元组的第一个值：{}\""
 
 #: src/primitives/tuples.md:30
 msgid "\"Long tuple second value: {}\""
-msgstr "\"Long tuple second value: {}\""
+msgstr "\"长元组的第二个值：{}\""
 
 #: src/primitives/tuples.md:32
 msgid "// Tuples can be tuple members.\n"
@@ -2320,7 +2321,7 @@ msgstr "// 元组是可打印的。\n"
 
 #: src/primitives/tuples.md:36
 msgid "\"tuple of tuples: {:?}\""
-msgstr "\"tuple of tuples: {:?}\""
+msgstr "\"元组的元组：{:?}\""
 
 #: src/primitives/tuples.md:38
 msgid ""
@@ -2329,37 +2330,38 @@ msgid ""
 "    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
 "    // TODO ^ Uncomment the above 2 lines to see the compiler error\n"
 msgstr ""
-"// 但是长元组（超过 12 个元素）不能被打印。\n"
+"// 但长元组（超过 12 个元素）无法打印。\n"
 "    //let too_long_tuple = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13);\n"
-"    //println!(\"Too long tuple: {:?}\", too_long_tuple);\n"
-"    // TODO ^ 取消上面两行的注释，查看编译器错误\n"
+"    //println!(\"过长的元组：{:?}\", too_long_tuple);\n"
+"    // TODO ^ 取消上面两行的注释以查看编译器错误\n"
 
 #: src/primitives/tuples.md:44
 msgid "\"Pair is {:?}\""
-msgstr "\"Pair is {:?}\""
+msgstr "\"对组是 {:?}\""
 
 #: src/primitives/tuples.md:46
 msgid "\"The reversed pair is {:?}\""
-msgstr "\"The reversed pair is {:?}\""
+msgstr "\"反转后的对组是 {:?}\""
 
 #: src/primitives/tuples.md:48
 msgid ""
 "// To create one element tuples, the comma is required to tell them apart\n"
 "    // from a literal surrounded by parentheses.\n"
 msgstr ""
-"// 创建单元素元组需要一个逗号，以区别被括号包围的字面量。\n"
+"// 创建单元素元组时，需要使用逗号来区分它们\n"
+"    // 与被括号包围的字面量。\n"
 
 #: src/primitives/tuples.md:50
 msgid "\"One element tuple: {:?}\""
-msgstr "\"One element tuple: {:?}\""
+msgstr "\"单元素元组：{:?}\""
 
 #: src/primitives/tuples.md:51
 msgid "\"Just an integer: {:?}\""
-msgstr "\"Just an integer: {:?}\""
+msgstr "\"仅是一个整数：{:?}\""
 
 #: src/primitives/tuples.md:53
 msgid "// Tuples can be destructured to create bindings.\n"
-msgstr "// 元组可以被解构，以创建绑定。\n"
+msgstr "// 可以通过解构元组来创建绑定。\n"
 
 #: src/primitives/tuples.md:54 src/conversion/from_into.md:17
 #: src/fn/closures/input_parameters.md:52 src/std_misc/fs.md:51
@@ -2368,7 +2370,7 @@ msgstr "\"hello\""
 
 #: src/primitives/tuples.md:57
 msgid "\"{:?}, {:?}, {:?}, {:?}\""
-msgstr "\"{:?}, {:?}, {:?}, {:?}\""
+msgstr "\"{:?}、{:?}、{:?}、{:?}\""
 
 #: src/primitives/tuples.md:66
 msgid ""
@@ -2376,15 +2378,16 @@ msgid ""
 "example, so that if you switch from printing the debug format `{:?}` to the "
 "display format `{}`, you see the following output:"
 msgstr ""
-"**复习**：在上面的例子中为 `Matrix` 结构体添加 `fmt::Display` trait，这样当你从打印调试格式 `{:?}` "
-"切换到显示格式 `{}` 时，你会看到以下输出："
+"**复习**：为上面示例中的 `Matrix` 结构体添加 `fmt::Display` trait，\n"
+"这样当你从打印调试格式 `{:?}` 切换到显示格式 `{}` 时，\n"
+"你会看到以下输出："
 
 #: src/primitives/tuples.md:75
 msgid ""
 "You may want to refer back to the example for [print display](../hello/print/"
 "print_display.md)."
 msgstr ""
-"你可能想回顾一下[输出显示（Display）](../hello/print/print_display.md) 的例子。"
+"你可能需要回顾一下 [打印显示](../hello/print/print_display.md) 的示例。"
 
 #: src/primitives/tuples.md:76
 msgid ""
@@ -2392,8 +2395,8 @@ msgid ""
 "accepts a matrix as an argument, and returns a matrix in which two elements "
 "have been swapped. For example:"
 msgstr ""
-"添加一个 `transpose` 函数，使用 `reverse` 函数作为模板，该函数接受一个矩阵作为参数，"
-"并返回一个两个元素已交换的矩阵。例如："
+"参考 `reverse` 函数的模板，添加一个 `transpose` 函数。\n"
+"该函数接受一个矩阵作为参数，并返回一个交换了两个元素的矩阵。例如："
 
 #: src/primitives/tuples.md:81
 msgid "\"Matrix:\\n{}\""
@@ -2405,7 +2408,7 @@ msgstr "\"转置：\\n{}\""
 
 #: src/primitives/tuples.md:85
 msgid "Results in the output:"
-msgstr "得到的输出为："
+msgstr "输出结果为："
 
 #: src/primitives/array.md:3
 msgid ""
@@ -2413,8 +2416,9 @@ msgid ""
 "contiguous memory. Arrays are created using brackets `[]`, and their length, "
 "which is known at compile time, is part of their type signature `[T; length]`."
 msgstr ""
-"数组（array）是一个存储在连续内存中的相同类型 `T` 的对象集合。数组使用方括号 `[]` 来创建，"
-"其长度在编译时是已知的，是它们类型签名 `[T; length]` 的一部分。"
+"数组是一种存储在连续内存中的相同类型 `T` 的对象集合。\n"
+"数组使用方括号 `[]` 创建，其长度在编译时已知，\n"
+"是其类型签名 `[T; length]` 的一部分。"
 
 #: src/primitives/array.md:7
 msgid ""
@@ -2425,21 +2429,22 @@ msgid ""
 "x86-64. Slices can be used to borrow a section of an array and have the type "
 "signature `&[T]`."
 msgstr ""
-"切片（slice）与数组类似，但其长度在编译时是未知的。实际上，切片是一个双字对象（two-word object）；第一个字是指向数据的指针，"
-"第二个字是切片的长度。字的大小与 usize 相同，由处理器架构决定，例如在 x86-64 上是 64 位。"
-"切片可以用来借用数组的一部分，其类型签名为 `&[T]`。"
+"切片类似于数组，但其长度在编译时未知。切片是一个双字对象：\n"
+"第一个字是指向数据的指针，第二个字是切片的长度。字的大小与 usize 相同，\n"
+"由处理器架构决定，例如在 x86-64 上是 64 位。切片可用于借用数组的一部分，\n"
+"其类型签名为 `&[T]`。"
 
 #: src/primitives/array.md:15
 msgid "// This function borrows a slice.\n"
-msgstr "// 这个函数借用一个切片。\n"
+msgstr "// 此函数借用一个切片。\n"
 
 #: src/primitives/array.md:18
 msgid "\"First element of the slice: {}\""
-msgstr "\"First element of the slice: {}\""
+msgstr "\"切片的第一个元素：{}\""
 
 #: src/primitives/array.md:19
 msgid "\"The slice has {} elements\""
-msgstr "\"The slice has {} elements\""
+msgstr "\"切片有 {} 个元素\""
 
 #: src/primitives/array.md:23
 msgid "// Fixed-size array (type signature is superfluous).\n"
@@ -2447,7 +2452,7 @@ msgstr "// 固定大小的数组（类型签名是多余的）。\n"
 
 #: src/primitives/array.md:26
 msgid "// All elements can be initialized to the same value.\n"
-msgstr "// 所有元素可以被初始化为相同的值。\n"
+msgstr "// 所有元素可以初始化为相同的值。\n"
 
 #: src/primitives/array.md:29
 msgid "// Indexing starts at 0.\n"
@@ -2455,11 +2460,11 @@ msgstr "// 索引从 0 开始。\n"
 
 #: src/primitives/array.md:30
 msgid "\"First element of the array: {}\""
-msgstr "\"First element of the array: {}\""
+msgstr "\"数组的第一个元素：{}\""
 
 #: src/primitives/array.md:31
 msgid "\"Second element of the array: {}\""
-msgstr "\"Second element of the array: {}\""
+msgstr "\"数组的第二个元素：{}\""
 
 #: src/primitives/array.md:33
 msgid "// `len` returns the count of elements in the array.\n"
@@ -2467,7 +2472,7 @@ msgstr "// `len` 返回数组中元素的数量。\n"
 
 #: src/primitives/array.md:34
 msgid "\"Number of elements in array: {}\""
-msgstr "\"Number of elements in array: {}\""
+msgstr "\"数组中的元素数量：{}\""
 
 #: src/primitives/array.md:36
 msgid "// Arrays are stack allocated.\n"
@@ -2475,7 +2480,7 @@ msgstr "// 数组是栈分配的。\n"
 
 #: src/primitives/array.md:37
 msgid "\"Array occupies {} bytes\""
-msgstr "\"Array occupies {} bytes\""
+msgstr "\"数组占用 {} 字节\""
 
 #: src/primitives/array.md:39
 msgid "// Arrays can be automatically borrowed as slices.\n"
@@ -2483,7 +2488,7 @@ msgstr "// 数组可以自动借用为切片。\n"
 
 #: src/primitives/array.md:40
 msgid "\"Borrow the whole array as a slice.\""
-msgstr "\"Borrow the whole array as a slice.\""
+msgstr "\"将整个数组借用为切片。\""
 
 #: src/primitives/array.md:43
 msgid ""
@@ -2493,21 +2498,21 @@ msgid ""
 "    // `ending_index` is one more than the last position in the slice.\n"
 msgstr ""
 "// 切片可以指向数组的一部分。\n"
-"    // 它们的形式是 [starting_index..ending_index]。\n"
-"    // `starting_index` 是切片中的第一个位置。\n"
-"    // `ending_index` 是切片中最后一个位置的后一个位置。\n"
+"    // 它们的形式是 [起始索引..结束索引]。\n"
+"    // `起始索引` 是切片中的第一个位置。\n"
+"    // `结束索引` 是切片中最后一个位置的后一个位置。\n"
 
 #: src/primitives/array.md:47
 msgid "\"Borrow a section of the array as a slice.\""
-msgstr "\"Borrow a section of the array as a slice.\""
+msgstr "\"借用数组的一部分作为切片。\""
 
 #: src/primitives/array.md:50
 msgid "// Example of empty slice `&[]`:\n"
-msgstr "// 空切片 `&[]` 的例子：\n"
+msgstr "// 空切片 `&[]` 的示例：\n"
 
 #: src/primitives/array.md:53
 msgid "// Same but more verbose\n"
-msgstr "// 同样的操作，但更冗长\n"
+msgstr "// 同样的操作，但更详细\n"
 
 #: src/primitives/array.md:55
 msgid ""
@@ -2517,12 +2522,13 @@ msgid ""
 "    // message instead of happily continue.\n"
 msgstr ""
 "// 可以使用 `.get` 安全地访问数组，它返回一个 `Option`。\n"
-"    // 可以像下面这样对其进行匹配，或者使用 `.expect()`，\n"
-"    // 如果你希望程序在访问越界时适当地退出，而不是继续执行。\n"
+"    // 可以像下面这样对其进行匹配，或者使用 `.expect()`。\n"
+"    // 如果你希望程序在访问越界时优雅地退出而不是继续执行，\n"
+"    // 可以使用 `.expect()`。\n"
 
 #: src/primitives/array.md:59
 msgid "// Oops, one element too far!\n"
-msgstr "// 哎呀，越界访问了元素！\n"
+msgstr "// 糟糕，访问超出了数组范围！\n"
 
 #: src/primitives/array.md:61
 msgid "\"{}: {}\""
@@ -2530,7 +2536,7 @@ msgstr "\"{}: {}\""
 
 #: src/primitives/array.md:62
 msgid "\"Slow down! {} is too far!\""
-msgstr "\"Slow down! {} is too far!\""
+msgstr "\"慢着！{} 超出范围了！\""
 
 #: src/primitives/array.md:66
 msgid ""
@@ -2546,15 +2552,15 @@ msgstr ""
 
 #: src/custom_types.md:3
 msgid "Rust custom data types are formed mainly through the two keywords:"
-msgstr "Rust 自定义数据类型主要通过以下两个关键字来创建："
+msgstr "Rust 的自定义数据类型主要通过以下两个关键字来创建："
 
 #: src/custom_types.md:5
 msgid "`struct`: define a structure"
-msgstr "`struct`：定义一个结构体"
+msgstr "`struct`：定义结构体"
 
 #: src/custom_types.md:6
 msgid "`enum`: define an enumeration"
-msgstr "`enum`：定义一个枚举"
+msgstr "`enum`：定义枚举"
 
 #: src/custom_types.md:8
 msgid "Constants can also be created via the `const` and `static` keywords."
@@ -2568,7 +2574,7 @@ msgstr "使用 `struct` 关键字可以创建三种类型的结构体（\"struct
 
 #: src/custom_types/structs.md:6
 msgid "Tuple structs, which are, basically, named tuples."
-msgstr "元组结构体，基本上就是具名元组。"
+msgstr "元组结构体：本质上是具名元组。"
 
 #: src/custom_types/structs.md:7
 msgid ""
@@ -2578,7 +2584,7 @@ msgstr "经典的 [C 语言风格结构体](https://en.wikipedia.org/wiki/Struct
 
 #: src/custom_types/structs.md:8
 msgid "Unit structs, which are field-less, are useful for generics."
-msgstr "单元结构体，不带字段，在泛型中很有用。"
+msgstr "单元结构体：没有字段，在泛型中很有用。"
 
 #: src/custom_types/structs.md:11 src/custom_types/enum/enum_use.md:6
 #: src/custom_types/enum/c_like.md:6
@@ -2595,19 +2601,19 @@ msgstr "// 元组结构体\n"
 
 #: src/custom_types/structs.md:25
 msgid "// A struct with two fields\n"
-msgstr "// 一个有两个字段的结构体\n"
+msgstr "// 带有两个字段的结构体\n"
 
 #: src/custom_types/structs.md:31
 msgid "// Structs can be reused as fields of another struct\n"
-msgstr "// 结构体可以作为另一个结构体的字段来使用\n"
+msgstr "// 结构体可以作为另一个结构体的字段\n"
 
 #: src/custom_types/structs.md:34
 msgid ""
 "// A rectangle can be specified by where the top left and bottom right\n"
 "    // corners are in space.\n"
 msgstr ""
-"// 一个矩形可以通过指定它的左上角和右下角\n"
-"    // 在空间中的位置来定义。\n"
+"// 可以通过指定左上角和右下角的位置\n"
+"    // 来定义一个矩形。\n"
 
 #: src/custom_types/structs.md:41
 msgid "// Create struct with field init shorthand\n"
@@ -2615,7 +2621,7 @@ msgstr "// 使用字段初始化简写语法创建结构体\n"
 
 #: src/custom_types/structs.md:46
 msgid "// Print debug struct\n"
-msgstr "// 打印调试的结构体\n"
+msgstr "// 打印结构体的调试信息\n"
 
 #: src/custom_types/structs.md:49
 msgid "// Instantiate a `Point`\n"
@@ -2623,11 +2629,11 @@ msgstr "// 实例化一个 `Point`\n"
 
 #: src/custom_types/structs.md:53
 msgid "// Access the fields of the point\n"
-msgstr "// 访问 point 的字段\n"
+msgstr "// 访问点的字段\n"
 
 #: src/custom_types/structs.md:54
 msgid "\"point coordinates: ({}, {})\""
-msgstr "\"point coordinates: ({}, {})\""
+msgstr "\"点的坐标：({}, {})\""
 
 #: src/custom_types/structs.md:56
 msgid ""
@@ -2635,27 +2641,27 @@ msgid ""
 "    // other one\n"
 msgstr ""
 "// 使用结构体更新语法创建新的点，\n"
-"    // 这里使用了我们之前创建的 point 的字段\n"
+"    // 复用之前创建的点的字段\n"
 
 #: src/custom_types/structs.md:60
 msgid ""
 "// `bottom_right.y` will be the same as `another_point.y` because we used that field\n"
 "    // from `another_point`\n"
 msgstr ""
-"// `bottom_right.y` 与 `another_point.y` 一样\n"
-"    // 因为这个字段就是从 `another_point` 中来的\n"
+"// `bottom_right.y` 与 `another_point.y` 相同，\n"
+"    // 因为我们使用了 `another_point` 的该字段\n"
 
 #: src/custom_types/structs.md:62
 msgid "\"second point: ({}, {})\""
-msgstr "\"second point: ({}, {})\""
+msgstr "\"第二个点：({}, {})\""
 
 #: src/custom_types/structs.md:64
 msgid "// Destructure the point using a `let` binding\n"
-msgstr "// 使用 `let` 绑定来解构点\n"
+msgstr "// 使用 `let` 绑定解构点\n"
 
 #: src/custom_types/structs.md:68
 msgid "// struct instantiation is an expression too\n"
-msgstr "// 结构体的实例化也是一个表达式\n"
+msgstr "// 结构体实例化也是一个表达式\n"
 
 #: src/custom_types/structs.md:73
 msgid "// Instantiate a unit struct\n"
@@ -2671,7 +2677,7 @@ msgstr "// 访问元组结构体的字段\n"
 
 #: src/custom_types/structs.md:80 src/custom_types/structs.md:85
 msgid "\"pair contains {:?} and {:?}\""
-msgstr "\"pair contains {:?} and {:?}\""
+msgstr "\"pair 包含 {:?} 和 {:?}\""
 
 #: src/custom_types/structs.md:82
 msgid "// Destructure a tuple struct\n"
@@ -2688,25 +2694,25 @@ msgid ""
 "Add a function `square` which takes a `Point` and a `f32` as arguments, and "
 "returns a `Rectangle` with its top left corner on the point, and a width and "
 "height corresponding to the `f32`."
-msgstr "添加一个 `square` 函数，它以一个 `Point` 和一个 `f32` 作为参数，并返回一个 `Rectangle`，其左上角在该点上，宽度和高度都等于 `f32` 参数。"
+msgstr "添加一个 `square` 函数，它接受一个 `Point` 和一个 `f32` 作为参数，返回一个 `Rectangle`，其左上角在该点上，宽度和高度都等于 `f32` 参数。"
 
 #: src/custom_types/structs.md:97
 msgid "See also"
-msgstr "参见"
+msgstr "另请参阅"
 
 #: src/custom_types/structs.md:99
 msgid ""
 "[`attributes`](../attribute.md), [raw identifiers](../compatibility/"
 "raw_identifiers.md) and [destructuring](../flow_control/match/destructuring."
 "md)"
-msgstr "[`attributes`](../attribute.md)、[原始标识符](../compatibility/raw_identifiers.md) 和 [解构](../flow_control/match/destructuring.md)"
+msgstr "[`属性`](../attribute.md)、[原始标识符](../compatibility/raw_identifiers.md)和[解构](../flow_control/match/destructuring.md)"
 
 #: src/custom_types/enum.md:3
 msgid ""
 "The `enum` keyword allows the creation of a type which may be one of a few "
 "different variants. Any variant which is valid as a `struct` is also valid in "
 "an `enum`."
-msgstr "`enum` 关键字允许创建一个可能是几个不同变体之一的类型。任何作为 `struct` 有效的变体在 `enum` 中也是有效的。"
+msgstr "`enum` 关键字允许创建一个可能是几种不同变体之一的类型。任何作为 `struct` 有效的变体在 `enum` 中也是有效的。"
 
 #: src/custom_types/enum.md:8
 msgid ""
@@ -2715,29 +2721,28 @@ msgid ""
 "// `PageLoad != PageUnload` and `KeyPress(char) != Paste(String)`.\n"
 "// Each is different and independent.\n"
 msgstr ""
-"// 创建一个 `enum` 来分类网页事件。注意名称和类型信息如何一起指定变体：\n"
+"// 创建一个 `enum` 来分类网页事件。注意名称和类型信息如何共同指定变体：\n"
 "// `PageLoad != PageUnload` 且 `KeyPress(char) != Paste(String)`。\n"
-"// 每个都是不同且独立的。\n"
+"// 每个变体都是不同且独立的。\n"
 
 #: src/custom_types/enum.md:13
 msgid "// An `enum` variant may either be `unit-like`,\n"
-msgstr "// 一个 `enum` 变体可以是 `unit-like`（类单元结构体），\n"
+msgstr "// `enum` 变体可以类似单元结构体（`unit-like`），\n"
 
 #: src/custom_types/enum.md:16
 msgid "// like tuple structs,\n"
-msgstr "// 像元组结构体，\n"
+msgstr "// 类似元组结构体，\n"
 
 #: src/custom_types/enum.md:19
 msgid "// or c-like structures.\n"
-msgstr "// 或者像 C 语言风格的结构体。\n"
+msgstr "// 或类似 C 语言的结构体。\n"
 
 #: src/custom_types/enum.md:22
 msgid ""
 "// A function which takes a `WebEvent` enum as an argument and\n"
 "// returns nothing.\n"
 msgstr ""
-"// 一个接受 `WebEvent` 枚举作为参数并且\n"
-"// 不返回任何值的函数。\n"
+"// 一个接受 `WebEvent` 枚举作为参数且不返回任何值的函数。\n"
 
 #: src/custom_types/enum.md:27
 msgid "\"page loaded\""
@@ -2753,11 +2758,11 @@ msgstr "// 从 `enum` 变体内部解构 `c`。\n"
 
 #: src/custom_types/enum.md:30
 msgid "\"pressed '{}'.\""
-msgstr "\"按下了 '{}'。\""
+msgstr "\"按下了'{}'键。\""
 
 #: src/custom_types/enum.md:31
 msgid "\"pasted \\\"{}\\\".\""
-msgstr "\"粘贴了 \\\"{}\\\"。\""
+msgstr "\"粘贴了\\\"{}\\\"。\""
 
 #: src/custom_types/enum.md:32
 msgid "// Destructure `Click` into `x` and `y`.\n"
@@ -2765,7 +2770,7 @@ msgstr "// 将 `Click` 解构为 `x` 和 `y`。\n"
 
 #: src/custom_types/enum.md:34
 msgid "\"clicked at x={}, y={}.\""
-msgstr "\"点击了 x={}, y={}。\""
+msgstr "\"点击坐标：x={}, y={}。\""
 
 #: src/custom_types/enum.md:40
 msgid "'x'"
@@ -2773,7 +2778,7 @@ msgstr "'x'"
 
 #: src/custom_types/enum.md:41
 msgid "// `to_owned()` creates an owned `String` from a string slice.\n"
-msgstr "// `to_owned()` 从字符串切片创建一个有所有权的 `String`。\n"
+msgstr "// `to_owned()` 从字符串切片创建一个拥有所有权的 `String`。\n"
 
 #: src/custom_types/enum.md:42
 msgid "\"my text\""
@@ -2788,19 +2793,18 @@ msgid ""
 "If you use a type alias, you can refer to each enum variant via its alias. "
 "This might be useful if the enum's name is too long or too generic, and you "
 "want to rename it."
-msgstr "如果你使用类型别名，你可以通过别名引用每个枚举变体。如果枚举的名称太长或太通用，而你想重命名它时，这可能会很有用。"
+msgstr "使用类型别名可以通过别名引用每个枚举变体。当枚举名称过长或过于泛化，而你想重命名它时，这会很有用。"
 
 #: src/custom_types/enum.md:67
 msgid "// Creates a type alias\n"
-msgstr "// 创建一个类型别名\n"
+msgstr "// 创建类型别名\n"
 
 #: src/custom_types/enum.md:72
 msgid ""
 "// We can refer to each variant via its alias, not its long and inconvenient\n"
 "    // name.\n"
 msgstr ""
-"// 我们可以通过别名引用每个变体，而不是它的又长又不方便的\n"
-"    // 名称。\n"
+"// 我们可以通过别名引用每个变体，而不是使用又长又不便的名称。\n"
 
 #: src/custom_types/enum.md:78
 msgid ""
@@ -2820,7 +2824,7 @@ msgid ""
 "[`match`](../flow_control/match.md), [`fn`](../fn.md), and [`String`](../std/"
 "str.md), [\"Type alias enum variants\" RFC](https://rust-lang.github.io/"
 "rfcs/2338-type-alias-enum-variants.html)"
-msgstr "[`match`](../flow_control/match.md)、[`fn`](../fn.md) 和 [`String`](../std/str.md)、[\"类型别名枚举变体\" RFC](https://rust-lang.github.io/rfcs/2338-type-alias-enum-variants.html)"
+msgstr "[`match`](../flow_control/match.md)、[`fn`](../fn.md)、[`String`](../std/str.md) 和 [\"类型别名枚举变体\" RFC](https://rust-lang.github.io/rfcs/2338-type-alias-enum-variants.html)"
 
 #: src/custom_types/enum/enum_use.md:3
 msgid "The `use` declaration can be used so manual scoping isn't needed:"
@@ -2831,12 +2835,12 @@ msgid ""
 "// Explicitly `use` each name so they are available without\n"
 "    // manual scoping.\n"
 msgstr ""
-"// 显式 `use` 每个名称，这样它们就可以不用\n"
-"    // 手动作用域限定而直接使用。\n"
+"// 显式 `use` 每个名称，使它们可以不需要\n"
+"    // 手动作用域限定就能使用。\n"
 
 #: src/custom_types/enum/enum_use.md:23
 msgid "// Automatically `use` each name inside `Role`.\n"
-msgstr "// 自动 `use` `Role` 内部的每个名称。\n"
+msgstr "// 自动 `use` `Role` 内的每个名称。\n"
 
 #: src/custom_types/enum/enum_use.md:26
 msgid "// Equivalent to `Stage::Beginner`.\n"
@@ -2880,11 +2884,11 @@ msgstr "`enum` 也可以像 C 语言那样使用。"
 
 #: src/custom_types/enum/c_like.md:8
 msgid "// enum with implicit discriminator (starts at 0)\n"
-msgstr "// 隐式辨别值（从 0 开始）的枚举\n"
+msgstr "// 带隐式判别值的枚举（从 0 开始）\n"
 
 #: src/custom_types/enum/c_like.md:15
 msgid "// enum with explicit discriminator\n"
-msgstr "// 显式辨别值的枚举\n"
+msgstr "// 带显式判别值的枚举\n"
 
 #: src/custom_types/enum/c_like.md:24
 msgid "// `enums` can be cast as integers.\n"
@@ -2892,19 +2896,19 @@ msgstr "// `enum` 可以转换为整数。\n"
 
 #: src/custom_types/enum/c_like.md:25
 msgid "\"zero is {}\""
-msgstr "\"zero 是 {}\""
+msgstr "\"zero 的值是 {}\""
 
 #: src/custom_types/enum/c_like.md:26
 msgid "\"one is {}\""
-msgstr "\"one 是 {}\""
+msgstr "\"one 的值是 {}\""
 
 #: src/custom_types/enum/c_like.md:28
 msgid "\"roses are #{:06x}\""
-msgstr "\"玫瑰花是 #{:06x}\""
+msgstr "\"玫瑰的颜色是 #{:06x}\""
 
 #: src/custom_types/enum/c_like.md:29
 msgid "\"violets are #{:06x}\""
-msgstr "\"紫罗兰是 #{:06x}\""
+msgstr "\"紫罗兰的颜色是 #{:06x}\""
 
 #: src/custom_types/enum/c_like.md:35
 msgid "[casting](../../types/cast.md)"
@@ -13067,8 +13071,8 @@ msgid ""
 "However, sometimes it is important to express _why_ an operation failed. To "
 "do this we have the `Result` enum."
 msgstr ""
-"我们已经看到 `Option` 枚举可以用作可能失败的函数的返回值，其中 `None` 可以用来表示失败。"
-"然而，有时表达操作**为什么**失败很重要。为此，我们有 `Result` 枚举。"
+"我们已经了解到 `Option` 枚举可以作为可能失败的函数的返回值，其中 `None` 用于表示失败。\n"
+"然而，有时表达操作失败的**原因**很重要。为此，我们有 `Result` 枚举。"
 
 #: src/std/result.md:8
 msgid "The `Result<T, E>` enum has two variants:"

--- a/po/zh.po
+++ b/po/zh.po
@@ -8005,36 +8005,39 @@ msgid ""
 "Multiple bounds for a single type can be applied with a `+`. Like normal, "
 "different types are separated with `,`."
 msgstr ""
+"可以使用 `+` 来为单个类型指定多个约束。依照惯例，不同的类型用 `,` 分隔。"
 
 #: src/generics/multi_bounds.md:10
 msgid "\"Debug: `{:?}`\""
-msgstr ""
+msgstr "\"Debug: `{:?}`\""
 
 #: src/generics/multi_bounds.md:11
 msgid "\"Display: `{}`\""
-msgstr ""
+msgstr "\"Display: `{}`\""
 
 #: src/generics/multi_bounds.md:15
 msgid "\"t: `{:?}`\""
-msgstr ""
+msgstr "\"t: `{:?}`\""
 
 #: src/generics/multi_bounds.md:16
 msgid "\"u: `{:?}`\""
-msgstr ""
+msgstr "\"u: `{:?}`\""
 
 #: src/generics/multi_bounds.md:20
 msgid "\"words\""
-msgstr ""
+msgstr "\"words\""
 
 #: src/generics/multi_bounds.md:25
 msgid ""
 "//compare_prints(&array);\n"
 "    // TODO ^ Try uncommenting this.\n"
 msgstr ""
+"//compare_prints(&array);\n"
+"    // TODO ^ 尝试取消这行的注释。\n"
 
 #: src/generics/multi_bounds.md:34
 msgid "[`std::fmt`](../hello/print.md) and [`trait`s](../trait.md)"
-msgstr ""
+msgstr "[`std::fmt`](../hello/print.md) 和 [`trait`](../trait.md)"
 
 #: src/generics/where.md:3
 msgid ""
@@ -8043,90 +8046,101 @@ msgid ""
 "clauses can apply bounds to arbitrary types, rather than just to type "
 "parameters."
 msgstr ""
+"约束也可以使用 `where` 分句来表达，它紧接在开括号 `{` 之前，而不是在类型首次提及时。此外，`where` 分句可以将约束应用于任意类型，而不仅限于类型参数。"
 
 #: src/generics/where.md:8
 msgid "Some cases that a `where` clause is useful:"
-msgstr ""
+msgstr "`where` 分句在以下情况下很有用："
 
 #: src/generics/where.md:10
 msgid "When specifying generic types and bounds separately is clearer:"
-msgstr ""
+msgstr "当单独指定泛型类型和约束更清晰时："
 
 #: src/generics/where.md:14
 msgid "// Expressing bounds with a `where` clause\n"
-msgstr ""
+msgstr "// 使用 `where` 分句表达约束\n"
 
 #: src/generics/where.md:21
 msgid ""
 "When using a `where` clause is more expressive than using normal syntax. The "
 "`impl` in this example cannot be directly expressed without a `where` clause:"
 msgstr ""
+"当使用 `where` 分句比使用普通语法更具表现力时。这个例子中的 `impl` 如果不使用 `where` 分句就无法直接表达："
 
 #: src/generics/where.md:30
 msgid ""
 "// Because we would otherwise have to express this as `T: Debug` or \n"
 "// use another method of indirect approach, this requires a `where` clause:\n"
 msgstr ""
+"// 这里需要一个 `where` 分句：否则就必须将其表达为 `T: Debug` 或\n"
+"// 使用另一种间接方法，\n"
 
 #: src/generics/where.md:35
 msgid ""
 "// We want `Option<T>: Debug` as our bound because that is what's\n"
 "    // being printed. Doing otherwise would be using the wrong bound.\n"
 msgstr ""
+"// 我们想要 `Option<T>: Debug` 作为我们的约束，因为这是\n"
+"    // 正在被打印的内容。否则就会使用错误的约束。\n"
 
 #: src/generics/where.md:51
 msgid ""
 "[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md), "
 "[`struct`](../custom_types/structs.md), and [`trait`](../trait.md)"
 msgstr ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0135-where.md)、[`struct`](../custom_types/structs.md) 和 [`trait`](../trait.md)"
 
 #: src/generics/new_types.md:3
 msgid ""
 "The `newtype` idiom gives compile time guarantees that the right type of "
 "value is supplied to a program."
 msgstr ""
+"`newtype` 惯用法在编译时保证了向程序提供了正确类型的值。"
 
 #: src/generics/new_types.md:6
 msgid ""
 "For example, an age verification function that checks age in years, _must_ be "
 "given a value of type `Years`."
 msgstr ""
+"例如，一个检查年龄（以年为单位）的年龄验证函数，**必须**给定 `Years` 类型的值。"
 
 #: src/generics/new_types.md:22
 msgid "/// truncates partial years\n"
-msgstr ""
+msgstr "/// 截断不足一年的部分\n"
 
 #: src/generics/new_types.md:35 src/generics/new_types.md:36
 msgid "\"Is an adult? {}\""
-msgstr ""
+msgstr "\"是成年人吗？{}\""
 
 #: src/generics/new_types.md:37
 msgid "// println!(\"Is an adult? {}\", is_adult(&age_days));\n"
-msgstr ""
+msgstr "// println!(\"是成年人吗？{}\", is_adult(&age_days));\n"
 
 #: src/generics/new_types.md:41
 msgid ""
 "Uncomment the last print statement to observe that the type supplied must be "
 "`Years`."
 msgstr ""
+"取消最后一个 print 语句的注释，观察所提供的类型必须是 `Years`。"
 
 #: src/generics/new_types.md:43
 msgid ""
 "To obtain the `newtype`'s value as the base type, you may use the tuple or "
 "destructuring syntax like so:"
 msgstr ""
+"要获取 `newtype` 的值作为基本类型，你可以使用元组或解构语法，如下所示："
 
 #: src/generics/new_types.md:49
 msgid "// Tuple\n"
-msgstr ""
+msgstr "// 元组\n"
 
 #: src/generics/new_types.md:50
 msgid "// Destructuring\n"
-msgstr ""
+msgstr "// 解构\n"
 
 #: src/generics/new_types.md:56
 msgid "[`structs`](../custom_types/structs.md)"
-msgstr ""
+msgstr "[`struct`](../custom_types/structs.md)"
 
 #: src/generics/assoc_items.md:3
 msgid ""
@@ -8134,24 +8148,28 @@ msgid ""
 "doc.rust-lang.org/reference/items.html)s of various types. It is an extension "
 "to `trait` generics, and allows `trait`s to internally define new items."
 msgstr ""
+"\"关联项\"指的是与各种类型的 [`item`](https://doc.rust-lang.org/reference/items.html) 相关的一组规则。它是 `trait` 泛型的扩展，允许 `trait` 在内部定义新的项。"
 
 #: src/generics/assoc_items.md:7
 msgid ""
 "One such item is called an _associated type_, providing simpler usage "
 "patterns when the `trait` is generic over its container type."
 msgstr ""
+"其中一种项被称为**关联类型**，当 `trait` 对其容器类型是泛型时，它提供了更简单的使用模式。"
 
 #: src/generics/assoc_items.md:12
 msgid ""
 "[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-"
 "items.md)"
 msgstr ""
+"[RFC](https://github.com/rust-lang/rfcs/blob/master/text/0195-associated-items.md)"
 
 #: src/generics/assoc_items/the_problem.md:3
 msgid ""
 "A `trait` that is generic over its container type has type specification "
 "requirements - users of the `trait` _must_ specify all of its generic types."
 msgstr ""
+"对于容器类型是泛型的 `trait`，须遵守类型规范要求 - `trait` 的使用者**必须**指定所有泛型类型。"
 
 #: src/generics/assoc_items/the_problem.md:6
 msgid ""
@@ -8160,6 +8178,7 @@ msgid ""
 "specifying `i32` for `A` and `B` so that it can be used with `fn "
 "difference()`."
 msgstr ""
+"在下面的例子中，`Contains` `trait` 允许使用泛型类型 `A` 和 `B`。然后为 `Container` 类型实现该 trait，为 `A` 和 `B` 指定 `i32`，以便可以与 `fn difference()` 一起使用。"
 
 #: src/generics/assoc_items/the_problem.md:10
 msgid ""
@@ -8168,6 +8187,7 @@ msgid ""
 "that `A` and `B` are determined by the _input_ `C`. As you will see in the "
 "next section, associated types provide exactly that capability."
 msgstr ""
+"因为 `Contains` 是泛型的，我们必须为 `fn difference()` 显式声明**所有**泛型类型。在实践中，我们希望有一种方法来表达 `A` 和 `B` 是由**输入** `C` 决定的。你将在下一节中看到，关联类型恰好提供了这种能力。"
 
 #: src/generics/assoc_items/the_problem.md:17
 #: src/generics/assoc_items/types.md:36
@@ -8175,60 +8195,64 @@ msgid ""
 "// A trait which checks if 2 items are stored inside of container.\n"
 "// Also retrieves first or last value.\n"
 msgstr ""
+"// 一个检查容器内是否存储了 2 个项的 trait。\n"
+"// 还可以检索第一个或最后一个值。\n"
 
 #: src/generics/assoc_items/the_problem.md:21
 msgid "// Explicitly requires `A` and `B`.\n"
-msgstr ""
+msgstr "// 显式要求 `A` 和 `B`。\n"
 
 #: src/generics/assoc_items/the_problem.md:22
 #: src/generics/assoc_items/the_problem.md:23
 msgid "// Doesn't explicitly require `A` or `B`.\n"
-msgstr ""
+msgstr "// 不显式要求 `A` 或 `B`。\n"
 
 #: src/generics/assoc_items/the_problem.md:27
 msgid "// True if the numbers stored are equal.\n"
-msgstr ""
+msgstr "// 如果存储的数字相等则为 true。\n"
 
 #: src/generics/assoc_items/the_problem.md:32
 #: src/generics/assoc_items/types.md:60
 msgid "// Grab the first number.\n"
-msgstr ""
+msgstr "// 获取第一个数字。\n"
 
 #: src/generics/assoc_items/the_problem.md:35
 #: src/generics/assoc_items/types.md:63
 msgid "// Grab the last number.\n"
-msgstr ""
+msgstr "// 获取最后一个数字。\n"
 
 #: src/generics/assoc_items/the_problem.md:38
 msgid ""
 "// `C` contains `A` and `B`. In light of that, having to express `A` and\n"
 "// `B` again is a nuisance.\n"
 msgstr ""
+"// `C` 包含了 `A` 和 `B`。鉴于此，还要指定 `A` 和 `B` 就显得很麻烦。\n"
 
 #: src/generics/assoc_items/the_problem.md:52
 #: src/generics/assoc_items/types.md:77
 msgid "\"Does container contain {} and {}: {}\""
-msgstr ""
+msgstr "\"容器是否包含 {} 和 {}：{}\""
 
 #: src/generics/assoc_items/the_problem.md:55
 #: src/generics/assoc_items/types.md:80
 msgid "\"First number: {}\""
-msgstr ""
+msgstr "\"第一个数字：{}\""
 
 #: src/generics/assoc_items/the_problem.md:56
 #: src/generics/assoc_items/types.md:81
 msgid "\"Last number: {}\""
-msgstr ""
+msgstr "\"最后一个数字：{}\""
 
 #: src/generics/assoc_items/the_problem.md:58
 #: src/generics/assoc_items/types.md:83
 msgid "\"The difference is: {}\""
-msgstr ""
+msgstr "\"差值是：{}\""
 
 #: src/generics/assoc_items/the_problem.md:64
 msgid ""
 "[`struct`s](../../custom_types/structs.md), and [`trait`s](../../trait.md)"
 msgstr ""
+"[`struct`](../../custom_types/structs.md) 和 [`trait`](../../trait.md)"
 
 #: src/generics/assoc_items/types.md:3
 msgid ""
@@ -8236,6 +8260,7 @@ msgid ""
 "moving inner types locally into a trait as _output_ types. Syntax for the "
 "`trait` definition is as follows:"
 msgstr ""
+"通过将内部类型移动到 trait 中作为**输出**类型，使用\"关联类型\"提高了代码的整体可读性。这种 `trait` 定义的语法如下："
 
 #: src/generics/assoc_items/types.md:8
 msgid ""
@@ -8243,33 +8268,35 @@ msgid ""
 "// (Note: `type` in this context is different from `type` when used for\n"
 "// aliases).\n"
 msgstr ""
+"// `A` 和 `B` 在 trait 中通过 `type` 关键字定义。\n"
+"// （注意：这里的 `type` 与用于别名的 `type` 不同）。\n"
 
 #: src/generics/assoc_items/types.md:15
 msgid "// Updated syntax to refer to these new types generically.\n"
-msgstr ""
+msgstr "// 这种新语法，能够泛型地表示这些新类型。\n"
 
 #: src/generics/assoc_items/types.md:20
 msgid ""
 "Note that functions that use the `trait` `Contains` are no longer required to "
 "express `A` or `B` at all:"
-msgstr ""
+msgstr "注意，使用 `Contains` 这个 `trait` 的函数不再需要明确表示 `A` 或 `B`："
 
 #: src/generics/assoc_items/types.md:24
 msgid "// Without using associated types\n"
-msgstr ""
+msgstr "// 不使用关联类型\n"
 
 #: src/generics/assoc_items/types.md:27
 msgid "// Using associated types\n"
-msgstr ""
+msgstr "// 使用关联类型\n"
 
 #: src/generics/assoc_items/types.md:32
 msgid ""
 "Let's rewrite the example from the previous section using associated types:"
-msgstr ""
+msgstr "让我们使用关联类型重写上一节的例子："
 
 #: src/generics/assoc_items/types.md:40
 msgid "// Define generic types here which methods will be able to utilize.\n"
-msgstr ""
+msgstr "// 在这里定义泛型类型，方法将能够使用这些类型。\n"
 
 #: src/generics/assoc_items/types.md:50
 msgid ""
@@ -8277,76 +8304,83 @@ msgid ""
 "    // is `Container(i32, i32)`, the `output` types are determined\n"
 "    // as `i32` and `i32`.\n"
 msgstr ""
+"// 指定 `A` 和 `B` 的类型。如果 `input` 类型\n"
+"    // 是 `Container(i32, i32)`，那么 `output` 类型就被确定\n"
+"    // 为 `i32` 和 `i32`。\n"
 
 #: src/generics/assoc_items/types.md:56
 msgid "// `&Self::A` and `&Self::B` are also valid here.\n"
-msgstr ""
+msgstr "// 这里 `&Self::A` 和 `&Self::B` 也是有效的。\n"
 
 #: src/generics/phantom.md:3
 msgid ""
 "A phantom type parameter is one that doesn't show up at runtime, but is "
 "checked statically (and only) at compile time."
-msgstr ""
+msgstr "虚类型参数是一种在运行时不会出现，但在（且仅在）编译时会被静态检查编译时检查的类型参数。"
 
 #: src/generics/phantom.md:6
 msgid ""
 "Data types can use extra generic type parameters to act as markers or to "
 "perform type checking at compile time. These extra parameters hold no storage "
 "values, and have no runtime behavior."
-msgstr ""
+msgstr "数据类型可以使用额外的泛型类型参数作为标记，或在编译时执行类型检查。这些额外的参数不占用存储空间，也没有运行时行为。"
 
 #: src/generics/phantom.md:10
 msgid ""
 "In the following example, we combine [std::marker::PhantomData](https://doc."
 "rust-lang.org/std/marker/struct.PhantomData.html) with the phantom type "
 "parameter concept to create tuples containing different data types."
-msgstr ""
+msgstr "在下面的例子中，我们将 [std::marker::PhantomData](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) 与虚类型参数的概念结合起来，创建包含不同数据类型的元组。"
 
 #: src/generics/phantom.md:16
 msgid ""
 "// A phantom tuple struct which is generic over `A` with hidden parameter "
 "`B`.\n"
-msgstr ""
+msgstr "// 一个虚元组结构体，它在 `A` 上是泛型的，带有隐藏参数 `B`。\n"
 
 #: src/generics/phantom.md:18 src/generics/phantom.md:22
 msgid "// Allow equality test for this type.\n"
-msgstr ""
+msgstr "// 允许对这个类型进行相等性测试。\n"
 
 #: src/generics/phantom.md:20
 msgid ""
 "// A phantom type struct which is generic over `A` with hidden parameter "
 "`B`.\n"
-msgstr ""
+msgstr "// 一个虚类型结构体，它在 `A` 上是泛型的，带有隐藏参数 `B`。\n"
 
 #: src/generics/phantom.md:24
 msgid ""
 "// Note: Storage is allocated for generic type `A`, but not for `B`.\n"
 "//       Therefore, `B` cannot be used in computations.\n"
 msgstr ""
+"// 注意：为泛型类型 `A` 分配了存储空间，但没有为 `B` 分配。\n"
+"//       因此，`B` 不能参与运算。\n"
 
 #: src/generics/phantom.md:29
 msgid ""
 "// Here, `f32` and `f64` are the hidden parameters.\n"
 "    // PhantomTuple type specified as `<char, f32>`.\n"
 msgstr ""
+"// 这里，`f32` 和 `f64` 是隐藏参数。\n"
+"    // PhantomTuple 类型指定为 `<char, f32>`。\n"
 
 #: src/generics/phantom.md:31 src/generics/phantom.md:33
 #: src/generics/phantom.md:37 src/generics/phantom.md:42
 #: src/scope/borrow/ref.md:12
 msgid "'Q'"
-msgstr ""
+msgstr "'Q'"
 
 #: src/generics/phantom.md:32
 msgid "// PhantomTuple type specified as `<char, f64>`.\n"
-msgstr ""
+msgstr "// PhantomTuple 类型指定为 `<char, f64>`。\n"
 
 #: src/generics/phantom.md:35
 msgid "// Type specified as `<char, f32>`.\n"
-msgstr ""
+msgstr "// 类型指定为 `<char, f32>`。\n"
 
 #: src/generics/phantom.md:40
 msgid "// Type specified as `<char, f64>`.\n"
-msgstr ""
+msgstr "// 类型指定为 `<char, f64>`。\n"
 
 #: src/generics/phantom.md:46
 msgid ""
@@ -8354,6 +8388,9 @@ msgid ""
 "    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
 "    //           _tuple1 == _tuple2);\n"
 msgstr ""
+"// 编译时错误！类型不匹配，所以这些不能比较：\n"
+"    // println!(\"_tuple1 == _tuple2 yields: {}\",\n"
+"    //           _tuple1 == _tuple2);\n"
 
 #: src/generics/phantom.md:50
 msgid ""
@@ -8361,36 +8398,41 @@ msgid ""
 "    // println!(\"_struct1 == _struct2 yields: {}\",\n"
 "    //           _struct1 == _struct2);\n"
 msgstr ""
+"// 编译时错误！类型不匹配，所以这些不能比较：\n"
+"    // println!(\"_struct1 == _struct2 yields: {}\",\n"
+"    //           _struct1 == _struct2);\n"
 
 #: src/generics/phantom.md:58
 msgid ""
 "[Derive](../trait/derive.md), [struct](../custom_types/structs.md), and "
 "[TupleStructs](../custom_types/structs.md)"
-msgstr ""
+msgstr "[Derive](../trait/derive.md)、[struct](../custom_types/structs.md) 和 [TupleStructs](../custom_types/structs.md)"
 
 #: src/generics/phantom/testcase_units.md:3
 msgid ""
 "A useful method of unit conversions can be examined by implementing `Add` "
 "with a phantom type parameter. The `Add` `trait` is examined below:"
-msgstr ""
+msgstr "通过使用虚类型参数实现 `Add` 可以研究一种有用的单位转换方法。下面我们来看看 `Add` 这个 `trait`："
 
 #: src/generics/phantom/testcase_units.md:7
 msgid ""
 "// This construction would impose: `Self + RHS = Output`\n"
 "// where RHS defaults to Self if not specified in the implementation.\n"
 msgstr ""
+"// 这个结构会强制要求：`Self + RHS = Output`\n"
+"// 其中如果在实现中没有指定 RHS，它会默认为 Self。\n"
 
 #: src/generics/phantom/testcase_units.md:14
 msgid "// `Output` must be `T<U>` so that `T<U> + T<U> = T<U>`.\n"
-msgstr ""
+msgstr "// `Output` 必须是 `T<U>`，这样 `T<U> + T<U> = T<U>`。\n"
 
 #: src/generics/phantom/testcase_units.md:22
 msgid "The whole implementation:"
-msgstr ""
+msgstr "完整的实现："
 
 #: src/generics/phantom/testcase_units.md:27
 msgid "/// Create void enumerations to define unit types.\n"
-msgstr ""
+msgstr "/// 创建空枚举来定义单位类型。\n"
 
 #: src/generics/phantom/testcase_units.md:33
 msgid ""
@@ -8399,26 +8441,30 @@ msgid ""
 "///\n"
 "/// `f64` already implements the `Clone` and `Copy` traits.\n"
 msgstr ""
+"/// `Length` 是一个带有虚类型参数 `Unit` 的类型，\n"
+"/// 它对长度类型（即 `f64`）并不是泛型的。\n"
+"///\n"
+"/// `f64` 已经实现了 `Clone` 和 `Copy` trait。\n"
 
 #: src/generics/phantom/testcase_units.md:40
 msgid "/// The `Add` trait defines the behavior of the `+` operator.\n"
-msgstr ""
+msgstr "/// `Add` trait 定义了 `+` 运算符的行为。\n"
 
 #: src/generics/phantom/testcase_units.md:45
 msgid "// add() returns a new `Length` struct containing the sum.\n"
-msgstr ""
+msgstr "// add() 返回一个包含和的新 `Length` 结构体。\n"
 
 #: src/generics/phantom/testcase_units.md:47
 msgid "// `+` calls the `Add` implementation for `f64`.\n"
-msgstr ""
+msgstr "// `+` 调用 `f64` 的 `Add` 实现。\n"
 
 #: src/generics/phantom/testcase_units.md:53
 msgid "// Specifies `one_foot` to have phantom type parameter `Inch`.\n"
-msgstr ""
+msgstr "// 指定 `one_foot` 具有虚类型参数 `Inch`。\n"
 
 #: src/generics/phantom/testcase_units.md:55
 msgid "// `one_meter` has phantom type parameter `Mm`.\n"
-msgstr ""
+msgstr "// `one_meter` 具有虚类型参数 `Mm`。\n"
 
 #: src/generics/phantom/testcase_units.md:58
 msgid ""
@@ -8427,18 +8473,22 @@ msgid ""
 "    // Since `Length` implements `Copy`, `add()` does not consume\n"
 "    // `one_foot` and `one_meter` but copies them into `self` and `rhs`.\n"
 msgstr ""
+"// `+` 调用我们为 `Length<Unit>` 实现的 `add()` 方法。\n"
+"    //\n"
+"    // 由于 `Length` 实现了 `Copy`，`add()` 不会消耗\n"
+"    // `one_foot` 和 `one_meter`，而是将它们复制到 `self` 和 `rhs` 中。\n"
 
 #: src/generics/phantom/testcase_units.md:65
 msgid "// Addition works.\n"
-msgstr ""
+msgstr "// 加法可以正常工作。\n"
 
 #: src/generics/phantom/testcase_units.md:66
 msgid "\"one foot + one_foot = {:?} in\""
-msgstr ""
+msgstr "\"一英尺 + 一英尺 = {:?} 英寸\""
 
 #: src/generics/phantom/testcase_units.md:67
 msgid "\"one meter + one_meter = {:?} mm\""
-msgstr ""
+msgstr "\"一米 + 一米 = {:?} 毫米\""
 
 #: src/generics/phantom/testcase_units.md:69
 msgid ""
@@ -8446,6 +8496,9 @@ msgid ""
 "    // Compile-time Error: type mismatch.\n"
 "    //let one_feter = one_foot + one_meter;\n"
 msgstr ""
+"// 无意义的操作会如预期那样失败：\n"
+"    // 编译时错误：类型不匹配。\n"
+"    //let one_feter = one_foot + one_meter;\n"
 
 #: src/generics/phantom/testcase_units.md:77
 msgid ""
@@ -8454,7 +8507,7 @@ msgid ""
 "methods.md), [Overloading](../../trait/ops.md), [ref](../../scope/borrow/ref."
 "md), [Traits (`X for Y`)](../../trait.md), and [TupleStructs](../../"
 "custom_types/structs.md)."
-msgstr ""
+msgstr "[借用 (`&`)](../../scope/borrow.md)、[约束 (`X: Y`)](../../generics/bounds.md)、[enum](../../custom_types/enum.md)、[impl 和 self](../../fn/methods.md)、[重载](../../trait/ops.md)、[ref](../../scope/borrow/ref.md)、[Traits (`X for Y`)](../../trait.md) 和 [元组结构体](../../custom_types/structs.md)。"
 
 #: src/scope.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -1784,70 +1784,80 @@ msgid ""
 "`fmt::Result`. Proper handling of this requires dealing with _all_ the "
 "results. Rust provides the `?` operator for exactly this purpose."
 msgstr ""
+"为一个结构体实现 `fmt::Display`，其中的元素必须依次处理，这是很棘手的。"
+"问题在于每个 `write!` 都会生成一个 `fmt::Result`。正确的方式需要处理**所有**结果。"
+"Rust 提供了 `?` 运算符来专门应对这个问题。"
 
 #: src/hello/print/print_display/testcase_list.md:8
 msgid "Using `?` on `write!` looks like this:"
-msgstr ""
+msgstr "在 `write!` 上使用 `?` 看起来像这样："
 
 #: src/hello/print/print_display/testcase_list.md:11
 msgid ""
 "// Try `write!` to see if it errors. If it errors, return\n"
 "// the error. Otherwise continue.\n"
 msgstr ""
+"// 尝试执行 `write!`，看看它是否会报错。如果报错，就返回错误。\n"
+"// 否则继续执行。\n"
 
 #: src/hello/print/print_display/testcase_list.md:16
 msgid ""
 "With `?` available, implementing `fmt::Display` for a `Vec` is "
 "straightforward:"
-msgstr ""
+msgstr "有了 `?` 可用，为 `Vec` 实现 `fmt::Display` 就变得很直观了："
 
 #: src/hello/print/print_display/testcase_list.md:20
 msgid "// Import the `fmt` module.\n"
-msgstr ""
+msgstr "// 导入 `fmt` 模块。\n"
 
 #: src/hello/print/print_display/testcase_list.md:21
 msgid "// Define a structure named `List` containing a `Vec`.\n"
-msgstr ""
+msgstr "// 定义一个包含 `Vec` 的结构体 `List`。\n"
 
 #: src/hello/print/print_display/testcase_list.md:27
 msgid ""
 "// Extract the value using tuple indexing,\n"
 "        // and create a reference to `vec`.\n"
 msgstr ""
+"// 使用元组索引提取值，\n"
+"        // 并创建一个指向 `vec` 的引用。\n"
 
 #: src/hello/print/print_display/testcase_list.md:31
 msgid "\"[\""
-msgstr ""
+msgstr "\"[\""
 
 #: src/hello/print/print_display/testcase_list.md:33
 msgid ""
 "// Iterate over `v` in `vec` while enumerating the iteration\n"
 "        // count in `count`.\n"
 msgstr ""
+"// 遍历 `vec` 中的 `v`，同时在 `count` 中记录迭代次数。\n"
 
 #: src/hello/print/print_display/testcase_list.md:36
 msgid ""
 "// For every element except the first, add a comma.\n"
 "            // Use the ? operator to return on errors.\n"
 msgstr ""
+"// 对除第一个元素外的每个元素，添加一个逗号。\n"
+"            // 使用 ? 运算符在出错时返回。\n"
 
 #: src/hello/print/print_display/testcase_list.md:38 src/std/str.md:36
 msgid "\", \""
-msgstr ""
+msgstr "\", \""
 
 #: src/hello/print/print_display/testcase_list.md:42
 msgid "// Close the opened bracket and return a fmt::Result value.\n"
-msgstr ""
+msgstr "// 关闭开括号并返回一个 fmt::Result 值。\n"
 
 #: src/hello/print/print_display/testcase_list.md:43
 msgid "\"]\""
-msgstr ""
+msgstr "\"]\""
 
 #: src/hello/print/print_display/testcase_list.md:55
 msgid ""
 "Try changing the program so that the index of each element in the vector is "
 "also printed. The new output should look like this:"
-msgstr ""
+msgstr "尝试修改程序，使向量中每个元素的索引也被打印出来。新的输出应该看起来像这样："
 
 #: src/hello/print/print_display/testcase_list.md:64
 msgid ""
@@ -1856,30 +1866,36 @@ msgid ""
 "md), [`?`](../../../std/result/question_mark.md), and [`vec!`](../../../std/"
 "vec.md)"
 msgstr ""
+"[`for`](../../../flow_control/for.md)、[`ref`](../../../scope/borrow/ref.md)、"
+"[`Result`](../../../std/result.md)、[`struct`](../../../custom_types/structs.md)、"
+"[`?`](../../../std/result/question_mark.md) 和 [`vec!`](../../../std/vec.md)"
 
 #: src/hello/print/fmt.md:3
 msgid "We've seen that formatting is specified via a _format string_:"
-msgstr ""
+msgstr "我们已经看到，格式化是通过**格式字符串**指定的："
 
 #: src/hello/print/fmt.md:5
 msgid "`format!(\"{}\", foo)` -> `\"3735928559\"`"
-msgstr ""
+msgstr "`format!(\"{}\", foo)` -> `\"3735928559\"`"
 
 #: src/hello/print/fmt.md:6
 msgid ""
 "`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/"
 "wiki/Deadbeef#Magic_debug_values)"
 msgstr ""
+"`format!(\"0x{:X}\", foo)` -> [`\"0xDEADBEEF\"`](https://en.wikipedia.org/"
+"wiki/Deadbeef#Magic_debug_values)"
 
 #: src/hello/print/fmt.md:7
 msgid "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
-msgstr ""
+msgstr "`format!(\"0o{:o}\", foo)` -> `\"0o33653337357\"`"
 
 #: src/hello/print/fmt.md:9
 msgid ""
 "The same variable (`foo`) can be formatted differently depending on which "
 "_argument type_ is used: `X` vs `o` vs _unspecified_."
 msgstr ""
+"根据使用的**参数类型**是 `X`、`o` 还是**未指定**，同样的变量（`foo`）能够格式化成不同的形式。"
 
 #: src/hello/print/fmt.md:12
 msgid ""
@@ -1888,63 +1904,68 @@ msgid ""
 "which handles cases where the argument type is left unspecified: `{}` for "
 "instance."
 msgstr ""
+"这种格式化功能是通过 trait 实现的，每种参数类型都有一个对应的 trait。"
+"最常见的格式化 trait 是 `Display`，它处理参数类型未指定的情况：例如 `{}`。"
 
 #: src/hello/print/fmt.md:21
 msgid "// Latitude\n"
-msgstr ""
+msgstr "// 纬度\n"
 
 #: src/hello/print/fmt.md:23
 msgid "// Longitude\n"
-msgstr ""
+msgstr "// 经度\n"
 
 #: src/hello/print/fmt.md:28
 msgid ""
 "// `f` is a buffer, and this method must write the formatted string into it.\n"
-msgstr ""
+msgstr "// `f` 是一个缓冲区，这个方法必须将格式化的字符串写入其中。\n"
 
 #: src/hello/print/fmt.md:30
 msgid "'N'"
-msgstr ""
+msgstr "'N'"
 
 #: src/hello/print/fmt.md:30
 msgid "'S'"
-msgstr ""
+msgstr "'S'"
 
 #: src/hello/print/fmt.md:31
 msgid "'E'"
-msgstr ""
+msgstr "'E'"
 
 #: src/hello/print/fmt.md:31
 msgid "'W'"
-msgstr ""
+msgstr "'W'"
 
 #: src/hello/print/fmt.md:33
 msgid ""
 "// `write!` is like `format!`, but it will write the formatted string\n"
 "        // into a buffer (the first argument).\n"
 msgstr ""
+"// `write!` 类似于 `format!`，但它会将格式化后的字符串\n"
+"        // 写入一个缓冲区（第一个参数）。\n"
 
 #: src/hello/print/fmt.md:35
 msgid "\"{}: {:.3}°{} {:.3}°{}\""
-msgstr ""
+msgstr "\"{}: {:.3}°{} {:.3}°{}\""
 
 #: src/hello/print/fmt.md:49
 msgid "\"Dublin\""
-msgstr ""
+msgstr "\"Dublin\""
 
 #: src/hello/print/fmt.md:50
 msgid "\"Oslo\""
-msgstr ""
+msgstr "\"Oslo\""
 
 #: src/hello/print/fmt.md:51
 msgid "\"Vancouver\""
-msgstr ""
+msgstr "\"Vancouver\""
 
 #: src/hello/print/fmt.md:60
 msgid ""
 "// Switch this to use {} once you've added an implementation\n"
 "        // for fmt::Display.\n"
 msgstr ""
+"// 一旦你为 fmt::Display 添加了实现，就把这里改成使用 {}。\n"
 
 #: src/hello/print/fmt.md:62 src/primitives/tuples.md:60
 #: src/custom_types/structs.md:47 src/types/inference.md:23
@@ -1953,7 +1974,7 @@ msgstr ""
 #: src/std/result.md:61 src/std/result.md:63 src/std/arc.md:26
 #: src/std_misc/channels.md:53
 msgid "\"{:?}\""
-msgstr ""
+msgstr "\"{:?}\""
 
 #: src/hello/print/fmt.md:67
 msgid ""
@@ -1961,16 +1982,19 @@ msgid ""
 "fmt/#formatting-traits) and their argument types in the [`std::fmt`](https://"
 "doc.rust-lang.org/std/fmt/) documentation."
 msgstr ""
+"你可以在 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) 文档中查看"
+"[格式化 trait 的完整列表](https://doc.rust-lang.org/std/fmt/#formatting-traits)"
+"及其参数类型。"
 
 #: src/hello/print/fmt.md:72
 msgid ""
 "Add an implementation of the `fmt::Display` trait for the `Color` struct "
 "above so that the output displays as:"
-msgstr ""
+msgstr "为上面的 `Color` 结构体添加 `fmt::Display` trait 的实现，使输出显示为："
 
 #: src/hello/print/fmt.md:81
 msgid "Three hints if you get stuck:"
-msgstr ""
+msgstr "如果你遇到困难，这里有三个提示："
 
 #: src/hello/print/fmt.md:83
 msgid ""
@@ -1979,22 +2003,24 @@ msgid ""
 "see [RGB color format & calculation](https://www.rapidtables.com/web/color/"
 "RGB_Color.html#rgb-format)."
 msgstr ""
+"在 RGB 颜色空间中计算颜色的公式是：`RGB = (R*65536)+(G*256)+B，（其中 R 是红色，G 是绿色，B 是蓝色）`。"
+"更多信息请参见 [RGB 颜色格式和计算](https://www.rapidtables.com/web/color/RGB_Color.html#rgb-format)。"
 
 #: src/hello/print/fmt.md:86
 msgid ""
 "You [may need to list each color more than once](https://doc.rust-lang.org/"
 "std/fmt/#named-parameters)."
-msgstr ""
+msgstr "你[可能需要多次列出每种颜色](https://doc.rust-lang.org/std/fmt/#named-parameters)。"
 
 #: src/hello/print/fmt.md:87
 msgid ""
 "You can [pad with zeros to a width of 2](https://doc.rust-lang.org/std/fmt/"
 "#width) with `:0>2`."
-msgstr ""
+msgstr "你可以使用 `:0>2` [用零填充到宽度为 2](https://doc.rust-lang.org/std/fmt/#width)。"
 
 #: src/hello/print/fmt.md:91
 msgid "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
-msgstr ""
+msgstr "[`std::fmt`](https://doc.rust-lang.org/std/fmt/)"
 
 #: src/primitives.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -922,7 +922,7 @@ msgstr "[补充](meta.md) - 文档，基准测试。"
 
 #: src/hello.md:3
 msgid "This is the source code of the traditional Hello World program."
-msgstr "这是传统的 Hello World 程序的源代码。"
+msgstr "这是经典的 Hello World 程序的源代码。"
 
 #: src/hello.md:6
 msgid ""
@@ -931,10 +931,9 @@ msgid ""
 "// or if you prefer to use your keyboard, you can use the \"Ctrl + Enter\"\n"
 "// shortcut.\n"
 msgstr ""
-"// 这是一个注释，编译器会忽略它。\n"
-"// 你可以通过点击那边的 \"运行\" 按钮来测试这段代码 ->\n"
-"// 或者，如果你更喜欢使用键盘，你可以使用 \"Ctrl + 回车\"\n"
-"// 快捷键。\n"
+"// 这是一行注释，编译器会忽略它。\n"
+"// 你可以点击右侧的 \"Run\" 按钮来测试这段代码 ->\n"
+"// 如果你更习惯使用键盘，也可以使用"Ctrl + Enter"快捷键来运行。\n"
 
 #: src/hello.md:10
 msgid ""
@@ -942,8 +941,8 @@ msgid ""
 "// You can always return to the original code by clicking the \"Reset\" "
 "button ->\n"
 msgstr ""
-"// 这段代码是可以编辑的，随意地修改它吧！\n"
-"// 你总是可以通过点击 \"重置\" 按钮来恢复原始代码 ->\n"
+"// 这段代码是可以编辑的，请随意修改！\n"
+"// 你可以随时点击 \"Reset\" 按钮恢复到初始代码 ->\n"
 
 #: src/hello.md:13
 msgid "// This is the main function.\n"
@@ -951,7 +950,7 @@ msgstr "// 这是主函数。\n"
 
 #: src/hello.md:16
 msgid "// Statements here are executed when the compiled binary is called.\n"
-msgstr "// 当编译后的二进制文件被调用时，这里的语句将被执行。\n"
+msgstr "// 当运行编译后的程序时，这里的语句会被执行。\n"
 
 #: src/hello.md:18
 msgid "// Print text to the console.\n"
@@ -963,59 +962,59 @@ msgstr "\"Hello World!\""
 
 #: src/hello.md:23
 msgid "`println!` is a [_macro_](macros.md) that prints text to the console."
-msgstr "`println!` 是一个[宏(macro_rule!)](macros.md)，用于在控制台打印文本。"
+msgstr "`println!` 是一个用于在控制台打印文本的[宏](macros.md)。"
 
 #: src/hello.md:26
 msgid "A binary can be generated using the Rust compiler: `rustc`."
-msgstr "可以使用 Rust 编译器 `rustc` 生成二进制文件。"
+msgstr "可以使用 Rust 编译器 `rustc` 来生成可执行文件。"
 
 #: src/hello.md:32
 msgid "`rustc` will produce a `hello` binary that can be executed."
-msgstr "`rustc` 将生成一个可以执行的 `hello` 二进制文件。"
+msgstr "`rustc` 将生成一个名为 `hello` 的可执行文件。"
 
 #: src/hello.md:39 src/hello/print/print_display.md:107
 #: src/hello/print/print_display/testcase_list.md:53 src/hello/print/fmt.md:70
 #: src/primitives/tuples.md:64 src/custom_types/structs.md:89
 msgid "Activity"
-msgstr "动手试一试"
+msgstr "练习"
 
 #: src/hello.md:41
 msgid ""
 "Click 'Run' above to see the expected output. Next, add a new line with a "
 "second `println!` macro so that the output shows:"
 msgstr ""
-"点击上面的 '运行' 查看预期输出。接下来，添加一行新的代码，再次使用 `println!` 宏，输出以下结果："
+"点击上方的"运行"按钮查看预期输出。接下来，添加一行新代码，再次使用 `println!` 宏，输出显示如下内容："
 
 #: src/hello/comment.md:3
 msgid ""
 "Any program requires comments, and Rust supports a few different varieties:"
-msgstr "任何程序都需要注释，Rust 支持几种不同的注释类型："
+msgstr "每个程序都需要注释，Rust 支持几种不同类型的注释："
 
 #: src/hello/comment.md:6
 msgid "_Regular comments_ which are ignored by the compiler:"
-msgstr "**普通注释**会被编译器会忽略的 ："
+msgstr "**普通注释**：编译器会忽略这些注释"
 
 #: src/hello/comment.md:7
 msgid "`// Line comments which go to the end of the line.`"
-msgstr "`// 行注释，直到行尾。`"
+msgstr "`// 行注释，从双斜杠开始到行尾。`"
 
 #: src/hello/comment.md:8
 msgid "`/* Block comments which go to the closing delimiter. */`"
-msgstr "`/* 块注释，直到闭合分隔符。 */`"
+msgstr "`/* 块注释，从开始符号到结束符号。 */`"
 
 #: src/hello/comment.md:9
 msgid ""
 "_Doc comments_ which are parsed into HTML library [documentation](../meta/doc."
 "md):"
-msgstr "**文档注释**会被解析成 HTML 库[文档](../meta/doc.md)："
+msgstr "**文档注释**：这些注释会被解析成 HTML 格式的[库文档](../meta/doc.md)"
 
 #: src/hello/comment.md:10
 msgid "`/// Generate library docs for the following item.`"
-msgstr "`/// 为下一项生成库文档。`"
+msgstr "`/// 为接下来的项生成库文档。`"
 
 #: src/hello/comment.md:11
 msgid "`//! Generate library docs for the enclosing item.`"
-msgstr "`//! 为所属项（译注：如 crate、模块或函数）生成库文档。`"
+msgstr "`//! 为当前项（如 crate、模块或函数）生成库文档。`"
 
 #: src/hello/comment.md:15
 msgid ""
@@ -1023,9 +1022,9 @@ msgid ""
 "    // There are two slashes at the beginning of the line.\n"
 "    // And nothing written after these will be read by the compiler.\n"
 msgstr ""
-"// 这是一个行注释的例子。\n"
-"    // 行首有两个斜杠。\n"
-"    // 这些之后写的内容不会被编译器读取。\n"
+"// 这是行注释的一个例子。\n"
+"    // 在行首有两个斜杠。\n"
+"    // 斜杠后面的内容编译器不会读取。\n"
 
 #: src/hello/comment.md:19
 msgid "// println!(\"Hello, world!\");\n"
@@ -1033,7 +1032,7 @@ msgstr "// println!(\"Hello, world!\");\n"
 
 #: src/hello/comment.md:21
 msgid "// Run it. See? Now try deleting the two slashes, and run it again.\n"
-msgstr "// 运行它。看到了吗？现在尝试删除两个斜杠，再运行一次。\n"
+msgstr "// 运行看看。明白了吗？现在试着删除这两个斜杠，再运行一次。\n"
 
 #: src/hello/comment.md:23
 msgid ""
@@ -1043,15 +1042,16 @@ msgid ""
 "     * are extremely useful for temporarily disabling chunks of code.\n"
 "     * /* Block comments can be /* nested, */ */ so it takes only a few\n"
 "     * keystrokes to comment out everything in this main() function.\n"
-"     * /*/*/* Try it yourself! */*/*/"
+"     * /*/*/* Try it yourself! */*/*/\n"
+"     */"
 msgstr ""
 "/*\n"
-"     * 这是另一种注释，块注释。通常，\n"
-"     * 推荐使用行注释风格。但块注释\n"
-"     * 非常适用于临时禁用代码块。\n"
-"     * /* 块注释可以 /* 嵌套， */ */ 所以只需要几个\n"
-"     * 按键就可以注释掉这个 main() 函数中的所有内容。\n"
-"     * /*/*/* 自己试试吧！ */*/*/"
+"     * 这是另一种类型的注释，称为块注释。一般来说，推荐使用行注释。\n"
+"     * 但是块注释在临时禁用大段代码时非常有用。\n"
+"     * /* 块注释可以 /* 嵌套， */ */ 因此只需几次按键就能\n"
+"     * 注释掉 main() 函数中的所有内容。\n"
+"     * /*/*/* 你可以自己试试！ */*/*/\n"
+"     */"
 
 #: src/hello/comment.md:32
 msgid ""
@@ -1061,8 +1061,7 @@ msgid ""
 "    */"
 msgstr ""
 "/*\n"
-"    注意：前面的 `*` 列完全是出于风格考虑。实际上\n"
-"    并不需要它。\n"
+"    注意：前面的 `*` 列纯粹是为了样式美观。实际上并不需要。\n"
 "    */"
 
 #: src/hello/comment.md:37
@@ -1071,9 +1070,8 @@ msgid ""
 "    // than with line comments. Try deleting the comment delimiters\n"
 "    // to change the result:\n"
 msgstr ""
-"// 你可以使用块注释比行注释更容易地操作表达式\n"
-"    // 尝试删除注释分隔符\n"
-"    // 来改变结果：\n"
+"// 块注释比行注释更方便地操作表达式\n"
+"    // 试试删除注释符号，看看结果会有什么变化：\n"
 
 #: src/hello/comment.md:40
 msgid "/* 90 + */"
@@ -1081,7 +1079,7 @@ msgstr "/* 90 + */"
 
 #: src/hello/comment.md:41
 msgid "\"Is `x` 10 or 100? x = {}\""
-msgstr "\"`x` 是 10 还是 100？x = {}\""
+msgstr ""`x` 是 10 还是 100？x = {}\""
 
 #: src/hello/comment.md:45 src/hello/print.md:103
 #: src/hello/print/print_debug.md:75 src/hello/print/print_display.md:118
@@ -1127,55 +1125,55 @@ msgstr "\"`x` 是 10 还是 100？x = {}\""
 #: src/std_misc/threads/testcase_mapreduce.md:128 src/std_misc/path.md:54
 #: src/std_misc/fs.md:150 src/meta/doc.md:109 src/meta/playground.md:49
 msgid "See also:"
-msgstr "参见："
+msgstr "另请参阅："
 
 #: src/hello/comment.md:47
 msgid "[Library documentation](../meta/doc.md)"
-msgstr "[文档注释](../meta/doc.md)"
+msgstr "[库文档](../meta/doc.md)"
 
 #: src/hello/print.md:3
 msgid ""
 "Printing is handled by a series of [`macros`](../macros.md) defined in [`std::"
 "fmt`](https://doc.rust-lang.org/std/fmt/) some of which are:"
-msgstr "打印功能由定义在 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) 中的一系列 [`macros`](../macros.md) 处理，其中包括："
+msgstr "打印功能由 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) 中定义的一系列[`宏`](../macros.md)处理，其中包括："
 
 #: src/hello/print.md:6
 msgid "`format!`: write formatted text to [`String`](../std/str.md)"
-msgstr "`format!`: 将格式化文本写入 [`String`](../std/str.md)"
+msgstr "`format!`：将格式化文本写入 [`String`](../std/str.md)"
 
 #: src/hello/print.md:7
 msgid ""
 "`print!`: same as `format!` but the text is printed to the console (io::"
 "stdout)."
-msgstr "`print!`: 与 `format!` 相同，但文本将被打印到控制台（io::stdout）."
+msgstr "`print!`：与 `format!` 类似，但文本会打印到控制台（io::stdout）"
 
 #: src/hello/print.md:9
 msgid "`println!`: same as `print!` but a newline is appended."
-msgstr "`println!`: 与 `print!` 相同，但会追加一个新行。"
+msgstr "`println!`：与 `print!` 类似，但会在末尾添加换行符"
 
 #: src/hello/print.md:10
 msgid ""
 "`eprint!`: same as `print!` but the text is printed to the standard error "
 "(io::stderr)."
-msgstr "`eprint!`: 与 `print!` 相同，但文本将被打印到标准错误输出（io::stderr）."
+msgstr "`eprint!`：与 `print!` 类似，但文本会打印到标准错误输出（io::stderr）"
 
 #: src/hello/print.md:12
 msgid "`eprintln!`: same as `eprint!` but a newline is appended."
-msgstr "`eprintln!`: 与 `eprint!` 相同，但会追加一个新行。"
+msgstr "`eprintln!`：与 `eprint!` 类似，但会在末尾添加换行符"
 
 #: src/hello/print.md:14
 msgid ""
 "All parse text in the same fashion. As a plus, Rust checks formatting "
 "correctness at compile time."
-msgstr "所有这些都以相同的方式解析文本。此外，Rust 会在编译时检查格式化的正确性。"
+msgstr "所有这些宏都以相同的方式解析文本。此外，Rust 会在编译时检查格式化的正确性。"
 
 #: src/hello/print.md:19
 msgid ""
 "// In general, the `{}` will be automatically replaced with any\n"
 "    // arguments. These will be stringified.\n"
 msgstr ""
-"// 通常，`{}` 将自动替换为任何\n"
-"    // 参数。这些将被转换为字符串。\n"
+"// 通常，`{}` 会被自动替换为任何参数。\n"
+"    // 这些参数会被转换为字符串。\n"
 
 #: src/hello/print.md:21
 msgid "\"{} days\""
@@ -1189,8 +1187,8 @@ msgid ""
 "    // at 0 immediately after the format string.\n"
 msgstr ""
 "// 可以使用位置参数。在 `{}` 中指定一个整数\n"
-"    // 决定了哪个附加参数将被替换。参数\n"
-"    // 在格式字符串之后立即从 0 开始。\n"
+"    // 来决定替换哪个额外的参数。参数编号\n"
+"    // 从格式字符串后立即开始，从 0 开始。\n"
 
 #: src/hello/print.md:26
 msgid "\"{0}, this is {1}. {1}, this is {0}\""
@@ -1207,7 +1205,7 @@ msgstr "\"Bob\""
 
 #: src/hello/print.md:28
 msgid "// As can named arguments.\n"
-msgstr "// 也可以使用命名参数。\n"
+msgstr "// 还可以使用命名参数。\n"
 
 #: src/hello/print.md:29
 msgid "\"{subject} {verb} {object}\""
@@ -1215,11 +1213,11 @@ msgstr "\"{subject} {verb} {object}\""
 
 #: src/hello/print.md:30
 msgid "\"the lazy dog\""
-msgstr "\"懒惰的狗\""
+msgstr "\"那只懒惰的狗\""
 
 #: src/hello/print.md:31
 msgid "\"the quick brown fox\""
-msgstr "\"快速的棕色狐狸\""
+msgstr "\"那只敏捷的棕色狐狸\""
 
 #: src/hello/print.md:32
 msgid "\"jumps over\""
@@ -1230,40 +1228,40 @@ msgid ""
 "// Different formatting can be invoked by specifying the format character\n"
 "    // after a `:`.\n"
 msgstr ""
-"// 通过在 `:` 后指定格式字符，可以调用不同的格式化\n"
-"    // 方式。\n"
+"// 在 `:` 后指定格式字符，\n"
+"    // 可以调用不同的格式化方式。\n"
 
 #: src/hello/print.md:36
 msgid "\"Base 10:               {}\""
-msgstr "\"10 进制：               {}\""
+msgstr "\"十进制：               {}\""
 
 #: src/hello/print.md:36
 msgid "// 69420\n"
-msgstr ""
+msgstr "// 69420\n"
 
 #: src/hello/print.md:37
 msgid "\"Base 2 (binary):       {:b}\""
-msgstr "\"2 进制（二进制）：    {:b}\""
+msgstr "\"二进制：               {:b}\""
 
 #: src/hello/print.md:37
 msgid "// 10000111100101100\n"
-msgstr ""
+msgstr "// 10000111100101100\n"
 
 #: src/hello/print.md:38
 msgid "\"Base 8 (octal):        {:o}\""
-msgstr "\"8 进制（八进制）：     {:o}\""
+msgstr "\"八进制：               {:o}\""
 
 #: src/hello/print.md:38
 msgid "// 207454\n"
-msgstr ""
+msgstr "// 207454\n"
 
 #: src/hello/print.md:39
 msgid "\"Base 16 (hexadecimal): {:x}\""
-msgstr "\"16 进制（十六进制）：   {:x}\""
+msgstr "\"十六进制：             {:x}\""
 
 #: src/hello/print.md:39
 msgid "// 10f2c\n"
-msgstr ""
+msgstr "// 10f2c\n"
 
 #: src/hello/print.md:41
 msgid ""
@@ -1271,8 +1269,8 @@ msgid ""
 "    // output \"    1\". (Four white spaces and a \"1\", for a total width of "
 "5.)\n"
 msgstr ""
-"// 你可以使用指定的宽度对文本进行右对齐。这将\n"
-"    // 输出 \"    1\"。（四个空格和一个 \"1\"，总宽度为 5。）\n"
+"// 可以指定宽度来右对齐文本。这将输出\n"
+"    // \"    1\"。（四个空格和一个 \"1\"，总宽度为 5。）\n"
 
 #: src/hello/print.md:43
 msgid "\"{number:>5}\""
@@ -1280,7 +1278,7 @@ msgstr "\"{number:>5}\""
 
 #: src/hello/print.md:45
 msgid "// You can pad numbers with extra zeroes,\n"
-msgstr "// 你可以用额外的零来填充数字，\n"
+msgstr "// 可以用额外的零来填充数字，\n"
 
 #: src/hello/print.md:46
 msgid "\"{number:0>5}\""
@@ -1292,7 +1290,7 @@ msgid ""
 "    // and left-adjust by flipping the sign. This will output \"10000\".\n"
 msgstr ""
 "// 00001\n"
-"    // 并通过翻转符号进行左对齐。这将输出 \"10000\"。\n"
+"    // 通过翻转符号来左对齐。这将输出 \"10000\"。\n"
 
 #: src/hello/print.md:48
 msgid "\"{number:0<5}\""
@@ -1300,13 +1298,13 @@ msgstr "\"{number:0<5}\""
 
 #: src/hello/print.md:48
 msgid "// 10000\n"
-msgstr ""
+msgstr "// 10000\n"
 
 #: src/hello/print.md:50
 msgid ""
 "// You can use named arguments in the format specifier by appending a `$`.\n"
 msgstr ""
-"// 你可以通过在格式说明符后附加 `$` 来使用命名参数。\n"
+"// 在格式说明符后添加 `$` 可以使用命名参数。\n"
 
 #: src/hello/print.md:51
 msgid "\"{number:0>width$}\""
@@ -1315,7 +1313,7 @@ msgstr "\"{number:0>width$}\""
 #: src/hello/print.md:53
 msgid ""
 "// Rust even checks to make sure the correct number of arguments are used.\n"
-msgstr "// Rust 甚至会检查使用的正确参数数量。\n"
+msgstr "// Rust 甚至会检查使用的参数数量是否正确。\n"
 
 #: src/hello/print.md:54
 msgid "\"My name is {0}, {1} {0}\""
@@ -1334,12 +1332,12 @@ msgid ""
 "// Only types that implement fmt::Display can be formatted with `{}`. User-\n"
 "    // defined types do not implement fmt::Display by default.\n"
 msgstr ""
-"// 只有实现了 fmt::Display 的类型才能使用 `{}` 进行格式化。用户\n"
-"    // 定义的类型默认不会实现 fmt::Display。\n"
+"// 只有实现了 fmt::Display 的类型才能用 `{}` 格式化。\n"
+"    // 用户定义的类型默认不实现 fmt::Display。\n"
 
 #: src/hello/print.md:60
 msgid "// disable `dead_code` which warn against unused module\n"
-msgstr "// 禁用 `dead_code`，它用于警告未使用的模块\n"
+msgstr "// 禁用 `dead_code`，它会警告未使用的模块\n"
 
 #: src/hello/print.md:63
 msgid ""
@@ -1348,10 +1346,9 @@ msgid ""
 "    // println!(\"This struct `{}` won't print...\", Structure(3));\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// 这将无法编译，因为 `Structure` 没有实现\n"
-"    // fmt::Display。\n"
+"// 这无法编译，因为 `Structure` 没有实现 fmt::Display。\n"
 "    // println!(\"这个结构体 `{}` 无法打印...\", Structure(3));\n"
-"    // TODO ^ 尝试取消注释这行\n"
+"    // TODO ^ 尝试取消注释这一行\n"
 
 #: src/hello/print.md:68
 msgid ""
@@ -1359,8 +1356,8 @@ msgid ""
 "    // surrounding variable. Just like the above, this will output\n"
 "    // \"    1\", 4 white spaces and a \"1\".\n"
 msgstr ""
-"// 对于 Rust 1.58 及以上版本，你可以直接从周围的变量捕获参数。就像上面一样，这将输出\n"
-"    // \"    1\"，4个空格和一个 \"1\"。\n"
+"// 在 Rust 1.58 及以上版本，你可以直接从周围的变量捕获参数。\n"
+"    // 就像上面一样，这将输出 \"    1\"，4 个空格和一个 \"1\"。\n"
 
 #: src/hello/print.md:73
 msgid "\"{number:>width$}\""
@@ -1372,13 +1369,13 @@ msgid ""
 "(https://doc.rust-lang.org/std/fmt/#formatting-traits) which govern the "
 "display of text. The base form of two important ones are listed below:"
 msgstr ""
-"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) 包含许多 [`traits`]"
-"(https://doc.rust-lang.org/std/fmt/#formatting-traits)，它们控制文本的显示。下面列出了两个重要的基本形式："
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) 包含许多控制文本显示的 [`traits`]"
+"(https://doc.rust-lang.org/std/fmt/#formatting-traits)。下面列出了两个重要的基本形式："
 
 #: src/hello/print.md:80
 msgid ""
 "`fmt::Debug`: Uses the `{:?}` marker. Format text for debugging purposes."
-msgstr "`fmt::Debug`: 使用 `{:?}` 标记。为了调试目的格式化文本。"
+msgstr "`fmt::Debug`: 使用 `{:?}` 标记。用于调试目的的文本格式化。"
 
 #: src/hello/print.md:81
 msgid ""
@@ -1390,7 +1387,7 @@ msgstr "`fmt::Display`: 使用 `{}` 标记。以更优雅、用户友好的方�
 msgid ""
 "Here, we used `fmt::Display` because the std library provides implementations "
 "for these types. To print text for custom types, more steps are required."
-msgstr "这里我们使用 `fmt::Display`，因为标准库为这些类型提供了实现。要打印自定义类型的文本，需要更多的步骤。"
+msgstr "这里我们使用 `fmt::Display`，因为标准库为这些类型提供了实现。要打印自定义类型的文本，需要额外的步骤。"
 
 #: src/hello/print.md:87
 msgid ""
@@ -1410,18 +1407,18 @@ msgstr "在 _43 行_，`#[allow(dead_code)]`是一个 [属性(attribute)](../att
 
 #: src/hello/print.md:92
 msgid "Activities"
-msgstr "动手试一试"
+msgstr "练习"
 
 #: src/hello/print.md:94
 msgid ""
 "Fix the issue in the above code (see FIXME) so that it runs without error."
-msgstr "修复上述代码中的问题（见 FIXME），以便它能无误运行。"
+msgstr "修复上述代码中的问题（参见 FIXME 注释），使其能够正常运行。"
 
 #: src/hello/print.md:96
 msgid ""
 "Try uncommenting the line that attempts to format the `Structure` struct (see "
 "TODO)"
-msgstr "尝试取消注释尝试格式化 `Structure` 结构体的行（见 TODO）"
+msgstr "尝试取消注释那行尝试格式化 `Structure` 结构体的代码（参见 TODO 注释）"
 
 #: src/hello/print.md:98
 msgid ""
@@ -1431,9 +1428,9 @@ msgid ""
 "[`std::fmt`](https://doc.rust-lang.org/std/fmt/) documentation for setting "
 "the number of decimals to display)"
 msgstr ""
-"添加一个 `println!` 宏调用，打印：`Pi 大约为 3.142`，通过控制显示的小数位数。为了这个练习的目的，使用 "
-"`let pi = 3.141592` 作为 pi 的近似值。（提示：你可能需要查看 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) "
-"文档以设置显示的小数位数）"
+"添加一个 `println!` 宏调用，打印：`Pi 约等于 3.142`，通过控制显示的小数位数来实现。\n"
+"在本练习中，使用 `let pi = 3.141592` 作为 pi 的近似值。（提示：你可能需要查阅\n"
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) 文档来了解如何设置显示的小数位数）"
 
 #: src/hello/print.md:105
 msgid ""
@@ -1441,8 +1438,9 @@ msgid ""
 "[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/"
 "std/fmt/#formatting-traits), and [`dead_code`](../attribute/unused.md)"
 msgstr ""
-"[`std::fmt`](https://doc.rust-lang.org/std/fmt/),  [`macros`](../macros.md), "
-"[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/std/fmt/#formatting-traits), 和 [`dead_code`](../attribute/unused.md)"
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/)、[`macros`](../macros.md)、\n"
+"[`struct`](../custom_types/structs.md)、[`traits`](https://doc.rust-lang.org/std/fmt/#formatting-traits) "
+"和 [`dead_code`](../attribute/unused.md)"
 
 #: src/hello/print/print_debug.md:3
 msgid ""
@@ -1451,8 +1449,8 @@ msgid ""
 "for types such as in the `std` library. All others _must_ be manually "
 "implemented somehow."
 msgstr ""
-"所有的类型，若想用 `std::fmt` 的格式化打印，都要实现至少一个可打印的 `traits`。"
-"自动实现只为 `std` 库中的类型提供。所有其他类型都**必须**以某种方式手动实现。"
+"所有想要使用 `std::fmt` 格式化 `traits` 的类型都需要实现才能打印。\n"
+"自动实现仅为 `std` 库中的类型提供。所有其他类型都**必须**以某种方式手动实现。"
 
 #: src/hello/print/print_debug.md:8
 msgid ""
@@ -1460,7 +1458,7 @@ msgid ""
 "`derive` (automatically create) the `fmt::Debug` implementation. This is not "
 "true for `fmt::Display` which must be manually implemented."
 msgstr ""
-"`fmt::Debug` `trait` 使这变得非常简单。**所有**类型都可以 `derive`（自动创建）"
+"`fmt::Debug` trait 使这变得非常简单。**所有**类型都可以 `derive`（自动创建）\n"
 "`fmt::Debug` 实现。但这对 `fmt::Display` 不适用，后者必须手动实现。"
 
 #: src/hello/print/print_debug.md:13
@@ -1468,48 +1466,44 @@ msgid ""
 "// This structure cannot be printed either with `fmt::Display` or\n"
 "// with `fmt::Debug`.\n"
 msgstr ""
-"// 这个结构体既不能用 `fmt::Display` 打印\n"
-"// 也不能用 `fmt::Debug` 打印。\n"
+"// 这个结构体无法通过 `fmt::Display` 或 `fmt::Debug` 打印。\n"
 
 #: src/hello/print/print_debug.md:16
 msgid ""
 "// The `derive` attribute automatically creates the implementation\n"
 "// required to make this `struct` printable with `fmt::Debug`.\n"
 msgstr ""
-"// `derive` 属性自动创建所需的实现\n"
-"// 使这个 `struct` 可以用 `fmt::Debug` 打印。\n"
+"// `derive` 属性自动创建使这个 `struct` 可以用 `fmt::Debug` 打印的实现。\n"
 
 #: src/hello/print/print_debug.md:23
 msgid "All `std` library types are automatically printable with `{:?}` too:"
-msgstr "所有 `std` 库类型也可以自动用 `{:?}` 打印："
+msgstr "所有 `std` 库类型也可以自动使用 `{:?}` 打印："
 
 #: src/hello/print/print_debug.md:26
 msgid ""
 "// Derive the `fmt::Debug` implementation for `Structure`. `Structure`\n"
 "// is a structure which contains a single `i32`.\n"
 msgstr ""
-"// 为 `Structure` 派生 `fmt::Debug` 实现。`Structure`\n"
-"// 是一个包含单个 `i32` 的结构体。\n"
+"// 为 `Structure` 派生 `fmt::Debug` 实现。`Structure` 是一个包含单个 `i32` 的结构体。\n"
 
 #: src/hello/print/print_debug.md:30
 msgid ""
 "// Put a `Structure` inside of the structure `Deep`. Make it printable\n"
 "// also.\n"
 msgstr ""
-"// 将一个 `Structure` 放在 `Deep` 结构体内。也让它可打印。\n"
-"\n"
+"// 在 `Deep` 结构体中放入一个 `Structure`。使其也可打印。\n"
 
 #: src/hello/print/print_debug.md:37
 msgid "// Printing with `{:?}` is similar to with `{}`.\n"
-msgstr "// 用 `{:?}` 打印类似于用 `{}`。\n"
+msgstr "// 使用 `{:?}` 打印类似于使用 `{}`。\n"
 
 #: src/hello/print/print_debug.md:38
 msgid "\"{:?} months in a year.\""
-msgstr "\"{:?} months in a year.\""
+msgstr "\"{:?} 个月在一年中。\""
 
 #: src/hello/print/print_debug.md:39
 msgid "\"{1:?} {0:?} is the {actor:?} name.\""
-msgstr "\"{1:?} {0:?} is the {actor:?} name.\""
+msgstr "\"{1:?} {0:?} 是这个 {actor:?} 的名字。\""
 
 #: src/hello/print/print_debug.md:40
 msgid "\"Slater\""
@@ -1521,31 +1515,31 @@ msgstr "\"Christian\""
 
 #: src/hello/print/print_debug.md:42
 msgid "\"actor's\""
-msgstr "\"actor's\""
+msgstr "\"演员\""
 
 #: src/hello/print/print_debug.md:44
 msgid "// `Structure` is printable!\n"
-msgstr "// `Structure` is printable!\n"
+msgstr "// `Structure` 现在可以打印了！\n"
 
 #: src/hello/print/print_debug.md:45 src/hello/print/print_debug.md:49
 msgid "\"Now {:?} will print!\""
-msgstr "\"Now {:?} will print!\""
+msgstr "\"现在 {:?} 将会打印！\""
 
 #: src/hello/print/print_debug.md:47
 msgid ""
 "// The problem with `derive` is there is no control over how\n"
 "    // the results look. What if I want this to just show a `7`?\n"
 msgstr ""
-"// `derive` 的问题是无法控制输出的形式\n"
-"    // 假如我只想显示一个 `7` 怎么办？\n"
+"// `derive` 的问题是无法控制输出的样式。\n"
+"    // 如果我只想显示一个 `7` 怎么办？\n"
 
 #: src/hello/print/print_debug.md:53
 msgid ""
 "So `fmt::Debug` definitely makes this printable but sacrifices some elegance. "
 "Rust also provides \"pretty printing\" with `{:#?}`."
 msgstr ""
-"所以 `fmt::Debug` 确实使其可打印，但牺牲了一些优雅。"
-"Rust 还提供了使用 `{:#?}` 的"美化打印"。"
+"所以 `fmt::Debug` 确实使其可打印，但牺牲了一些优雅。\n"
+"Rust 还提供了使用 `{:#?}` 进行"美化打印"的功能。"
 
 #: src/hello/print/print_debug.md:64 src/custom_types/structs.md:42
 msgid "\"Peter\""
@@ -1561,7 +1555,7 @@ msgstr "\"{:#?}\""
 
 #: src/hello/print/print_debug.md:73
 msgid "One can manually implement `fmt::Display` to control the display."
-msgstr "可以手动实现 `fmt::Display` 来控制显示。"
+msgstr "可以手动实现 `fmt::Display` 来控制显示方式。"
 
 #: src/hello/print/print_debug.md:77
 msgid ""
@@ -1569,8 +1563,8 @@ msgid ""
 "[`derive`](../../trait/derive.md), [`std::fmt`](https://doc.rust-lang.org/std/"
 "fmt/), and [`struct`](../../custom_types/structs.md)"
 msgstr ""
-"[`attributes`](https://doc.rust-lang.org/reference/attributes.html)、"
-"[`derive`](../../trait/derive.md)、[`std::fmt`](https://doc.rust-lang.org/std/fmt/) "
+"[`attributes`](https://doc.rust-lang.org/reference/attributes.html)、\n"
+"[`derive`](../../trait/derive.md)、[`std::fmt`](https://doc.rust-lang.org/std/fmt/) \n"
 "和 [`struct`](../../custom_types/structs.md)"
 
 #: src/hello/print/print_display.md:3
@@ -1580,32 +1574,32 @@ msgid ""
 "Display`](https://doc.rust-lang.org/std/fmt/), which uses the `{}` print "
 "marker. Implementing it looks like this:"
 msgstr ""
-"`fmt::Debug` 看起来并不简洁美观，因此通常需要进一步自定义输出的形式。"
-"这可以通过手动实现 [`fmt::Display`](https://doc.rust-lang.org/std/fmt/) 来完成，"
-"它使用 `{}` 打印标记。实现方式看起来像这样："
+"`fmt::Debug` 的输出往往不够简洁清晰，因此自定义输出外观通常更有优势。\n"
+"这可以通过手动实现 [`fmt::Display`](https://doc.rust-lang.org/std/fmt/) 来完成，\n"
+"它使用 `{}` 打印标记。实现方式如下："
 
 #: src/hello/print/print_display.md:9
 msgid "// Import (via `use`) the `fmt` module to make it available.\n"
-msgstr "// 导入（通过 `use`）`fmt` 模块使其可用。\n"
+msgstr "// 通过 `use` 导入 `fmt` 模块使其可用。\n"
 
 #: src/hello/print/print_display.md:11
 msgid ""
 "// Define a structure for which `fmt::Display` will be implemented. This is\n"
 "// a tuple struct named `Structure` that contains an `i32`.\n"
 msgstr ""
-"// 定义一个结构体，我们将为它实现 `fmt::Display`。这是一个包含\n"
-"// 单个 `i32` 的元组结构体，名为 `Structure`。\n"
+"// 定义一个结构体，我们将为其实现 `fmt::Display`。\n"
+"// 这是一个名为 `Structure` 的元组结构体，包含一个 `i32`。\n"
 
 #: src/hello/print/print_display.md:15
 msgid ""
 "// To use the `{}` marker, the trait `fmt::Display` must be implemented\n"
 "// manually for the type.\n"
 msgstr ""
-"// 为了使用 `{}` 标记，必须手动为类型实现 `fmt::Display` trait。\n"
+"// 要使用 `{}` 标记，必须为该类型手动实现 `fmt::Display` trait。\n"
 
 #: src/hello/print/print_display.md:19
 msgid "// This trait requires `fmt` with this exact signature.\n"
-msgstr "// 这个 trait 要求 `fmt` 使用与此完全一致的函数签名。\n"
+msgstr "// 这个 trait 要求 `fmt` 方法具有确切的签名。\n"
 
 #: src/hello/print/print_display.md:21
 msgid ""
@@ -1615,9 +1609,9 @@ msgid ""
 "which\n"
 "        // is very similar to `println!`.\n"
 msgstr ""
-"// 将第一个元素写入到提供的输出流 `f` 中。\n"
-"        // 返回 `fmt::Result`，指示操作是否成功。\n"
-"        // 注意 `write!` 的用法和 `println!` 非常相似。\n"
+"// 将第一个元素严格写入提供的输出流 `f`。\n"
+"        // 返回 `fmt::Result`，表示操作是否成功。\n"
+"        // 注意 `write!` 的语法与 `println!` 非常相似。\n"
 
 #: src/hello/print/print_display.md:25
 #: src/hello/print/print_display/testcase_list.md:13
@@ -2293,7 +2287,7 @@ msgstr "// `let` 可以用来把元组的成员绑定到变量。\n"
 
 #: src/primitives/tuples.md:16
 msgid "// The following struct is for the activity.\n"
-msgstr "// 在 “动手试一试” 的练习中要用到下面这个结构体。\n"
+msgstr "// 以下结构体将用于后续练习。\n"
 
 #: src/primitives/tuples.md:22
 msgid "// A tuple with a bunch of different types.\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -5214,7 +5214,7 @@ msgstr ""
 
 #: src/fn/methods.md:67
 msgid "// `Pair` owns resources: two heap allocated integers\n"
-msgstr "// `Pair` 拥有资源：两个堆分配的整数\n"
+msgstr "// `Pair` 持有资源：两个堆分配的整数\n"
 
 #: src/fn/methods.md:72
 msgid ""
@@ -8515,6 +8515,7 @@ msgid ""
 "is, they indicate to the compiler when borrows are valid, when resources can "
 "be freed, and when variables are created or destroyed."
 msgstr ""
+"作用域在所有权、借用和生命周期中扮演着重要的角色。它们向编译器指示何时借用是有效的，何时资源可以被释放，以及何时变量被创建或销毁。"
 
 #: src/scope/raii.md:3
 msgid ""
@@ -8524,6 +8525,7 @@ msgid ""
 "(Resource Acquisition Is Initialization), so whenever an object goes out of "
 "scope, its destructor is called and its owned resources are freed."
 msgstr ""
+"Rust 中的变量不只是在栈上保存数据：它们还**持有**资源，例如 `Box<T>` 持有堆上的内存。Rust 强制执行 [RAII](https://en.wikipedia.org/wiki/Resource_Acquisition_Is_Initialization)（资源获取即初始化），因此每当一个对象离开作用域时，它的析构函数就会被调用，它持有的资源就会被释放。"
 
 #: src/scope/raii.md:8
 msgid ""
@@ -8531,50 +8533,54 @@ msgid ""
 "manually free memory or worry about memory leaks again! Here's a quick "
 "showcase:"
 msgstr ""
+"这种行为可以防止**资源泄漏**的错误，所以你再也不用手动释放内存或担心内存泄漏了！这是一个简单示例："
 
 #: src/scope/raii.md:12
 msgid "// raii.rs\n"
-msgstr ""
+msgstr "// raii.rs\n"
 
 #: src/scope/raii.md:14 src/scope/raii.md:21 src/scope/raii.md:26
 msgid "// Allocate an integer on the heap\n"
-msgstr ""
+msgstr "// 在堆上分配一个整数\n"
 
 #: src/scope/raii.md:17
 msgid "// `_box1` is destroyed here, and memory gets freed\n"
-msgstr ""
+msgstr "// `_box1` 在这里被销毁，内存被释放\n"
 
 #: src/scope/raii.md:24
 msgid "// A nested scope:\n"
-msgstr ""
+msgstr "// 一个嵌套的作用域：\n"
 
 #: src/scope/raii.md:29
 msgid "// `_box3` is destroyed here, and memory gets freed\n"
-msgstr ""
+msgstr "// `_box3` 在这里被销毁，内存被释放\n"
 
 #: src/scope/raii.md:32
 msgid ""
 "// Creating lots of boxes just for fun\n"
 "    // There's no need to manually free memory!\n"
 msgstr ""
+"// 创建很多 box（只是为了好玩）\n"
+"    // 不需要手动释放内存！\n"
 
 #: src/scope/raii.md:38
 msgid "// `_box2` is destroyed here, and memory gets freed\n"
-msgstr ""
+msgstr "// `_box2` 在这里被销毁，内存被释放\n"
 
 #: src/scope/raii.md:42
 msgid ""
 "Of course, we can double check for memory errors using [`valgrind`](http://"
 "valgrind.org/info/):"
 msgstr ""
+"当然，我们可以使用 [`valgrind`](http://valgrind.org/info/) 来再次检查内存错误："
 
 #: src/scope/raii.md:65
 msgid "No leaks here!"
-msgstr ""
+msgstr "没有泄漏！"
 
 #: src/scope/raii.md:67
 msgid "Destructor"
-msgstr ""
+msgstr "析构函数"
 
 #: src/scope/raii.md:69
 msgid ""
@@ -8584,6 +8590,7 @@ msgid ""
 "implemented for every type, only implement it for your type if you require "
 "its own destructor logic."
 msgstr ""
+"Rust 中析构函数的概念是通过 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 提供的。当资源离开作用域时，析构函数被调用。并不是每种类型都需要实现这个 trait，只有当你需要为自己的类型实现析构函数逻辑时才需要实现它。"
 
 #: src/scope/raii.md:74
 msgid ""
@@ -8591,18 +8598,19 @@ msgid ""
 "ops/trait.Drop.html) trait works. When the variable in the `main` function "
 "goes out of scope the custom destructor will be invoked."
 msgstr ""
+"运行下面的例子来看看 [`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 是如何工作的。当 `main` 函数中的变量离开作用域时，自定义的析构函数将被调用。"
 
 #: src/scope/raii.md:82
 msgid "\"ToDrop is being dropped\""
-msgstr ""
+msgstr "\"ToDrop 被丢弃了\""
 
 #: src/scope/raii.md:88
 msgid "\"Made a ToDrop!\""
-msgstr ""
+msgstr "\"创建了一个 ToDrop！\""
 
 #: src/scope/raii.md:94
 msgid "[Box](../std/box.md)"
-msgstr ""
+msgstr "[Box](../std/box.md)"
 
 #: src/scope/move.md:3
 msgid ""
@@ -8611,6 +8619,7 @@ msgid ""
 "once. Note that not all variables own resources (e.g. [references](../"
 "flow_control/match/destructuring/destructure_pointers.md))."
 msgstr ""
+"因为变量负责释放它们持有的资源，**资源只能有一个所有者**。这可以防止资源被多次释放。注意并不是所有的变量都持有资源（例如 [引用](../flow_control/match/destructuring/destructure_pointers.md)）。"
 
 #: src/scope/move.md:8
 msgid ""
@@ -8618,52 +8627,54 @@ msgid ""
 "(`foo(x)`), the _ownership_ of the resources is transferred. In Rust-speak, "
 "this is known as a _move_."
 msgstr ""
+"当进行赋值（`let x = y`）或按值传递函数参数（`foo(x)`）时，资源的**所有权**会被转移。在 Rust 中，这被称为**移动**（move）。"
 
 #: src/scope/move.md:12
 msgid ""
 "After moving resources, the previous owner can no longer be used. This avoids "
 "creating dangling pointers."
 msgstr ""
+"在移动资源之后，之前的所有者就不能再被使用了。这避免了悬垂指针的产生。"
 
 #: src/scope/move.md:16
 msgid "// This function takes ownership of the heap allocated memory\n"
-msgstr ""
+msgstr "// 这个函数获取堆分配内存的所有权\n"
 
 #: src/scope/move.md:18
 msgid "\"Destroying a box that contains {}\""
-msgstr ""
+msgstr "\"销毁一个包含 {} 的 box\""
 
 #: src/scope/move.md:20
 msgid "// `c` is destroyed and the memory freed\n"
-msgstr ""
+msgstr "// `c` 被销毁并且内存被释放\n"
 
 #: src/scope/move.md:24
 msgid "// _Stack_ allocated integer\n"
-msgstr ""
+msgstr "// 「栈」分配的整数\n"
 
 #: src/scope/move.md:27
 msgid "// *Copy* `x` into `y` - no resources are moved\n"
-msgstr ""
+msgstr "// 将 `x` *复制*到 `y` - 没有资源被移动\n"
 
 #: src/scope/move.md:30
 msgid "// Both values can be independently used\n"
-msgstr ""
+msgstr "// 两个值可以独立使用\n"
 
 #: src/scope/move.md:31
 msgid "\"x is {}, and y is {}\""
-msgstr ""
+msgstr "\"x 是 {}，y 是 {}\""
 
 #: src/scope/move.md:33
 msgid "// `a` is a pointer to a _heap_ allocated integer\n"
-msgstr ""
+msgstr "// `a` 是一个指向「堆」分配的整数的指针\n"
 
 #: src/scope/move.md:36
 msgid "\"a contains: {}\""
-msgstr ""
+msgstr "\"a 包含：{}\""
 
 #: src/scope/move.md:38
 msgid "// *Move* `a` into `b`\n"
-msgstr ""
+msgstr "// 将 `a` *移动* 到 `b`\n"
 
 #: src/scope/move.md:40
 msgid ""
@@ -8671,6 +8682,9 @@ msgid ""
 "    // Both are now pointers to the same heap allocated data, but\n"
 "    // `b` now owns it.\n"
 msgstr ""
+"// 把 `a` 的指针地址（而不是数据）复制到 `b`。\n"
+"    // 现在两者都是指向同一个堆分配数据的指针，但是\n"
+"    // `b` 现在持有它。\n"
 
 #: src/scope/move.md:44
 msgid ""
@@ -8679,10 +8693,13 @@ msgid ""
 "    //println!(\"a contains: {}\", a);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！`a` 不能再访问数据，因为它不再持有堆内存\n"
+"    //println!(\"a contains: {}\", a);\n"
+"    // TODO ^ 试着取消注释这一行\n"
 
 #: src/scope/move.md:49
 msgid "// This function takes ownership of the heap allocated memory from `b`\n"
-msgstr ""
+msgstr "// 这个函数从 `b` 获取堆分配内存的所有权\n"
 
 #: src/scope/move.md:52
 msgid ""
@@ -8693,36 +8710,43 @@ msgid ""
 "    //println!(\"b contains: {}\", b);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 由于堆内存在这一点已经被释放，这个操作会导致解引用已释放的内存，\n"
+"    // 但这被编译器禁止\n"
+"    // 错误！原因与前面的错误相同\n"
+"    //println!(\"b contains: {}\", b);\n"
+"    // TODO ^ 试着取消注释这一行\n"
 
 #: src/scope/move/mut.md:3
 msgid "Mutability of data can be changed when ownership is transferred."
-msgstr ""
+msgstr "当所有权被转移时，数据的可变性可以被改变。"
 
 #: src/scope/move/mut.md:9
 msgid "\"immutable_box contains {}\""
-msgstr ""
+msgstr "\"immutable_box 包含 {}\""
 
 #: src/scope/move/mut.md:11
 msgid ""
 "// Mutability error\n"
 "    //*immutable_box = 4;\n"
 msgstr ""
+"// 可变性错误\n"
+"    //*immutable_box = 4;\n"
 
 #: src/scope/move/mut.md:14
 msgid "// *Move* the box, changing the ownership (and mutability)\n"
-msgstr ""
+msgstr "// *移动* box，改变所有权（和可变性）\n"
 
 #: src/scope/move/mut.md:17
 msgid "\"mutable_box contains {}\""
-msgstr ""
+msgstr "\"mutable_box 包含 {}\""
 
 #: src/scope/move/mut.md:19
 msgid "// Modify the contents of the box\n"
-msgstr ""
+msgstr "// 修改 box 的内容\n"
 
 #: src/scope/move/mut.md:22
 msgid "\"mutable_box now contains {}\""
-msgstr ""
+msgstr "\"mutable_box 现在包含 {}\""
 
 #: src/scope/move/partial_move.md:3
 msgid ""
@@ -8734,33 +8758,37 @@ msgid ""
 "a whole, however the parts that are only referenced (and not moved) can still "
 "be used."
 msgstr ""
+"在对单个变量进行[解构](../../flow_control/match/destructuring.md)时，可以同时使用 `by-move` 和 `by-reference` 模式绑定。这样做会导致变量的**部分移动**，这意味着变量的一部分会被移动，而其他部分保持不变。在这种情况下，父级变量之后不能作为一个整体使用，但是仍然可以使用只被引用（而不是被移动）的部分。"
 
 #: src/scope/move/partial_move.md:24
 msgid "// `name` is moved out of person, but `age` is referenced\n"
-msgstr ""
+msgstr "// `name` 从 person 中被移出，但 `age` 只是被引用\n"
 
 #: src/scope/move/partial_move.md:27
 msgid "\"The person's age is {}\""
-msgstr ""
+msgstr "\"此人的年龄是 {}\""
 
 #: src/scope/move/partial_move.md:29
 msgid "\"The person's name is {}\""
-msgstr ""
+msgstr "\"此人的名字是 {}\""
 
 #: src/scope/move/partial_move.md:31
 msgid ""
 "// Error! borrow of partially moved value: `person` partial move occurs\n"
 "    //println!(\"The person struct is {:?}\", person);\n"
 msgstr ""
+"// 错误！借用了部分移动的值：`person` 发生了部分移动\n"
+"    //println!(\"此人的结构体是 {:?}\", person);\n"
 
 #: src/scope/move/partial_move.md:34
 msgid ""
 "// `person` cannot be used but `person.age` can be used as it is not moved\n"
 msgstr ""
+"// `person` 不能被使用，但 `person.age` 可以使用，因为它没有被移动\n"
 
 #: src/scope/move/partial_move.md:35
 msgid "\"The person's age from person struct is {}\""
-msgstr ""
+msgstr "\"从 person 结构体中获取的此人年龄是 {}\""
 
 #: src/scope/move/partial_move.md:38
 msgid ""
@@ -8770,10 +8798,11 @@ msgid ""
 "age` were stored on the stack, `ref` would not be required as the definition "
 "of `age` would copy the data from `person.age` without moving it.)"
 msgstr ""
+"（在这个例子中，我们将 `age` 变量存储在堆上以说明部分移动：删除上面代码中的 `ref` 会导致错误，因为 `person.age` 的所有权会被移动到变量 `age`。如果 `Person.age` 存储在栈上，就不需要 `ref`，因为 `age` 的定义会从 `person.age` 复制数据而不是移动它。）"
 
 #: src/scope/move/partial_move.md:46
 msgid "[destructuring](../../flow_control/match/destructuring.md)"
-msgstr ""
+msgstr "[解构](../../flow_control/match/destructuring.md)"
 
 #: src/scope/borrow.md:3
 msgid ""
@@ -8781,6 +8810,7 @@ msgid ""
 "To accomplish this, Rust uses a _borrowing_ mechanism. Instead of passing "
 "objects by value (`T`), objects can be passed by reference (`&T`)."
 msgstr ""
+"大多数情况下，我们希望访问数据而不获取其所有权。为了实现这一点，Rust 使用了**借用**机制。对象可以通过引用（`&T`）传递，而不是按值（`T`）传递。"
 
 #: src/scope/borrow.md:7
 msgid ""
@@ -8788,22 +8818,23 @@ msgid ""
 "_always_ point to valid objects. That is, while references to an object "
 "exist, the object cannot be destroyed."
 msgstr ""
+"编译器通过其借用检查器静态地保证引用**始终**指向有效的对象。也就是说，当存在引用指向一个对象时，该对象就不能被销毁。"
 
 #: src/scope/borrow.md:12
 msgid "// This function takes ownership of a box and destroys it\n"
-msgstr ""
+msgstr "// 这个函数获取一个 box 的所有权并销毁它\n"
 
 #: src/scope/borrow.md:14
 msgid "\"Destroying box that contains {}\""
-msgstr ""
+msgstr "\"销毁包含 {} 的 box\""
 
 #: src/scope/borrow.md:16
 msgid "// This function borrows an i32\n"
-msgstr ""
+msgstr "// 这个函数借用一个 i32\n"
 
 #: src/scope/borrow.md:19
 msgid "\"This int is: {}\""
-msgstr ""
+msgstr "\"这个整数是：{}\""
 
 #: src/scope/borrow.md:23
 msgid ""
@@ -8812,16 +8843,21 @@ msgid ""
 "readability\n"
 "    // 5_i32 is the same as 5i32\n"
 msgstr ""
+"// 在堆上创建一个装箱的 i32，在栈上创建一个 i32\n"
+"    // 注：数字可以添加任意下划线以提高可读性\n"
+"    // 5_i32 与 5i32 相同\n"
 
 #: src/scope/borrow.md:29
 msgid ""
 "// Borrow the contents of the box. Ownership is not taken,\n"
 "    // so the contents can be borrowed again.\n"
 msgstr ""
+"// 借用 box 的数据。所有权未被获取，\n"
+"    // 所以数据可以再次被借用。\n"
 
 #: src/scope/borrow.md:35
 msgid "// Take a reference to the data contained inside the box\n"
-msgstr ""
+msgstr "// 获取 box 内数据的引用\n"
 
 #: src/scope/borrow.md:38
 msgid ""
@@ -8829,19 +8865,22 @@ msgid ""
 "        // Can't destroy `boxed_i32` while the inner value is borrowed later "
 "in scope.\n"
 msgstr ""
+"// 错误！\n"
+"        // 当内部值在作用域内稍后被借用时，不能销毁 `boxed_i32`。\n"
 
 #: src/scope/borrow.md:43
 msgid "// Attempt to borrow `_ref_to_i32` after inner value is destroyed\n"
-msgstr ""
+msgstr "// 尝试在内部值被销毁后借用 `_ref_to_i32`\n"
 
 #: src/scope/borrow.md:45
 msgid "// `_ref_to_i32` goes out of scope and is no longer borrowed.\n"
-msgstr ""
+msgstr "// `_ref_to_i32` 超出作用域，不再被借用。\n"
 
 #: src/scope/borrow.md:48
 msgid ""
 "// `boxed_i32` can now give up ownership to `eat_box_i32` and be destroyed\n"
 msgstr ""
+"// `boxed_i32` 现在可以将所有权交给 `eat_box_i32` 并被销毁\n"
 
 #: src/scope/borrow/mut.md:3
 msgid ""
@@ -8850,69 +8889,72 @@ msgid ""
 "`&T` borrows the data via an immutable reference, and the borrower can read "
 "the data but not modify it:"
 msgstr ""
+"可变数据可以使用 `&mut T` 进行可变借用。这被称为**可变引用**，并给予借用者读/写访问权。相比之下，`&T` 通过不可变引用借用数据，借用者可以读取数据但不能修改它："
 
 #: src/scope/borrow/mut.md:12
 msgid ""
 "// `&'static str` is a reference to a string allocated in read only memory\n"
 msgstr ""
+"// `&'static str` 是对分配在只读内存中的字符串的引用\n"
 
 #: src/scope/borrow/mut.md:17
 msgid "// This function takes a reference to a book\n"
-msgstr ""
+msgstr "// 这个函数接受一个对 Book 类型数据的引用\n"
 
 #: src/scope/borrow/mut.md:20
 msgid "\"I immutably borrowed {} - {} edition\""
-msgstr ""
+msgstr "\"我不可变地借用了 {} - {} 版\""
 
 #: src/scope/borrow/mut.md:22
 msgid ""
 "// This function takes a reference to a mutable book and changes `year` to "
 "2014\n"
 msgstr ""
+"// 这个函数接受一个对可变书的引用，并将 `year` 改为 2014\n"
 
 #: src/scope/borrow/mut.md:26
 msgid "\"I mutably borrowed {} - {} edition\""
-msgstr ""
+msgstr "\"我可变地借用了 {} - {} 版\""
 
 #: src/scope/borrow/mut.md:30
 msgid "// Create an immutable Book named `immutabook`\n"
-msgstr ""
+msgstr "// 创建一个名为 `immutabook` 的不可变 Book\n"
 
 #: src/scope/borrow/mut.md:32
 msgid "// string literals have type `&'static str`\n"
-msgstr ""
+msgstr "// 字符串字面量的类型是 `&'static str`\n"
 
 #: src/scope/borrow/mut.md:33
 msgid "\"Douglas Hofstadter\""
-msgstr ""
+msgstr "\"Douglas Hofstadter\""
 
 #: src/scope/borrow/mut.md:34
 msgid "\"Gödel, Escher, Bach\""
-msgstr ""
+msgstr "\"Gödel, Escher, Bach\""
 
 #: src/scope/borrow/mut.md:38
 msgid "// Create a mutable copy of `immutabook` and call it `mutabook`\n"
-msgstr ""
+msgstr "// 创建 `immutabook` 的一个可变副本，并将其命名为 `mutabook`\n"
 
 #: src/scope/borrow/mut.md:41
 msgid "// Immutably borrow an immutable object\n"
-msgstr ""
+msgstr "// 不可变地借用一个不可变对象\n"
 
 #: src/scope/borrow/mut.md:44
 msgid "// Immutably borrow a mutable object\n"
-msgstr ""
+msgstr "// 不可变地借用一个可变对象\n"
 
 #: src/scope/borrow/mut.md:47
 msgid "// Borrow a mutable object as mutable\n"
-msgstr ""
+msgstr "// 可变地借用一个可变对象\n"
 
 #: src/scope/borrow/mut.md:50
 msgid "// Error! Cannot borrow an immutable object as mutable\n"
-msgstr ""
+msgstr "// 错误！不能可变地借用一个不可变对象\n"
 
 #: src/scope/borrow/mut.md:57
 msgid "[`static`](../lifetime/static_lifetime.md)"
-msgstr ""
+msgstr "[`static`](../lifetime/static_lifetime.md)"
 
 #: src/scope/borrow/alias.md:3
 msgid ""
@@ -8922,15 +8964,16 @@ msgid ""
 "borrowed again only _after_ the mutable reference has been used for the last "
 "time."
 msgstr ""
+"数据可以被不可变地借用任意次数，但在不可变借用期间，原始数据不能被可变地借用。另一方面，同一时间只允许**一个**可变借用。只有在可变引用最后一次使用之后，原始数据才能再次被借用。"
 
 #: src/scope/borrow/alias.md:17
 msgid "// Data can be accessed via the references and the original owner\n"
-msgstr ""
+msgstr "// 可以通过引用和原始所有者访问数据\n"
 
 #: src/scope/borrow/alias.md:18 src/scope/borrow/alias.md:27
 #: src/scope/borrow/alias.md:49
 msgid "\"Point has coordinates: ({}, {}, {})\""
-msgstr ""
+msgstr "\"Point has coordinates: ({}, {}, {})\""
 
 #: src/scope/borrow/alias.md:21
 msgid ""
@@ -8939,20 +8982,25 @@ msgid ""
 "    // let mutable_borrow = &mut point;\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！不能将 `point` 作为可变借用，因为它当前被不可变借用。\n"
+"    // let mutable_borrow = &mut point;\n"
+"    // TODO ^ 尝试取消注释此行\n"
 
 #: src/scope/borrow/alias.md:26
 msgid "// The borrowed values are used again here\n"
-msgstr ""
+msgstr "// 这里再次使用了借用的值\n"
 
 #: src/scope/borrow/alias.md:30
 msgid ""
 "// The immutable references are no longer used for the rest of the code so\n"
 "    // it is possible to reborrow with a mutable reference.\n"
 msgstr ""
+"// 不可变引用在代码的剩余部分不再使用\n"
+"    // 所以可以用可变引用重新借用。\n"
 
 #: src/scope/borrow/alias.md:34
 msgid "// Change data via mutable reference\n"
-msgstr ""
+msgstr "// 通过可变引用改变数据\n"
 
 #: src/scope/borrow/alias.md:39
 msgid ""
@@ -8961,6 +9009,9 @@ msgid ""
 "    // let y = &point.y;\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！不能将 `point` 作为不可变借用，因为它当前被可变借用。\n"
+"    // let y = &point.y;\n"
+"    // TODO ^ 尝试取消注释此行\n"
 
 #: src/scope/borrow/alias.md:44
 msgid ""
@@ -8968,20 +9019,24 @@ msgid ""
 "    // println!(\"Point Z coordinate is {}\", point.z);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！不能打印，因为 `println!` 用到了一个不可变引用。\n"
+"    // println!(\"Point Z coordinate is {}\", point.z);\n"
+"    // TODO ^ 尝试取消注释此行\n"
 
 #: src/scope/borrow/alias.md:48
 msgid "// Ok! Mutable references can be passed as immutable to `println!`\n"
-msgstr ""
+msgstr "// 可以！可变引用可以作为不可变引用传递给 `println!`\n"
 
 #: src/scope/borrow/alias.md:52
 msgid ""
 "// The mutable reference is no longer used for the rest of the code so it\n"
 "    // is possible to reborrow\n"
 msgstr ""
+"// 可变引用在代码的剩余部分不再使用，所以可以重新借用\n"
 
 #: src/scope/borrow/alias.md:55
 msgid "\"Point now has coordinates: ({}, {}, {})\""
-msgstr ""
+msgstr "\"Point now has coordinates: ({}, {}, {})\""
 
 #: src/scope/borrow/ref.md:3
 msgid ""
@@ -8989,60 +9044,62 @@ msgid ""
 "keyword can be used to take references to the fields of a struct/tuple. The "
 "example below shows a few instances where this can be useful:"
 msgstr ""
+"在通过 `let` 绑定进行模式匹配或解构时，可以使用 `ref` 关键字来获取结构体/元组字段的引用。下面的例子展示了几个这种用法有用的情况："
 
 #: src/scope/borrow/ref.md:14
 msgid ""
 "// A `ref` borrow on the left side of an assignment is equivalent to\n"
 "    // an `&` borrow on the right side.\n"
 msgstr ""
+"// 赋值左侧的 `ref` 借用等同于右侧的 `&` 借用。\n"
 
 #: src/scope/borrow/ref.md:19
 msgid "\"ref_c1 equals ref_c2: {}\""
-msgstr ""
+msgstr "\"ref_c1 equals ref_c2: {}\""
 
 #: src/scope/borrow/ref.md:23
 msgid "// `ref` is also valid when destructuring a struct.\n"
-msgstr ""
+msgstr "// 在解构结构体时，`ref` 也是有效的。\n"
 
 #: src/scope/borrow/ref.md:25
 msgid "// `ref_to_x` is a reference to the `x` field of `point`.\n"
-msgstr ""
+msgstr "// `ref_to_x` 是 `point` 的 `x` 字段的引用。\n"
 
 #: src/scope/borrow/ref.md:28
 msgid "// Return a copy of the `x` field of `point`.\n"
-msgstr ""
+msgstr "// 返回 `point` 的 `x` 字段的拷贝。\n"
 
 #: src/scope/borrow/ref.md:32
 msgid "// A mutable copy of `point`\n"
-msgstr ""
+msgstr "// `point` 的可变拷贝\n"
 
 #: src/scope/borrow/ref.md:36
 msgid "// `ref` can be paired with `mut` to take mutable references.\n"
-msgstr ""
+msgstr "// `ref` 可以与 `mut` 配对来获取可变引用。\n"
 
 #: src/scope/borrow/ref.md:39
 msgid "// Mutate the `y` field of `mutable_point` via a mutable reference.\n"
-msgstr ""
+msgstr "// 通过可变引用修改 `mutable_point` 的 `y` 字段。\n"
 
 #: src/scope/borrow/ref.md:43
 msgid "\"point is ({}, {})\""
-msgstr ""
+msgstr "\"point is ({}, {})\""
 
 #: src/scope/borrow/ref.md:44
 msgid "\"mutable_point is ({}, {})\""
-msgstr ""
+msgstr "\"mutable_point is ({}, {})\""
 
 #: src/scope/borrow/ref.md:46
 msgid "// A mutable tuple that includes a pointer\n"
-msgstr ""
+msgstr "// 包含指针的可变元组\n"
 
 #: src/scope/borrow/ref.md:50
 msgid "// Destructure `mutable_tuple` to change the value of `last`.\n"
-msgstr ""
+msgstr "// 解构 `mutable_tuple` 以改变 `last` 的值。\n"
 
 #: src/scope/borrow/ref.md:55
 msgid "\"tuple is {:?}\""
-msgstr ""
+msgstr "\"tuple is {:?}\""
 
 #: src/scope/lifetime.md:3
 msgid ""
@@ -9051,6 +9108,7 @@ msgid ""
 "lifetime begins when it is created and ends when it is destroyed. While "
 "lifetimes and scopes are often referred to together, they are not the same."
 msgstr ""
+"**生命周期**是编译器（更具体地说是其**借用检查器**）用来确保所有借用都是有效的一个构造。具体来说，变量的生命周期从创建时开始，到销毁时结束。虽然生命周期和作用域经常被一起提到，但它们并不相同。"
 
 #: src/scope/lifetime.md:8
 msgid ""
@@ -9059,12 +9117,14 @@ msgid ""
 "borrow is valid as long as it ends before the lender is destroyed. However, "
 "the scope of the borrow is determined by where the reference is used."
 msgstr ""
+"例如，考虑我们通过 `&` 借用一个变量的情况。借用的生命周期由其声明的位置决定。因此，只要借用在出借者被销毁之前结束，它就是有效的。然而，借用的作用域由引用使用的位置决定。"
 
 #: src/scope/lifetime.md:13
 msgid ""
 "In the following example and in the rest of this section, we will see how "
 "lifetimes relate to scopes, as well as how the two differ."
 msgstr ""
+"在下面的例子和本节的其余部分中，我们将看到生命周期如何与作用域相关，以及两者有何不同。"
 
 #: src/scope/lifetime.md:17
 msgid ""
@@ -9074,30 +9134,38 @@ msgid ""
 "// both `borrow1` and `borrow2`. The duration of `borrow1` compared \n"
 "// to `borrow2` is irrelevant since they are disjoint.\n"
 msgstr ""
+"// 下面用线条标注了每个变量的创建和销毁，以表示生命周期。\n"
+"// `i` 的生命周期最长，因为它的作用域完全包含了 `borrow1` 和 `borrow2`。\n"
+"// `borrow1` 相对于 `borrow2` 的持续时间是无关紧要的，因为它们是不相交的。\n"
+"// （译注：为避免中文的宽度显示问题，下面注释没有翻译） \n"
 
 #: src/scope/lifetime.md:23
 msgid ""
 "// Lifetime for `i` starts. ────────────────┐\n"
 "    //                                                     │\n"
 msgstr ""
+"// Lifetime for `i` starts. ────────────────┐\n"
+"    //                                                     │\n"
 
 #: src/scope/lifetime.md:25 src/scope/lifetime.md:32
 msgid "//                                                   │\n"
-msgstr ""
+msgstr "//                                                   │\n"
 
 #: src/scope/lifetime.md:26
 msgid ""
 "// `borrow1` lifetime starts. ──┐│\n"
 "        //                                                ││\n"
 msgstr ""
+"// `borrow1` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
 
 #: src/scope/lifetime.md:28
 msgid "\"borrow1: {}\""
-msgstr ""
+msgstr "\"borrow1: {}\""
 
 #: src/scope/lifetime.md:28 src/scope/lifetime.md:35
 msgid "//              ││\n"
-msgstr ""
+msgstr "//              ││\n"
 
 #: src/scope/lifetime.md:29
 msgid ""
@@ -9105,32 +9173,40 @@ msgid ""
 "    //                                                     │\n"
 "    //                                                     │\n"
 msgstr ""
+"// `borrow1` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
+"    //                                                     │\n"
 
 #: src/scope/lifetime.md:33
 msgid ""
 "// `borrow2` lifetime starts. ──┐│\n"
 "        //                                                ││\n"
 msgstr ""
+"// `borrow2` lifetime starts. ──┐│\n"
+"        //                                                ││\n"
 
 #: src/scope/lifetime.md:35
 msgid "\"borrow2: {}\""
-msgstr ""
+msgstr "\"borrow2: {}\""
 
 #: src/scope/lifetime.md:36
 msgid ""
 "// `borrow2` ends. ─────────────────────────────────┘│\n"
 "    //                                                     │\n"
 msgstr ""
+"// `borrow2` ends. ─────────────────────────────────┘│\n"
+"    //                                                     │\n"
 
 #: src/scope/lifetime.md:38
 msgid "// Lifetime ends. ─────────────────────────────────────┘\n"
-msgstr ""
+msgstr "// Lifetime ends. ─────────────────────────────────────┘\n"
 
 #: src/scope/lifetime.md:41
 msgid ""
 "Note that no names or types are assigned to label lifetimes. This restricts "
 "how lifetimes will be able to be used as we will see."
 msgstr ""
+"请注意，没有名称或类型被分配给标记生命周期。这限制了生命周期的使用方式，我们将在后面看到。"
 
 #: src/scope/lifetime/explicit.md:3
 msgid ""
@@ -9140,10 +9216,11 @@ msgid ""
 "should be. The syntax for explicitly annotating a lifetime uses an apostrophe "
 "character as follows:"
 msgstr ""
+"借用检查器使用显式生命周期注解来确定引用应该有效多长时间。在生命周期没有被省略[^1]的情况下，Rust 需要显式注解来确定引用的生命周期应该是怎样的。显式注解生命周期的语法使用撇号字符，如下所示："
 
 #: src/scope/lifetime/explicit.md:10
 msgid "// `foo` has a lifetime parameter `'a`\n"
-msgstr ""
+msgstr "// `foo` 有一个生命周期参数 `'a`\n"
 
 #: src/scope/lifetime/explicit.md:14
 msgid ""
@@ -9152,24 +9229,25 @@ msgid ""
 "lifetime of `foo` may not exceed that of `'a`. Explicit annotation of a type "
 "has the form `&'a T` where `'a` has already been introduced."
 msgstr ""
+"类似于[闭包](../../fn/closures/anonymity.md)，使用生命周期需要泛型。此外，这种生命周期语法表示 `foo` 的生命周期不能超过 `'a` 的生命周期。类型的显式注解形式为 `&'a T`，其中 `'a` 已经被引入。"
 
 #: src/scope/lifetime/explicit.md:19
 msgid "In cases with multiple lifetimes, the syntax is similar:"
-msgstr ""
+msgstr "在有多个生命周期的情况下，语法类似："
 
 #: src/scope/lifetime/explicit.md:22
 msgid "// `foo` has lifetime parameters `'a` and `'b`\n"
-msgstr ""
+msgstr "// `foo` 有生命周期参数 `'a` 和 `'b`\n"
 
 #: src/scope/lifetime/explicit.md:26
 msgid ""
 "In this case, the lifetime of `foo` cannot exceed that of either `'a` _or_ "
 "`'b`."
-msgstr ""
+msgstr "在这种情况下，`foo` 的生命周期不能超过 `'a` **或** `'b` 的生命周期。"
 
 #: src/scope/lifetime/explicit.md:28
 msgid "See the following example for explicit lifetime annotation in use:"
-msgstr ""
+msgstr "请看下面的例子，展示了显式生命周期注解的使用："
 
 #: src/scope/lifetime/explicit.md:31
 msgid ""
@@ -9177,19 +9255,22 @@ msgid ""
 "// lifetimes `'a` and `'b`. These two lifetimes must both be at\n"
 "// least as long as the function `print_refs`.\n"
 msgstr ""
+"// `print_refs` 接受两个 `i32` 的引用，它们有不同的\n"
+"// 生命周期 `'a` 和 `'b`。这两个生命周期都必须\n"
+"// 至少和函数 `print_refs` 一样长。\n"
 
 #: src/scope/lifetime/explicit.md:35
 msgid "\"x is {} and y is {}\""
-msgstr ""
+msgstr "\"x is {} and y is {}\""
 
 #: src/scope/lifetime/explicit.md:37
 msgid ""
 "// A function which takes no arguments, but has a lifetime parameter `'a`.\n"
-msgstr ""
+msgstr "// 一个没有参数但有生命周期参数 `'a` 的函数。\n"
 
 #: src/scope/lifetime/explicit.md:42
 msgid "// ERROR: `_x` does not live long enough\n"
-msgstr ""
+msgstr "// 错误：`_x` 的生命周期不够长\n"
 
 #: src/scope/lifetime/explicit.md:44
 msgid ""
@@ -9199,14 +9280,17 @@ msgid ""
 "    // than that of `_y`. A short lifetime cannot be coerced into a longer "
 "one.\n"
 msgstr ""
+"// 尝试在函数内部使用生命周期 `'a` 作为显式类型注解\n"
+"    // 会失败，因为 `&_x` 的生命周期比 `_y` 的短。\n"
+"    // 短生命周期不能被强制转换为长生命周期。\n"
 
 #: src/scope/lifetime/explicit.md:50
 msgid "// Create variables to be borrowed below.\n"
-msgstr ""
+msgstr "// 创建将要被借用的变量。\n"
 
 #: src/scope/lifetime/explicit.md:53
 msgid "// Borrows (`&`) of both variables are passed into the function.\n"
-msgstr ""
+msgstr "// 两个变量的借用（`&`）被传递给函数。\n"
 
 #: src/scope/lifetime/explicit.md:55
 msgid ""
@@ -9214,6 +9298,9 @@ msgid ""
 "    // In other words, the lifetime of `four` and `nine` must \n"
 "    // be longer than that of `print_refs`.\n"
 msgstr ""
+"// 任何被借用的输入必须比借用者存活更久。\n"
+"    // 换句话说，`four` 和 `nine` 的生命周期必须\n"
+"    // 比 `print_refs` 的生命周期更长。\n"
 
 #: src/scope/lifetime/explicit.md:60
 msgid ""
@@ -9221,31 +9308,34 @@ msgid ""
 "    // longer than the lifetime of the function, but `'a` is longer.\n"
 "    // Because the lifetime is never constrained, it defaults to `'static`.\n"
 msgstr ""
+"// `failed_borrow` 不包含任何引用来强制 `'a` 比\n"
+"    // 函数的生命周期更长，但 `'a` 确实更长。\n"
+"    // 因为生命周期从未被约束，它默认为 `'static`。\n"
 
 #: src/scope/lifetime/explicit.md:66
 msgid ""
 "[elision](elision.md) implicitly annotates lifetimes and so is different."
-msgstr ""
+msgstr "[省略](elision.md)隐式地注解生命周期，因此是不同的。"
 
 #: src/scope/lifetime/explicit.md:70
 msgid "[generics](../../generics.md) and [closures](../../fn/closures.md)"
-msgstr ""
+msgstr "[泛型](../../generics.md)和[闭包](../../fn/closures.md)"
 
 #: src/scope/lifetime/fn.md:3
 msgid ""
 "Ignoring [elision](elision.md), function signatures with lifetimes have a few "
 "constraints:"
-msgstr ""
+msgstr "排除[省略](elision.md)的情况，带有生命周期的函数签名有一些限制："
 
 #: src/scope/lifetime/fn.md:5
 msgid "any reference _must_ have an annotated lifetime."
-msgstr ""
+msgstr "任何引用**必须**有一个标注了的生命周期。"
 
 #: src/scope/lifetime/fn.md:6
 msgid ""
 "any reference being returned _must_ have the same lifetime as an input or be "
 "`static`."
-msgstr ""
+msgstr "任何被返回的引用**必须**具有与输入相同的生命周期或者是 `static`。"
 
 #: src/scope/lifetime/fn.md:9
 msgid ""
@@ -9253,20 +9343,22 @@ msgid ""
 "would result in returning references to invalid data. The following example "
 "shows off some valid forms of functions with lifetimes:"
 msgstr ""
+"此外，请注意，如果返回引用却没有输入，会导致返回无效数据的引用，这是被禁止的。以下示例展示了一些带有生命周期的函数："
 
 #: src/scope/lifetime/fn.md:14
 msgid ""
 "// One input reference with lifetime `'a` which must live\n"
 "// at least as long as the function.\n"
 msgstr ""
+"// 一个具有生命周期 `'a` 的输入引用，它的存活至少和函数一样长。\n"
 
 #: src/scope/lifetime/fn.md:17
 msgid "\"`print_one`: x is {}\""
-msgstr ""
+msgstr "\"`print_one`: x is {}\""
 
 #: src/scope/lifetime/fn.md:19
 msgid "// Mutable references are possible with lifetimes as well.\n"
-msgstr ""
+msgstr "// 可变引用也可以有生命周期。\n"
 
 #: src/scope/lifetime/fn.md:24
 msgid ""
@@ -9274,16 +9366,21 @@ msgid ""
 "// would be fine for both to have the same lifetime `'a`, but\n"
 "// in more complex cases, different lifetimes may be required.\n"
 msgstr ""
+"// 多个具有不同生命周期的元素。在这种情况下，\n"
+"// 两者都有相同的生命周期 `'a` 是可以的，但\n"
+"// 在更复杂的情况下，可能需要不同的生命周期。\n"
 
 #: src/scope/lifetime/fn.md:29
 msgid "\"`print_multi`: x is {}, y is {}\""
-msgstr ""
+msgstr "\"`print_multi`: x is {}, y is {}\""
 
 #: src/scope/lifetime/fn.md:31
 msgid ""
 "// Returning references that have been passed in is acceptable.\n"
 "// However, the correct lifetime must be returned.\n"
 msgstr ""
+"// 返回已传入的引用是可以接受的。\n"
+"// 但是，必须返回正确的生命周期。\n"
 
 #: src/scope/lifetime/fn.md:35
 msgid ""
@@ -9293,108 +9390,114 @@ msgid ""
 "// reference. Then the data is dropped upon exiting the scope, leaving\n"
 "// a reference to invalid data to be returned.\n"
 msgstr ""
+"//fn invalid_output<'a>() -> &'a String { &String::from(\"foo\") }\n"
+"// 上面的代码是无效的：`'a` 的存活时间必须比函数更长。\n"
+"// 这里的 `&String::from(\"foo\")` 会创建一个 `String`，再引用它。 \n"
+"// 然后在退出作用域时数据被丢弃，返回一个指向无效数据的引用"
 
 #: src/scope/lifetime/fn.md:60
 msgid "[Functions](../../fn.md)"
-msgstr ""
+msgstr "[函数](../../fn.md)"
 
 #: src/scope/lifetime/methods.md:3
 msgid "Methods are annotated similarly to functions:"
-msgstr ""
+msgstr "方法的注解和函数类似："
 
 #: src/scope/lifetime/methods.md:9
 msgid "// Annotate lifetimes as in a standalone function.\n"
-msgstr ""
+msgstr "// 像独立函数一样注解生命周期。\n"
 
 #: src/scope/lifetime/methods.md:12
 msgid "\"`print`: {}\""
-msgstr ""
+msgstr "\"`print`: {}\""
 
 #: src/scope/lifetime/methods.md:26
 msgid "[methods](../../fn/methods.md)"
-msgstr ""
+msgstr "[方法](../../fn/methods.md)"
 
 #: src/scope/lifetime/struct.md:3
 msgid "Annotation of lifetimes in structures are also similar to functions:"
-msgstr ""
+msgstr "结构体中生命周期的注解也和函数类似："
 
 #: src/scope/lifetime/struct.md:6
 msgid ""
 "// A type `Borrowed` which houses a reference to an\n"
 "// `i32`. The reference to `i32` must outlive `Borrowed`.\n"
 msgstr ""
+"// 一个包含 `i32` 引用的 `Borrowed` 类型。\n"
+"// 对 `i32` 的引用必须比 `Borrowed` 存活更久。\n"
 
 #: src/scope/lifetime/struct.md:10
 msgid "// Similarly, both references here must outlive this structure.\n"
-msgstr ""
+msgstr "// 同样，这里的两个引用都必须比这个结构体存活更久。\n"
 
 #: src/scope/lifetime/struct.md:17
 msgid "// An enum which is either an `i32` or a reference to one.\n"
-msgstr ""
+msgstr "// 一个枚举，表示 `i32`，或者 `i32` 的引用。\n"
 
 #: src/scope/lifetime/struct.md:34 src/scope/lifetime/struct.md:36
 msgid "\"x is borrowed in {:?}\""
-msgstr ""
+msgstr "\"x 在 {:?} 中被借用\""
 
 #: src/scope/lifetime/struct.md:35
 msgid "\"x and y are borrowed in {:?}\""
-msgstr ""
+msgstr "\"x 和 y 在 {:?} 中被借用\""
 
 #: src/scope/lifetime/struct.md:37
 msgid "\"y is *not* borrowed in {:?}\""
-msgstr ""
+msgstr "\"y 在 {:?} 中**没有**被借用\""
 
 #: src/scope/lifetime/struct.md:43
 msgid "[`struct`s](../../custom_types/structs.md)"
-msgstr ""
+msgstr "[`struct`](../../custom_types/structs.md)"
 
 #: src/scope/lifetime/trait.md:3
 msgid ""
 "Annotation of lifetimes in trait methods basically are similar to functions. "
 "Note that `impl` may have annotation of lifetimes too."
-msgstr ""
+msgstr "trait 方法中的生命周期注解基本上与函数类似。注意 `impl` 也可能有生命周期注解。"
 
 #: src/scope/lifetime/trait.md:7
 msgid "// A struct with annotation of lifetimes.\n"
-msgstr ""
+msgstr "// 一个带有生命周期注解的结构体。\n"
 
 #: src/scope/lifetime/trait.md:12
 msgid "// Annotate lifetimes to impl.\n"
-msgstr ""
+msgstr "// 为 impl 注解生命周期。\n"
 
 #: src/scope/lifetime/trait.md:24
 msgid "\"b is {:?}\""
-msgstr ""
+msgstr "\"b 是 {:?}\""
 
 #: src/scope/lifetime/trait.md:30
 msgid "[`trait`s](../../trait.md)"
-msgstr ""
+msgstr "[`trait`](../../trait.md)"
 
 #: src/scope/lifetime/lifetime_bounds.md:3
 msgid ""
 "Just like generic types can be bounded, lifetimes (themselves generic) use "
 "bounds as well. The `:` character has a slightly different meaning here, but "
 "`+` is the same. Note how the following read:"
-msgstr ""
+msgstr "就像泛型类型可以被约束一样，生命周期（本身就是泛型）也可以使用约束。这里 `:` 字符的含义略有不同，但 `+` 是相同的。注意下面说明："
 
 #: src/scope/lifetime/lifetime_bounds.md:7
 msgid "`T: 'a`: _All_ references in `T` must outlive lifetime `'a`."
-msgstr ""
+msgstr "`T: 'a`：`T` 中的**所有**引用必须比生命周期 `'a` 存活更久。"
 
 #: src/scope/lifetime/lifetime_bounds.md:8
 msgid ""
 "`T: Trait + 'a`: Type `T` must implement trait `Trait` and _all_ references "
 "in `T` must outlive `'a`."
-msgstr ""
+msgstr "`T: Trait + 'a`：类型 `T` 必须实现 trait `Trait`，并且 `T` 中的**所有**引用必须比 `'a` 存活更久。"
 
 #: src/scope/lifetime/lifetime_bounds.md:11
 msgid ""
 "The example below shows the above syntax in action used after keyword `where`:"
-msgstr ""
+msgstr "下面的例子展示了上述语法在 `where` 关键字之后的实际应用："
 
 #: src/scope/lifetime/lifetime_bounds.md:14
 msgid "// Trait to bound with.\n"
-msgstr ""
+msgstr "// 用于约束的 trait。\n"
 
 #: src/scope/lifetime/lifetime_bounds.md:17
 msgid ""
@@ -9403,14 +9506,17 @@ msgid ""
 "// *references* in `T` must outlive `'a`. Additionally, the lifetime\n"
 "// of `Ref` may not exceed `'a`.\n"
 msgstr ""
+"// `Ref` 包含一个指向泛型类型 `T` 的引用，其中 `T` 拥有一个未知的\n"
+"// 生命周期 `'a`。`T` 被约束，使得 `T` 中的任何*引用*必须\n"
+"// 比 `'a` 存活更久。此外，`Ref` 的生命周期不能超过 `'a`。\n"
 
 #: src/scope/lifetime/lifetime_bounds.md:22
 msgid "// A generic function which prints using the `Debug` trait.\n"
-msgstr ""
+msgstr "// 一个使用 `Debug` trait 进行打印的泛型函数。\n"
 
 #: src/scope/lifetime/lifetime_bounds.md:26
 msgid "\"`print`: t is {:?}\""
-msgstr ""
+msgstr "\"`print`: t 是 {:?}\""
 
 #: src/scope/lifetime/lifetime_bounds.md:28
 msgid ""
@@ -9418,16 +9524,19 @@ msgid ""
 "// `Debug` and all *references* in `T` outlive `'a`. In\n"
 "// addition, `'a` must outlive the function.\n"
 msgstr ""
+"// 这里取了一个 `T` 的引用，其中 `T` 实现了\n"
+"// `Debug` 并且 `T` 中的所有*引用*都比 `'a` 存活更久。\n"
+"// 此外，`'a` 必须比函数存活更久。\n"
 
 #: src/scope/lifetime/lifetime_bounds.md:34
 msgid "\"`print_ref`: t is {:?}\""
-msgstr ""
+msgstr "\"`print_ref`: t 是 {:?}\""
 
 #: src/scope/lifetime/lifetime_bounds.md:48
 msgid ""
 "[generics](../../generics.md), [bounds in generics](../../generics/bounds."
 "md), and [multiple bounds in generics](../../generics/multi_bounds.md)"
-msgstr ""
+msgstr "[泛型](../../generics.md)，[泛型中的约束](../../generics/bounds.md)，以及[泛型中的多重约束](../../generics/multi_bounds.md)"
 
 #: src/scope/lifetime/lifetime_coercion.md:3
 msgid ""
@@ -9435,13 +9544,15 @@ msgid ""
 "scope it normally wouldn't work in. This comes in the form of inferred "
 "coercion by the Rust compiler, and also in the form of declaring a lifetime "
 "difference:"
-msgstr ""
+msgstr "一个较长的生命周期可以被强制转换为一个较短的生命周期，以便它在通常不能工作的作用域内工作。强制转换可由编译器隐式地推导并执行，也可以通过声明不同的生命周期的形式实现："
 
 #: src/scope/lifetime/lifetime_coercion.md:9
 msgid ""
 "// Here, Rust infers a lifetime that is as short as possible.\n"
 "// The two references are then coerced to that lifetime.\n"
 msgstr ""
+"// 在这里，Rust 推断出一个尽可能短的生命周期。\n"
+"// 然后两个引用被强制转换为该生命周期。\n"
 
 #: src/scope/lifetime/lifetime_coercion.md:14
 msgid ""
@@ -9449,119 +9560,125 @@ msgid ""
 "// Here, we take in an `&'a i32` and return a `&'b i32` as a result of "
 "coercion.\n"
 msgstr ""
+"// `<'a: 'b, 'b>` 表示生命周期 `'a` 至少和 `'b` 一样长。\n"
+"// 这里，我们接收一个 `&'a i32` 并返回一个 `&'b i32` 作为强制转换的结果。\n"
 
 #: src/scope/lifetime/lifetime_coercion.md:22
 msgid "// Longer lifetime\n"
-msgstr ""
+msgstr "// 较长的生命周期\n"
 
 #: src/scope/lifetime/lifetime_coercion.md:25
 msgid "// Shorter lifetime\n"
-msgstr ""
+msgstr "// 较短的生命周期\n"
 
 #: src/scope/lifetime/lifetime_coercion.md:27
 msgid "\"The product is {}\""
-msgstr ""
+msgstr "\"乘积是 {}\""
 
 #: src/scope/lifetime/lifetime_coercion.md:28
 msgid "\"{} is the first\""
-msgstr ""
+msgstr "\"{} 是第一个\""
 
 #: src/scope/lifetime/static_lifetime.md:3
 msgid ""
 "Rust has a few reserved lifetime names. One of those is `'static`. You might "
 "encounter it in two situations:"
-msgstr ""
+msgstr "Rust 有几个保留的生命周期名称。其中之一是 `'static`。你可能在两种情况下遇到它："
 
 #: src/scope/lifetime/static_lifetime.md:7
 msgid "// A reference with 'static lifetime:\n"
-msgstr ""
+msgstr "// 一个带有 'static 生命周期的引用：\n"
 
 #: src/scope/lifetime/static_lifetime.md:8
 msgid "\"hello world\""
-msgstr ""
+msgstr "\"hello world\""
 
 #: src/scope/lifetime/static_lifetime.md:9
 msgid "// 'static as part of a trait bound:\n"
-msgstr ""
+msgstr "// 'static 作为 trait 约束的一部分：\n"
 
 #: src/scope/lifetime/static_lifetime.md:14
 msgid ""
 "Both are related but subtly different and this is a common source for "
 "confusion when learning Rust. Here are some examples for each situation:"
-msgstr ""
+msgstr "两者相关但有微妙的区别，这是学习 Rust 时常见的困惑来源。以下是每种情况的一些例子："
 
 #: src/scope/lifetime/static_lifetime.md:17
 msgid "Reference lifetime"
-msgstr ""
+msgstr "引用生命周期"
 
 #: src/scope/lifetime/static_lifetime.md:19
 msgid ""
 "As a reference lifetime `'static` indicates that the data pointed to by the "
 "reference lives for the remaining lifetime of the running program. It can "
 "still be coerced to a shorter lifetime."
-msgstr ""
+msgstr "作为引用生命周期，`'static` 表示该引用指向的数据在程序的剩余生命周期内都存在。它仍然可以被强制转换为更短的生命周期。"
 
 #: src/scope/lifetime/static_lifetime.md:23
 msgid ""
 "There are two common ways to make a variable with `'static` lifetime, and "
 "both are stored in the read-only memory of the binary:"
-msgstr ""
+msgstr "有两种常见的方法可以创建具有 `'static` 生命周期的变量，它们都存储在二进制文件的只读内存中："
 
 #: src/scope/lifetime/static_lifetime.md:26
 msgid "Make a constant with the `static` declaration."
-msgstr ""
+msgstr "使用 `static` 声明创建一个常量。"
 
 #: src/scope/lifetime/static_lifetime.md:27
 msgid "Make a `string` literal which has type: `&'static str`."
-msgstr ""
+msgstr "创建一个 `string` 字面量，类型为：`&'static str`。"
 
 #: src/scope/lifetime/static_lifetime.md:29
 msgid "See the following example for a display of each method:"
-msgstr ""
+msgstr "请看下面的例子，展示了这些方法："
 
 #: src/scope/lifetime/static_lifetime.md:32
 msgid "// Make a constant with `'static` lifetime.\n"
-msgstr ""
+msgstr "// 创建一个具有 `'static` 生命周期的常量。\n"
 
 #: src/scope/lifetime/static_lifetime.md:34
 msgid ""
 "// Returns a reference to `NUM` where its `'static`\n"
 "// lifetime is coerced to that of the input argument.\n"
 msgstr ""
+"// 返回一个对 `NUM` 的引用，其中它的 `'static`\n"
+"// 生命周期被强制转换为输入参数的生命周期。\n"
 
 #: src/scope/lifetime/static_lifetime.md:43
 msgid "// Make a `string` literal and print it:\n"
-msgstr ""
+msgstr "// 创建一个 `string` 字面量并打印它：\n"
 
 #: src/scope/lifetime/static_lifetime.md:44
 msgid "\"I'm in read-only memory\""
-msgstr ""
+msgstr "\"我在只读内存中\""
 
 #: src/scope/lifetime/static_lifetime.md:45
 msgid "\"static_string: {}\""
-msgstr ""
+msgstr "\"static_string: {}\""
 
 #: src/scope/lifetime/static_lifetime.md:47
 msgid ""
 "// When `static_string` goes out of scope, the reference\n"
 "        // can no longer be used, but the data remains in the binary.\n"
 msgstr ""
+"// 当 `static_string` 离开作用域时，该引用\n"
+"        // 不能再被使用，但数据仍然保留在二进制文件中。\n"
 
 #: src/scope/lifetime/static_lifetime.md:52
 msgid "// Make an integer to use for `coerce_static`:\n"
-msgstr ""
+msgstr "// 创建一个整数用于 `coerce_static`：\n"
 
 #: src/scope/lifetime/static_lifetime.md:55
 msgid "// Coerce `NUM` to lifetime of `lifetime_num`:\n"
-msgstr ""
+msgstr "// 将 `NUM` 强制转换为 `lifetime_num` 的生命周期：\n"
 
 #: src/scope/lifetime/static_lifetime.md:58
 msgid "\"coerced_static: {}\""
-msgstr ""
+msgstr "\"coerced_static: {}\""
 
 #: src/scope/lifetime/static_lifetime.md:61
 msgid "\"NUM: {} stays accessible!\""
-msgstr ""
+msgstr "\"NUM: {} 仍然可访问！\""
 
 #: src/scope/lifetime/static_lifetime.md:65
 msgid ""
@@ -9572,10 +9689,11 @@ msgid ""
 "references. In that case it definitely doesn't live for the entire duration, "
 "but only for the leaking point onward."
 msgstr ""
+"由于 `'static` 引用只需要在程序生命周期的**剩余部分**有效，它们可以在程序执行过程中创建。为了演示，下面的例子使用 [`Box::leak`](https://doc.rust-lang.org/std/boxed/struct.Box.html#method.leak) 动态创建 `'static` 引用。在这种情况下，它肯定不会存活整个程序的生命周期，而只是从泄漏点开始存在。"
 
 #: src/scope/lifetime/static_lifetime.md:90
 msgid "Trait bound"
-msgstr ""
+msgstr "Trait 约束"
 
 #: src/scope/lifetime/static_lifetime.md:92
 msgid ""
@@ -9583,6 +9701,7 @@ msgid ""
 "references. Eg. the receiver can hold on to the type for as long as they want "
 "and it will never become invalid until they drop it."
 msgstr ""
+"作为 trait 约束，它表示该类型不包含任何非静态引用。例如，接收者可以随意保留该类型，并且它永远不会失效，直到他们放弃它为止。。"
 
 #: src/scope/lifetime/static_lifetime.md:96
 msgid ""
@@ -9590,28 +9709,31 @@ msgid ""
 "`'static` lifetime bound, but a reference to that owned data generally does "
 "not:"
 msgstr ""
+"理解这一点很重要：任何拥有所有权的数据总是满足 `'static` 生命周期约束，但对该拥有所有权数据的引用通常不满足："
 
 #: src/scope/lifetime/static_lifetime.md:104
 msgid "\"'static value passed in is: {:?}\""
-msgstr ""
+msgstr "\"传入的 'static 值是：{:?}\""
 
 #: src/scope/lifetime/static_lifetime.md:108
 msgid "// i is owned and contains no references, thus it's 'static:\n"
-msgstr ""
+msgstr "// i 是拥有所有权的，不包含任何引用，因此它是 'static 的：\n"
 
 #: src/scope/lifetime/static_lifetime.md:112
 msgid ""
 "// oops, &i only has the lifetime defined by the scope of\n"
 "    // main(), so it's not 'static:\n"
 msgstr ""
+"// 糟糕，&i 只有 main() 作用域定义的生命周期，\n"
+"    // 所以它不是 'static 的：\n"
 
 #: src/scope/lifetime/static_lifetime.md:117
 msgid "The compiler will tell you:"
-msgstr ""
+msgstr "编译器会告诉你："
 
 #: src/scope/lifetime/static_lifetime.md:133
 msgid "[`'static` constants](../../custom_types/constants.md)"
-msgstr ""
+msgstr "[`'static` 常量](../../custom_types/constants.md)"
 
 #: src/scope/lifetime/elision.md:3
 msgid ""
@@ -9620,6 +9742,7 @@ msgid ""
 "is known as elision. Elision exists in Rust solely because these patterns are "
 "common."
 msgstr ""
+"有些生命周期模式非常常见，因此借用检查器允许你省略它们以减少代码并提高可读性。这被称为省略。Rust 中存在省略仅仅是因为这些模式很常见。"
 
 #: src/scope/lifetime/elision.md:8
 msgid ""
@@ -9627,6 +9750,7 @@ msgid ""
 "description of elision, see [lifetime elision](https://doc.rust-lang.org/book/"
 "ch10-03-lifetime-syntax.html#lifetime-elision) in the book."
 msgstr ""
+"以下代码展示了一些省略的例子。要更全面地了解省略，请参阅 Rust 程序设计语言中的[生命周期省略](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision)。"
 
 #: src/scope/lifetime/elision.md:12
 msgid ""
@@ -9634,34 +9758,40 @@ msgid ""
 "signatures\n"
 "// because the lifetime of `elided_input` is inferred by the compiler:\n"
 msgstr ""
+"// `elided_input` 和 `annotated_input` 本质上具有相同的签名\n"
+"// 因为 `elided_input` 的生命周期是由编译器推断的：\n"
 
 #: src/scope/lifetime/elision.md:15
 msgid "\"`elided_input`: {}\""
-msgstr ""
+msgstr "\"`elided_input`: {}\""
 
 #: src/scope/lifetime/elision.md:19
 msgid "\"`annotated_input`: {}\""
-msgstr ""
+msgstr "\"`annotated_input`: {}\""
 
 #: src/scope/lifetime/elision.md:21
 msgid ""
 "// Similarly, `elided_pass` and `annotated_pass` have identical signatures\n"
 "// because the lifetime is added implicitly to `elided_pass`:\n"
 msgstr ""
+"// 同样，`elided_pass` 和 `annotated_pass` 具有相同的签名\n"
+"// 因为生命周期被隐式地添加到 `elided_pass`：\n"
 
 #: src/scope/lifetime/elision.md:34
 msgid "\"`elided_pass`: {}\""
-msgstr ""
+msgstr "\"`elided_pass`: {}\""
 
 #: src/scope/lifetime/elision.md:35
 msgid "\"`annotated_pass`: {}\""
-msgstr ""
+msgstr "\"`annotated_pass`: {}\""
 
 #: src/scope/lifetime/elision.md:41
 msgid ""
 "[elision](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax."
 "html#lifetime-elision)"
 msgstr ""
+"[省略](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax."
+"html#lifetime-elision)"
 
 #: src/trait.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -3108,137 +3108,146 @@ msgid ""
 "infer the type of the variable from the context, heavily reducing the "
 "annotation burden."
 msgstr ""
+"Rust 通过静态类型提供类型安全。变量绑定在声明时可以进行类型注解。然而，在大多数情况下，编译器能够从上下文中推断出变量的类型，大大减少了注解的负担。"
 
 #: src/variable_bindings.md:8
 msgid ""
 "Values (like literals) can be bound to variables, using the `let` binding."
 msgstr ""
+"值（如字面量）可以使用 `let` 绑定到变量。"
 
 #: src/variable_bindings.md:16
 msgid "// copy `an_integer` into `copied_integer`\n"
-msgstr ""
+msgstr "// 将 `an_integer` 复制到 `copied_integer`\n"
 
 #: src/variable_bindings.md:19
 msgid "\"An integer: {:?}\""
-msgstr ""
+msgstr "\"一个整数：{:?}\""
 
 #: src/variable_bindings.md:20
 msgid "\"A boolean: {:?}\""
-msgstr ""
+msgstr "\"一个布尔值：{:?}\""
 
 #: src/variable_bindings.md:21
 msgid "\"Meet the unit value: {:?}\""
-msgstr ""
+msgstr "\"遇见单元值：{:?}\""
 
 #: src/variable_bindings.md:23
 msgid ""
 "// The compiler warns about unused variable bindings; these warnings can\n"
 "    // be silenced by prefixing the variable name with an underscore\n"
 msgstr ""
+"// 编译器会对未使用的变量绑定发出警告；这些警告可以\n"
+"    // 通过在变量名前加上下划线来消除\n"
 
 #: src/variable_bindings.md:28
 msgid ""
 "// FIXME ^ Prefix with an underscore to suppress the warning\n"
 "    // Please note that warnings may not be shown in a browser\n"
 msgstr ""
+"// 修复 ^ 在变量名前加上下划线以抑制警告\n"
+"    // 请注意，在浏览器中可能不会显示警告\n"
 
 #: src/variable_bindings/mut.md:3
 msgid ""
 "Variable bindings are immutable by default, but this can be overridden using "
 "the `mut` modifier."
 msgstr ""
+"变量绑定默认是不可变的，但可以使用 `mut` 修饰符来覆盖这一行为。"
 
 #: src/variable_bindings/mut.md:11
 msgid "\"Before mutation: {}\""
-msgstr ""
+msgstr "\"修改前：{}\""
 
 #: src/variable_bindings/mut.md:13
 msgid "// Ok\n"
-msgstr ""
+msgstr "// 正确\n"
 
 #: src/variable_bindings/mut.md:16
 msgid "\"After mutation: {}\""
-msgstr ""
+msgstr "\"修改后：{}\""
 
 #: src/variable_bindings/mut.md:18
 msgid "// Error! Cannot assign a new value to an immutable variable\n"
-msgstr ""
+msgstr "// 错误！不能对不可变变量赋新值\n"
 
 #: src/variable_bindings/mut.md:23
 msgid "The compiler will throw a detailed diagnostic about mutability errors."
-msgstr ""
+msgstr "编译器会对可变性错误给出详细的诊断信息。"
 
 #: src/variable_bindings/scope.md:3
 msgid ""
 "Variable bindings have a scope, and are constrained to live in a _block_. A "
 "block is a collection of statements enclosed by braces `{}`."
 msgstr ""
+"变量绑定有作用域，它们被限制在一个**代码块**中存在。代码块是由花括号 `{}` 包围的一系列语句。"
 
 #: src/variable_bindings/scope.md:7
 msgid "// This binding lives in the main function\n"
-msgstr ""
+msgstr "// 这个绑定存在于 main 函数中\n"
 
 #: src/variable_bindings/scope.md:10
 msgid "// This is a block, and has a smaller scope than the main function\n"
-msgstr ""
+msgstr "// 这是一个代码块，它的作用域比 main 函数小\n"
 
 #: src/variable_bindings/scope.md:12
 msgid "// This binding only exists in this block\n"
-msgstr ""
+msgstr "// 这个绑定只存在于这个代码块中\n"
 
 #: src/variable_bindings/scope.md:15
 msgid "\"inner short: {}\""
-msgstr ""
+msgstr "\"内部的 short：{}\""
 
 #: src/variable_bindings/scope.md:17
 msgid "// End of the block\n"
-msgstr ""
+msgstr "// 代码块结束\n"
 
 #: src/variable_bindings/scope.md:19
 msgid "// Error! `short_lived_binding` doesn't exist in this scope\n"
-msgstr ""
+msgstr "// 错误！`short_lived_binding` 在这个作用域中不存在\n"
 
 #: src/variable_bindings/scope.md:20
 msgid "\"outer short: {}\""
-msgstr ""
+msgstr "\"外部的 short：{}\""
 
 #: src/variable_bindings/scope.md:23
 msgid "\"outer long: {}\""
-msgstr ""
+msgstr "\"外部的 long：{}\""
 
 #: src/variable_bindings/scope.md:26
 msgid ""
 "Also, [variable shadowing](https://en.wikipedia.org/wiki/Variable_shadowing) "
 "is allowed."
 msgstr ""
+"此外，允许[变量遮蔽](https://en.wikipedia.org/wiki/Variable_shadowing)。"
 
 #: src/variable_bindings/scope.md:32
 msgid "\"before being shadowed: {}\""
-msgstr ""
+msgstr "\"被遮蔽之前：{}\""
 
 #: src/variable_bindings/scope.md:34
 msgid "// This binding *shadows* the outer one\n"
-msgstr ""
+msgstr "// 这个绑定*遮蔽*了外部的绑定\n"
 
 #: src/variable_bindings/scope.md:35
 msgid "\"abc\""
-msgstr ""
+msgstr "\"abc\""
 
 #: src/variable_bindings/scope.md:37
 msgid "\"shadowed in inner block: {}\""
-msgstr ""
+msgstr "\"在内部代码块中被遮蔽：{}\""
 
 #: src/variable_bindings/scope.md:39
 msgid "\"outside inner block: {}\""
-msgstr ""
+msgstr "\"在内部代码块外：{}\""
 
 #: src/variable_bindings/scope.md:41
 msgid "// This binding *shadows* the previous binding\n"
-msgstr ""
+msgstr "// 这个绑定*遮蔽*了之前的绑定\n"
 
 #: src/variable_bindings/scope.md:43
 msgid "\"shadowed in outer block: {}\""
-msgstr ""
+msgstr "\"在外部代码块中被遮蔽：{}\""
 
 #: src/variable_bindings/declare.md:3
 msgid ""
@@ -3246,54 +3255,57 @@ msgid ""
 "However, this form is seldom used, as it may lead to the use of uninitialized "
 "variables."
 msgstr ""
+"可以先声明变量绑定，然后再初始化它们。然而，这种形式很少使用，因为它可能导致使用未初始化的变量。"
 
 #: src/variable_bindings/declare.md:9
 msgid "// Declare a variable binding\n"
-msgstr ""
+msgstr "// 声明一个变量绑定\n"
 
 #: src/variable_bindings/declare.md:15
 msgid "// Initialize the binding\n"
-msgstr ""
+msgstr "// 初始化绑定\n"
 
 #: src/variable_bindings/declare.md:19
 msgid "\"a binding: {}\""
-msgstr ""
+msgstr "\"一个绑定：{}\""
 
 #: src/variable_bindings/declare.md:23
 msgid "// Error! Use of uninitialized binding\n"
-msgstr ""
+msgstr "// 错误！使用未初始化的绑定\n"
 
 #: src/variable_bindings/declare.md:24 src/variable_bindings/declare.md:29
 msgid "\"another binding: {}\""
-msgstr ""
+msgstr "\"另一个绑定：{}\""
 
 #: src/variable_bindings/declare.md:33
 msgid ""
 "The compiler forbids use of uninitialized variables, as this would lead to "
 "undefined behavior."
 msgstr ""
+"编译器禁止使用未初始化的变量，因为这会导致未定义行为。"
 
 #: src/variable_bindings/freeze.md:3
 msgid ""
 "When data is bound by the same name immutably, it also _freezes_. _Frozen_ "
 "data can't be modified until the immutable binding goes out of scope:"
 msgstr ""
+"当数据以相同的名称被不可变地绑定时，它也会**冻结**。被冻结的数据在不可变绑定离开作用域之前不能被修改："
 
 #: src/variable_bindings/freeze.md:11
 msgid "// Shadowing by immutable `_mutable_integer`\n"
-msgstr ""
+msgstr "// 通过不可变的 `_mutable_integer` 进行遮蔽\n"
 
 #: src/variable_bindings/freeze.md:14
 msgid "// Error! `_mutable_integer` is frozen in this scope\n"
-msgstr ""
+msgstr "// 错误！`_mutable_integer` 在这个作用域中被冻结\n"
 
 #: src/variable_bindings/freeze.md:18
 msgid "// `_mutable_integer` goes out of scope\n"
-msgstr ""
+msgstr "// `_mutable_integer` 离开作用域\n"
 
 #: src/variable_bindings/freeze.md:21
 msgid "// Ok! `_mutable_integer` is not frozen in this scope\n"
-msgstr ""
+msgstr "// 正确！`_mutable_integer` 在这个作用域中没有被冻结\n"
 
 #: src/types.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -6820,26 +6820,29 @@ msgid ""
 "`cargo` is the official Rust package management tool. It has lots of really "
 "useful features to improve code quality and developer velocity! These include"
 msgstr ""
+"`cargo` 是 Rust 的官方包管理工具。它有许多非常有用的功能来提高代码质量和开发效率！这些功能包括"
 
 #: src/cargo.md:6
 msgid ""
 "Dependency management and integration with [crates.io](https://crates.io) "
 "(the official Rust package registry)"
 msgstr ""
+"依赖管理和与 [crates.io](https://crates.io)（官方 Rust 包注册中心）的集成"
 
 #: src/cargo.md:8
 msgid "Awareness of unit tests"
-msgstr ""
+msgstr "支持单元测试"
 
 #: src/cargo.md:9
 msgid "Awareness of benchmarks"
-msgstr ""
+msgstr "支持基准测试"
 
 #: src/cargo.md:11
 msgid ""
 "This chapter will go through some quick basics, but you can find the "
 "comprehensive docs in [The Cargo Book](https://doc.rust-lang.org/cargo/)."
 msgstr ""
+"本章将快速介绍一些基础知识，不过你可以在 [Cargo 手册](https://doc.rust-lang.org/cargo/) 中找到更全面的文档。"
 
 #: src/cargo/deps.md:3
 msgid ""
@@ -6848,28 +6851,30 @@ msgid ""
 "Rust ecosystem comes standard with `cargo`! `cargo` can manage dependencies "
 "for a project."
 msgstr ""
+"大多数程序都依赖于一些库。如果你曾经手动管理过依赖，你就知道这有多痛苦。幸运的是，Rust 生态系统标配了 `cargo` 工具！`cargo` 可以为项目管理依赖。"
 
 #: src/cargo/deps.md:8
 msgid "To create a new Rust project,"
-msgstr ""
+msgstr "创建一个新的 Rust 项目，"
 
 #: src/cargo/deps.md:11
 msgid "# A binary\n"
-msgstr ""
+msgstr "# 二进制程序\n"
 
 #: src/cargo/deps.md:13
 msgid "# A library\n"
-msgstr ""
+msgstr "# 库\n"
 
 #: src/cargo/deps.md:18
 msgid ""
 "For the rest of this chapter, let's assume we are making a binary, rather "
 "than a library, but all of the concepts are the same."
 msgstr ""
+"在本章的剩余部分，我们假设我们正在创建一个二进制程序，而不是一个库，但所有的概念都是相同的。"
 
 #: src/cargo/deps.md:21
 msgid "After the above commands, you should see a file hierarchy like this:"
-msgstr ""
+msgstr "执行上述命令后，应该会得到这样的文件层次结构："
 
 #: src/cargo/deps.md:35
 msgid ""
@@ -6877,6 +6882,7 @@ msgid ""
 "new there. The `Cargo.toml` is the config file for `cargo` for this project. "
 "If you look inside it, you should see something like this:"
 msgstr ""
+"`main.rs` 是新的 `foo` 项目的入口源文件 —— 这没什么新鲜的。`Cargo.toml` 是这个项目的 `cargo` 配置文件。如果你查看它的内容，你应该看到类似这样的内容："
 
 #: src/cargo/deps.md:39
 msgid ""
@@ -6889,6 +6895,14 @@ msgid ""
 "[dependencies]\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"```"
 
 #: src/cargo/deps.md:48
 msgid ""
@@ -6896,20 +6910,22 @@ msgid ""
 "is used by `crates.io` if you publish the crate (more later). It is also the "
 "name of the output binary when you compile."
 msgstr ""
+"`[package]` 下的 `name` 字段决定了项目的名称。如果你发布 crate（稍后会详细介绍），这个名称将被 `crates.io` 使用。这也是编译时输出的二进制文件的名称。"
 
 #: src/cargo/deps.md:52
 msgid ""
 "The `version` field is a crate version number using [Semantic Versioning]"
 "(http://semver.org/)."
 msgstr ""
+"`version` 字段是使用 [语义化版本控制](http://semver.org/) 的 crate 版本号。"
 
 #: src/cargo/deps.md:55
 msgid "The `authors` field is a list of authors used when publishing the crate."
-msgstr ""
+msgstr "`authors` 字段是发布 crate 时使用的作者列表。"
 
 #: src/cargo/deps.md:57
 msgid "The `[dependencies]` section lets you add dependencies for your project."
-msgstr ""
+msgstr "`[dependencies]` 部分用来为项目添加依赖。"
 
 #: src/cargo/deps.md:59
 msgid ""
@@ -6921,12 +6937,14 @@ msgid ""
 "to our `Cargo.toml` under `[dependencies]`: `clap = \"2.27.1\"`. And that's "
 "it! You can start using `clap` in your program."
 msgstr ""
+"例如，假设我们希望我们的程序有一个出色的命令行界面（CLI）。你可以在 [crates.io](https://crates.io)（官方的 Rust 包注册中心）上找到许多优秀的包。一个受欢迎的选择是 [clap](https://crates.io/crates/clap)。在撰写本文时，`clap` 最新发布的版本是 `2.27.1`。要在我们的程序中添加依赖，我们只需在 `Cargo.toml` 的 `[dependencies]` 下添加以下内容：`clap = \"2.27.1\"`。就是这样！你现在可以在你的程序中开始使用 `clap` 了。"
 
 #: src/cargo/deps.md:67
 msgid ""
 "`cargo` also supports [other types of dependencies](https://doc.rust-lang.org/"
 "cargo/reference/specifying-dependencies.html). Here is just a small sampling:"
 msgstr ""
+"`cargo` 还支持 [其他类型的依赖](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)。这里只是一个小示例："
 
 #: src/cargo/deps.md:70
 msgid ""
@@ -6943,6 +6961,17 @@ msgid ""
 "bar = { path = \"../bar\" } # from a path in the local filesystem\n"
 "```"
 msgstr ""
+"```toml\n"
+"[package]\n"
+"name = \"foo\"\n"
+"version = \"0.1.0\"\n"
+"authors = [\"mark\"]\n"
+"\n"
+"[dependencies]\n"
+"clap = \"2.27.1\" # 来自 crates.io\n"
+"rand = { git = \"https://github.com/rust-lang-nursery/rand\" } # 来自在线仓库\n"
+"bar = { path = \"../bar\" } # 来自本地文件系统中的路径\n"
+"```"
 
 #: src/cargo/deps.md:82
 msgid ""
@@ -6950,6 +6979,7 @@ msgid ""
 "options are listed in the [format specification](https://doc.rust-lang.org/"
 "cargo/reference/manifest.html) of `Cargo.toml`."
 msgstr ""
+"`cargo` 不仅仅是一个依赖管理器。所有可用的配置选项都列在 `Cargo.toml` 的 [格式规范](https://doc.rust-lang.org/cargo/reference/manifest.html) 中。"
 
 #: src/cargo/deps.md:86
 msgid ""
@@ -6959,20 +6989,22 @@ msgid ""
 "crates if needed, and build everything, including your crate. (Note that it "
 "only rebuilds what it has not already built, similar to `make`)."
 msgstr ""
+"要构建我们的项目，我们可以在项目目录的任何位置（包括子目录！）执行 `cargo build`。我们也可以使用 `cargo run` 来构建并运行。注意，这些命令会解析所有依赖，如果需要的话下载 crate，并构建所有内容，包括你的 crate。（注意，它只会重新构建尚未构建的部分，类似于 `make`）。"
 
 #: src/cargo/deps.md:92
 msgid "Voila! That's all there is to it!"
-msgstr ""
+msgstr "瞧！就是这么简单！"
 
 #: src/cargo/conventions.md:3
 msgid "In the previous chapter, we saw the following directory hierarchy:"
-msgstr ""
+msgstr "在上一章中，我们看到了以下目录层次结构："
 
 #: src/cargo/conventions.md:12
 msgid ""
 "Suppose that we wanted to have two binaries in the same project, though. What "
 "then?"
 msgstr ""
+"假设我们想在同一个项目中有两个二进制文件。那该怎么办呢？"
 
 #: src/cargo/conventions.md:15
 msgid ""
@@ -6980,6 +7012,7 @@ msgid ""
 "as we saw before, but you can add additional binaries by placing them in a "
 "`bin/` directory:"
 msgstr ""
+"事实证明，`cargo` 支持这一点。默认的二进制文件名是 `main`，就像我们之前看到的那样，但你可以通过将额外的二进制文件放在 `bin/` 目录中来添加它们："
 
 #: src/cargo/conventions.md:28
 msgid ""
@@ -6987,6 +7020,7 @@ msgid ""
 "`--bin my_other_bin` flag, where `my_other_bin` is the name of the binary we "
 "want to work with."
 msgstr ""
+"要告诉 `cargo` 只编译或运行这个二进制文件，我们只需要给 `cargo` 传递 `--bin my_other_bin` 标志，其中 `my_other_bin` 是我们想要处理的二进制文件的名称。"
 
 #: src/cargo/conventions.md:32
 msgid ""
@@ -6994,10 +7028,11 @@ msgid ""
 "rust-lang.org/cargo/guide/project-layout.html) such as benchmarks, tests, and "
 "examples."
 msgstr ""
+"除了额外的二进制文件，`cargo` 还支持 [更多功能](https://doc.rust-lang.org/cargo/guide/project-layout.html)，如基准测试、测试和示例。"
 
 #: src/cargo/conventions.md:35
 msgid "In the next chapter, we will look more closely at tests."
-msgstr ""
+msgstr "在下一章中，我们将更仔细地看看测试。"
 
 #: src/cargo/test.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -3145,7 +3145,7 @@ msgid ""
 "// FIXME ^ Prefix with an underscore to suppress the warning\n"
 "    // Please note that warnings may not be shown in a browser\n"
 msgstr ""
-"// 修复 ^ 在变量名前加上下划线以抑制警告\n"
+"// 修复 ^ 在变量名前加上下划线以消除警告\n"
 "    // 请注意，在浏览器中可能不会显示警告\n"
 
 #: src/variable_bindings/mut.md:3
@@ -6453,7 +6453,7 @@ msgid ""
 "    //my_mod::nested::public_function_in_my_mod();\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
-"// pub(in path) 条目只能从指定的模块内部调用\n"
+"// pub(in path) 项只能从指定的模块内部调用\n"
 "    // 报错！函数 `public_function_in_my_mod` 是私有的\n"
 "    //my_mod::nested::public_function_in_my_mod();\n"
 "    // TODO ^ 尝试取消这一行的注释\n"
@@ -6463,7 +6463,7 @@ msgid ""
 "// Private items of a module cannot be directly accessed, even if\n"
 "    // nested in a public module:\n"
 msgstr ""
-"// 模块的私有条目不能被直接访问，即使嵌套在一个公有模块中：\n"
+"// 模块的私有项不能被直接访问，即使嵌套在一个公有模块中：\n"
 
 #: src/mod/visibility.md:112
 msgid ""
@@ -7283,48 +7283,51 @@ msgid ""
 "An attribute is metadata applied to some module, crate or item. This metadata "
 "can be used to/for:"
 msgstr ""
+"属性是应用于某个模块、crate 或项的元数据。这些元数据可以用于以下目的："
 
 #: src/attribute.md:8
 msgid "[conditional compilation of code](attribute/cfg.md)"
-msgstr ""
+msgstr "[代码的条件编译](attribute/cfg.md)"
 
 #: src/attribute.md:9
 msgid ""
 "[set crate name, version and type (binary or library)](attribute/crate.md)"
-msgstr ""
+msgstr "[设置 crate 名称、版本和类型（二进制或库）](attribute/crate.md)"
 
 #: src/attribute.md:10
 msgid ""
 "disable [lints](https://en.wikipedia.org/wiki/Lint_%28software%29) (warnings)"
-msgstr ""
+msgstr "禁用 [lints](https://en.wikipedia.org/wiki/Lint_%28software%29)（警告）"
 
 #: src/attribute.md:11
 msgid "enable compiler features (macros, glob imports, etc.)"
-msgstr ""
+msgstr "启用编译器特性（宏、全局导入等）"
 
 #: src/attribute.md:12
 msgid "link to a foreign library"
-msgstr ""
+msgstr "链接到外部库"
 
 #: src/attribute.md:13
 msgid "mark functions as unit tests"
-msgstr ""
+msgstr "将函数标记为单元测试"
 
 #: src/attribute.md:14
 msgid "mark functions that will be part of a benchmark"
-msgstr ""
+msgstr "将函数标记成为基准测试的一部分"
 
 #: src/attribute.md:15
 msgid ""
 "[attribute like macros](https://doc.rust-lang.org/book/ch19-06-macros."
 "html#attribute-like-macros)"
 msgstr ""
+"[类似属性的宏](https://doc.rust-lang.org/book/ch19-06-macros.html#attribute-like-macros)"
 
 #: src/attribute.md:17
 msgid ""
 "Attributes look like `#[outer_attribute]` or `#![inner_attribute]`, with the "
 "difference between them being where they apply."
 msgstr ""
+"属性看起来像 `#[outer_attribute]` 或 `#![inner_attribute]`，它们之间的区别在于应用的位置。"
 
 #: src/attribute.md:20
 msgid ""
@@ -7333,6 +7336,7 @@ msgid ""
 "function, a module declaration, a constant, a structure, an enum. Here is an "
 "example where attribute `#[derive(Debug)]` applies to the struct `Rectangle`:"
 msgstr ""
+"`#[outer_attribute]` 应用于紧随其后的[项](https://doc.rust-lang.org/stable/reference/items.html)。项的一些例子包括：函数、模块声明、常量、结构体、枚举。这里是一个例子，其中属性 `#[derive(Debug)]` 应用于结构体 `Rectangle`："
 
 #: src/attribute.md:33
 msgid ""
@@ -7342,32 +7346,33 @@ msgid ""
 "it's placed. Here is an example where `#![allow(unused_variables)]` applies "
 "to the whole crate (if placed in `main.rs`):"
 msgstr ""
+"`#![inner_attribute]` 应用于包围它的[项](https://doc.rust-lang.org/stable/reference/items.html)（通常是模块或 crate）。换句话说，这个属性被解释为应用于它所在的整个作用域。这里是一个例子，其中 `#![allow(unused_variables)]` 应用于整个 crate（如果放在 `main.rs` 中）："
 
 #: src/attribute.md:42
 msgid "// This would normally warn about an unused variable.\n"
-msgstr ""
+msgstr "// 这通常会警告未使用的变量。\n"
 
 #: src/attribute.md:46
 msgid "Attributes can take arguments with different syntaxes:"
-msgstr ""
+msgstr "属性可以使用不同的语法接受参数："
 
 #: src/attribute.md:48
 msgid "`#[attribute = \"value\"]`"
-msgstr ""
+msgstr "`#[attribute = \"value\"]`"
 
 #: src/attribute.md:49
 msgid "`#[attribute(key = \"value\")]`"
-msgstr ""
+msgstr "`#[attribute(key = \"value\")]`"
 
 #: src/attribute.md:50
 msgid "`#[attribute(value)]`"
-msgstr ""
+msgstr "`#[attribute(value)]`"
 
 #: src/attribute.md:52
 msgid ""
 "Attributes can have multiple values and can be separated over multiple lines, "
 "too:"
-msgstr ""
+msgstr "属性可以有多个值，也可以分成多行："
 
 #: src/attribute/unused.md:3
 msgid ""
@@ -7375,15 +7380,16 @@ msgid ""
 "Lint_%28software%29) that will warn about unused functions. An _attribute_ "
 "can be used to disable the lint."
 msgstr ""
+"编译器提供了一个 `dead_code` [_lint_](https://en.wikipedia.org/wiki/Lint_%28software%29)，它会对未使用的函数发出警告。可以使用**属性**来禁用这个 lint。"
 
 #: src/attribute/unused.md:9
 msgid ""
 "// `#[allow(dead_code)]` is an attribute that disables the `dead_code` lint\n"
-msgstr ""
+msgstr "// `#[allow(dead_code)]` 是一个禁用 `dead_code` lint 的属性\n"
 
 #: src/attribute/unused.md:14
 msgid "// FIXME ^ Add an attribute to suppress the warning\n"
-msgstr ""
+msgstr "// FIXME ^ 添加一个属性来消除警告\n"
 
 #: src/attribute/unused.md:22
 msgid ""
@@ -7391,6 +7397,7 @@ msgid ""
 "we'll allow dead code in some places because of the interactive nature of the "
 "examples."
 msgstr ""
+"注意，在实际程序中，你应该消除死代码。在这些例子中，我们会在某些地方允许死代码，这是因为这些例子的交互性质。"
 
 #: src/attribute/crate.md:3
 msgid ""
@@ -7398,6 +7405,7 @@ msgid ""
 "is a binary or a library (and even which type of library), and the "
 "`crate_name` attribute can be used to set the name of the crate."
 msgstr ""
+"`crate_type` 属性可以用来告诉编译器一个 crate 是二进制文件还是库（甚至是哪种类型的库），而 `crate_name` 属性可以用来设置 crate 的名称。"
 
 #: src/attribute/crate.md:7
 msgid ""
@@ -7406,41 +7414,43 @@ msgid ""
 "manager. Since Cargo is used for the majority of Rust projects, this means "
 "real-world uses of `crate_type` and `crate_name` are relatively limited."
 msgstr ""
+"然而，需要注意的是，当使用 Cargo（Rust 的包管理器）时，`crate_type` 和 `crate_name` 属性**完全没有**效果。由于大多数 Rust 项目都使用 Cargo，这意味着 `crate_type` 和 `crate_name` 在实际使用中相对有限。"
 
 #: src/attribute/crate.md:13
 msgid "// This crate is a library\n"
-msgstr ""
+msgstr "// 这个 crate 是一个库\n"
 
 #: src/attribute/crate.md:14
 msgid "\"lib\""
-msgstr ""
+msgstr "\"lib\""
 
 #: src/attribute/crate.md:14
 msgid "// The library is named \"rary\"\n"
-msgstr ""
+msgstr "// 这个库的名称是 \"rary\"\n"
 
 #: src/attribute/crate.md:16
 msgid "\"rary\""
-msgstr ""
+msgstr "\"rary\""
 
 #: src/attribute/crate.md:33
 msgid ""
 "When the `crate_type` attribute is used, we no longer need to pass the `--"
 "crate-type` flag to `rustc`."
 msgstr ""
+"当使用 `crate_type` 属性时，我们不再需要向 `rustc` 传递 `--crate-type` 标志。"
 
 #: src/attribute/cfg.md:3
 msgid ""
 "Configuration conditional checks are possible through two different operators:"
-msgstr ""
+msgstr "配置条件检查可以通过两种不同的操作符实现："
 
 #: src/attribute/cfg.md:5
 msgid "the `cfg` attribute: `#[cfg(...)]` in attribute position"
-msgstr ""
+msgstr "`cfg` 属性：在属性位置使用 `#[cfg(...)]`"
 
 #: src/attribute/cfg.md:6
 msgid "the `cfg!` macro: `cfg!(...)` in boolean expressions"
-msgstr ""
+msgstr "`cfg!` 宏：在布尔表达式中使用 `cfg!(...)`"
 
 #: src/attribute/cfg.md:8
 msgid ""
@@ -7448,6 +7458,7 @@ msgid ""
 "evaluates to `true` or `false` literals allowing for checks at run-time. Both "
 "utilize identical argument syntax."
 msgstr ""
+"前者启用条件编译，后者在运行时条件性地求值为 `true` 或 `false` 字面量，允许在运行时进行检查。两者使用相同的参数语法。"
 
 #: src/attribute/cfg.md:12
 msgid ""
@@ -7456,39 +7467,40 @@ msgid ""
 "when `cfg!` is used for the condition, regardless of what `cfg!` is "
 "evaluating."
 msgstr ""
+"`cfg!` 与 `#[cfg]` 不同，它不会移除任何代码，只会求值为 true 或 false。例如，当 `cfg!` 用于条件时，if/else 表达式中的所有块都需要是有效的，无论 `cfg!` 正在评估什么。"
 
 #: src/attribute/cfg.md:15
 msgid "// This function only gets compiled if the target OS is linux\n"
-msgstr ""
+msgstr "// 这个函数只有在目标操作系统是 linux 时才会被编译\n"
 
 #: src/attribute/cfg.md:16 src/attribute/cfg.md:22 src/attribute/cfg.md:31
 msgid "\"linux\""
-msgstr ""
+msgstr "\"linux\""
 
 #: src/attribute/cfg.md:18
 msgid "\"You are running linux!\""
-msgstr ""
+msgstr "\"你正在运行 linux！\""
 
 #: src/attribute/cfg.md:20
 msgid ""
 "// And this function only gets compiled if the target OS is *not* linux\n"
-msgstr ""
+msgstr "// 而这个函数只有在目标操作系统*不是* linux 时才会被编译\n"
 
 #: src/attribute/cfg.md:24
 msgid "\"You are *not* running linux!\""
-msgstr ""
+msgstr "\"你*不是*在运行 linux！\""
 
 #: src/attribute/cfg.md:30
 msgid "\"Are you sure?\""
-msgstr ""
+msgstr "\"你确定吗？\""
 
 #: src/attribute/cfg.md:32
 msgid "\"Yes. It's definitely linux!\""
-msgstr ""
+msgstr "\"是的。这绝对是 linux！\""
 
 #: src/attribute/cfg.md:34
 msgid "\"Yes. It's definitely *not* linux!\""
-msgstr ""
+msgstr "\"是的。这绝对**不是** linux！\""
 
 #: src/attribute/cfg.md:41
 msgid ""
@@ -7496,24 +7508,26 @@ msgid ""
 "html#conditional-compilation), [`cfg!`](https://doc.rust-lang.org/std/macro."
 "cfg!.html), and [macros](../macros.md)."
 msgstr ""
+"[参考](https://doc.rust-lang.org/reference/attributes.html#conditional-compilation)、[`cfg!`](https://doc.rust-lang.org/std/macro.cfg!.html) 和 [宏](../macros.md)。"
 
 #: src/attribute/cfg/custom.md:3
 msgid ""
 "Some conditionals like `target_os` are implicitly provided by `rustc`, but "
 "custom conditionals must be passed to `rustc` using the `--cfg` flag."
 msgstr ""
+"一些条件如 `target_os` 是由 `rustc` 隐式提供的，但自定义条件必须使用 `--cfg` 标志传递给 `rustc`。"
 
 #: src/attribute/cfg/custom.md:9
 msgid "\"condition met!\""
-msgstr ""
+msgstr "\"条件满足！\""
 
 #: src/attribute/cfg/custom.md:17
 msgid "Try to run this to see what happens without the custom `cfg` flag."
-msgstr ""
+msgstr "尝试运行这个，看看没有自定义 `cfg` 标志会发生什么。"
 
 #: src/attribute/cfg/custom.md:19
 msgid "With the custom `cfg` flag:"
-msgstr ""
+msgstr "使用自定义 `cfg` 标志："
 
 #: src/generics.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -3312,22 +3312,23 @@ msgid ""
 "Rust provides several mechanisms to change or define the type of primitive "
 "and user defined types. The following sections cover:"
 msgstr ""
+"Rust 提供了几种机制来更改或定义原始类型和用户定义类型。以下部分涵盖了："
 
 #: src/types.md:5
 msgid "[Casting](types/cast.md) between primitive types"
-msgstr ""
+msgstr "原始类型之间的[转换](types/cast.md)"
 
 #: src/types.md:6
 msgid "Specifying the desired type of [literals](types/literals.md)"
-msgstr ""
+msgstr "指定[字面值](types/literals.md)的所需类型"
 
 #: src/types.md:7
 msgid "Using [type inference](types/inference.md)"
-msgstr ""
+msgstr "使用[类型推断](types/inference.md)"
 
 #: src/types.md:8
 msgid "[Aliasing](types/alias.md) types"
-msgstr ""
+msgstr "[别名化](types/alias.md)类型"
 
 #: src/types/cast.md:3
 msgid ""
@@ -3335,6 +3336,7 @@ msgid ""
 "But, explicit type conversion (casting) can be performed using the `as` "
 "keyword."
 msgstr ""
+"Rust 不提供原始类型之间的隐式类型转换（coercion, 强制转换）。但是，可以使用 `as` 关键字执行显式类型转换（casting）。"
 
 #: src/types/cast.md:6
 msgid ""
@@ -3342,28 +3344,31 @@ msgid ""
 "except in cases where C has undefined behavior. The behavior of all casts "
 "between integral types is well defined in Rust."
 msgstr ""
+"整型类型之间的转换规则通常遵循 C 语言的惯例，除了 C 语言中存在未定义行为的情况。在 Rust 中，所有整型类型之间的转换行为都是明确定义的。"
 
 #: src/types/cast.md:11
 msgid "// Suppress all warnings from casts which overflow.\n"
-msgstr ""
+msgstr "// 抑制所有来自溢出转换的警告。\n"
 
 #: src/types/cast.md:17
 msgid "// Error! No implicit conversion\n"
-msgstr ""
+msgstr "// 错误！没有隐式转换\n"
 
 #: src/types/cast.md:21
 msgid "// Explicit conversion\n"
-msgstr ""
+msgstr "// 显式转换\n"
 
 #: src/types/cast.md:25
 msgid ""
 "// Error! There are limitations in conversion rules.\n"
 "    // A float cannot be directly converted to a char.\n"
 msgstr ""
+"// 错误！转换规则有限制。\n"
+"    // 浮点数不能直接转换为字符。\n"
 
 #: src/types/cast.md:30
 msgid "\"Casting: {} -> {} -> {}\""
-msgstr ""
+msgstr "\"转换：{} -> {} -> {}\""
 
 #: src/types/cast.md:32
 msgid ""
@@ -3371,14 +3376,17 @@ msgid ""
 "    // T::MAX + 1 is added or subtracted until the value\n"
 "    // fits into the new type\n"
 msgstr ""
+"// 当将任何值转换为无符号类型 T 时，\n"
+"    // 会不断加上或减去 T::MAX + 1，直到该值\n"
+"    // 适合新类型\n"
 
 #: src/types/cast.md:36
 msgid "// 1000 already fits in a u16\n"
-msgstr ""
+msgstr "// 1000 已经适合 u16\n"
 
 #: src/types/cast.md:37
 msgid "\"1000 as a u16 is: {}\""
-msgstr ""
+msgstr "\"1000 作为 u16 是：{}\""
 
 #: src/types/cast.md:39
 msgid ""
@@ -3386,26 +3394,29 @@ msgid ""
 "    // Under the hood, the first 8 least significant bits (LSB) are kept,\n"
 "    // while the rest towards the most significant bit (MSB) get truncated.\n"
 msgstr ""
+"// 1000 - 256 - 256 - 256 = 232\n"
+"    // 在底层，保留了最低有效位（LSB）的前 8 位，\n"
+"    // 而朝最高有效位（MSB）方向的其余位被截断。\n"
 
 #: src/types/cast.md:42 src/types/cast.md:61
 msgid "\"1000 as a u8 is : {}\""
-msgstr ""
+msgstr "\"1000 作为 u8 是：{}\""
 
 #: src/types/cast.md:43
 msgid "// -1 + 256 = 255\n"
-msgstr ""
+msgstr "// -1 + 256 = 255\n"
 
 #: src/types/cast.md:44
 msgid "\"  -1 as a u8 is : {}\""
-msgstr ""
+msgstr "\"  -1 作为 u8 是：{}\""
 
 #: src/types/cast.md:46
 msgid "// For positive numbers, this is the same as the modulus\n"
-msgstr ""
+msgstr "// 对于正数，这与取模操作相同\n"
 
 #: src/types/cast.md:47
 msgid "\"1000 mod 256 is : {}\""
-msgstr ""
+msgstr "\"1000 mod 256 是：{}\""
 
 #: src/types/cast.md:49
 msgid ""
@@ -3414,39 +3425,44 @@ msgid ""
 "significant\n"
 "    // bit of that value is 1, then the value is negative.\n"
 msgstr ""
+"// 当转换为有符号类型时，（按位）结果与\n"
+"    // 首先转换为相应的无符号类型相同。如果该值的最高有效位\n"
+"    // 是 1，那么该值为负数。\n"
 
 #: src/types/cast.md:53
 msgid "// Unless it already fits, of course.\n"
-msgstr ""
+msgstr "// 当然，除非它已经适合。\n"
 
 #: src/types/cast.md:54
 msgid "\" 128 as a i16 is: {}\""
-msgstr ""
+msgstr "\" 128 作为 i16 是：{}\""
 
 #: src/types/cast.md:56
 msgid ""
 "// In boundary case 128 value in 8-bit two's complement representation is "
 "-128\n"
-msgstr ""
+msgstr "// 在边界情况下，128 在 8 位二进制补码表示中是 -128\n"
 
 #: src/types/cast.md:57
 msgid "\" 128 as a i8 is : {}\""
-msgstr ""
+msgstr "\" 128 作为 i8 是：{}\""
 
 #: src/types/cast.md:59
 msgid ""
 "// repeating the example above\n"
 "    // 1000 as u8 -> 232\n"
 msgstr ""
+"// 重复上面的例子\n"
+"    // 1000 作为 u8 -> 232\n"
 
 #: src/types/cast.md:62
 msgid ""
 "// and the value of 232 in 8-bit two's complement representation is -24\n"
-msgstr ""
+msgstr "// 而 232 在 8 位二进制补码表示中是 -24\n"
 
 #: src/types/cast.md:63
 msgid "\" 232 as a i8 is : {}\""
-msgstr ""
+msgstr "\" 232 作为 i8 是：{}\""
 
 #: src/types/cast.md:65
 msgid ""
@@ -3455,30 +3471,33 @@ msgid ""
 "    // the upper bound or is less than the lower bound, the returned value\n"
 "    // will be equal to the bound crossed.\n"
 msgstr ""
+"// 从 Rust 1.45 开始，`as` 关键字在从浮点数转换为整数时执行*饱和转换*\n"
+"    // 如果浮点值超过上界或小于下界，返回值\n"
+"    // 将等于所跨越的边界。\n"
 
 #: src/types/cast.md:70
 msgid "// 300.0 as u8 is 255\n"
-msgstr ""
+msgstr "// 300.0 作为 u8 是 255\n"
 
 #: src/types/cast.md:71 src/types/cast.md:82
 msgid "\" 300.0 as u8 is : {}\""
-msgstr ""
+msgstr "\" 300.0 作为 u8 是：{}\""
 
 #: src/types/cast.md:72
 msgid "// -100.0 as u8 is 0\n"
-msgstr ""
+msgstr "// -100.0 作为 u8 是 0\n"
 
 #: src/types/cast.md:73 src/types/cast.md:84
 msgid "\"-100.0 as u8 is : {}\""
-msgstr ""
+msgstr "\"-100.0 作为 u8 是：{}\""
 
 #: src/types/cast.md:74 src/types/cast.md:85
 msgid "// nan as u8 is 0\n"
-msgstr ""
+msgstr "// nan 作为 u8 是 0\n"
 
 #: src/types/cast.md:75 src/types/cast.md:86
 msgid "\"   nan as u8 is : {}\""
-msgstr ""
+msgstr "\"   nan 作为 u8 是：{}\""
 
 #: src/types/cast.md:77
 msgid ""
@@ -3486,14 +3505,17 @@ msgid ""
 "    // with unsafe methods, however the results might overflow and\n"
 "    // return **unsound values**. Use these methods wisely:\n"
 msgstr ""
+"// 这种行为会产生小的运行时开销，可以通过\n"
+"    // 不安全的方法来避免，但是结果可能会溢出并\n"
+"    // 返回**不健全的值**。请谨慎使用这些方法：\n"
 
 #: src/types/cast.md:81
 msgid "// 300.0 as u8 is 44\n"
-msgstr ""
+msgstr "// 300.0 作为 u8 是 44\n"
 
 #: src/types/cast.md:83
 msgid "// -100.0 as u8 is 156\n"
-msgstr ""
+msgstr "// -100.0 作为 u8 是 156\n"
 
 #: src/types/literals.md:3
 msgid ""
@@ -3501,6 +3523,7 @@ msgid ""
 "example, to specify that the literal `42` should have the type `i32`, write "
 "`42i32`."
 msgstr ""
+"数字字面值可以通过添加类型作为后缀来进行类型注解。例如，要指定字面值 `42` 应该具有 `i32` 类型，可以写成 `42i32`。"
 
 #: src/types/literals.md:6
 msgid ""
@@ -3508,44 +3531,46 @@ msgid ""
 "no constraint exists, the compiler will use `i32` for integers, and `f64` for "
 "floating-point numbers."
 msgstr ""
+"无后缀数字字面值的类型将取决于它们的使用方式。如果没有约束，编译器将对整数使用 `i32`，对浮点数使用 `f64`。"
 
 #: src/types/literals.md:12
 msgid "// Suffixed literals, their types are known at initialization\n"
-msgstr ""
+msgstr "// 带后缀的字面值，它们的类型在初始化时就已知\n"
 
 #: src/types/literals.md:17
 msgid "// Unsuffixed literals, their types depend on how they are used\n"
-msgstr ""
+msgstr "// 无后缀的字面值，它们的类型取决于使用方式\n"
 
 #: src/types/literals.md:21
 msgid "// `size_of_val` returns the size of a variable in bytes\n"
-msgstr ""
+msgstr "// `size_of_val` 返回变量的大小（以字节为单位）\n"
 
 #: src/types/literals.md:22
 msgid "\"size of `x` in bytes: {}\""
-msgstr ""
+msgstr "\"x 的大小（字节）：{}\""
 
 #: src/types/literals.md:23
 msgid "\"size of `y` in bytes: {}\""
-msgstr ""
+msgstr "\"y 的大小（字节）：{}\""
 
 #: src/types/literals.md:24
 msgid "\"size of `z` in bytes: {}\""
-msgstr ""
+msgstr "\"z 的大小（字节）：{}\""
 
 #: src/types/literals.md:25
 msgid "\"size of `i` in bytes: {}\""
-msgstr ""
+msgstr "\"i 的大小（字节）：{}\""
 
 #: src/types/literals.md:26
 msgid "\"size of `f` in bytes: {}\""
-msgstr ""
+msgstr "\"f 的大小（字节）：{}\""
 
 #: src/types/literals.md:30
 msgid ""
 "There are some concepts used in the previous code that haven't been explained "
 "yet, here's a brief explanation for the impatient readers:"
 msgstr ""
+"上面的代码中使用了一些尚未解释的概念，这里为急于了解的读者提供一个简短的解释："
 
 #: src/types/literals.md:33
 msgid ""
@@ -3555,6 +3580,7 @@ msgid ""
 "is defined in the `std` _crate_. For more details, see [modules](../mod.md) "
 "and [crates](../crates.md)."
 msgstr ""
+"`std::mem::size_of_val` 是一个函数，但使用其**完整路径**调用。代码可以分割成称为**模块**的逻辑单元。在这种情况下，`size_of_val` 函数定义在 `mem` 模块中，而 `mem` 模块定义在 `std` *crate* 中。更多详情，请参见[模块](../mod.md)和[crate](../crates.md)。"
 
 #: src/types/inference.md:3
 msgid ""
@@ -3563,37 +3589,43 @@ msgid ""
 "the variable is used afterwards to infer its type. Here's an advanced example "
 "of type inference:"
 msgstr ""
+"类型推断引擎非常智能。它不仅在初始化期间查看值表达式的类型，还会查看变量后续如何使用来推断其类型。以下是一个高级的类型推断示例："
 
 #: src/types/inference.md:10
 msgid ""
 "// Because of the annotation, the compiler knows that `elem` has type u8.\n"
 msgstr ""
+"// 由于注解，编译器知道 `elem` 的类型是 u8。\n"
 
 #: src/types/inference.md:13
 msgid "// Create an empty vector (a growable array).\n"
-msgstr ""
+msgstr "// 创建一个空向量（可增长的数组）。\n"
 
 #: src/types/inference.md:15
 msgid ""
 "// At this point the compiler doesn't know the exact type of `vec`, it\n"
 "    // just knows that it's a vector of something (`Vec<_>`).\n"
 msgstr ""
+"// 在这一点上，编译器不知道 `vec` 的确切类型，\n"
+"    // 它只知道这是一个某种类型的向量（`Vec<_>`）。\n"
 
 #: src/types/inference.md:18
 msgid "// Insert `elem` in the vector.\n"
-msgstr ""
+msgstr "// 将 `elem` 插入向量。\n"
 
 #: src/types/inference.md:20
 msgid ""
 "// Aha! Now the compiler knows that `vec` is a vector of `u8`s (`Vec<u8>`)\n"
 "    // TODO ^ Try commenting out the `vec.push(elem)` line\n"
 msgstr ""
+"// 啊哈！现在编译器知道 `vec` 是一个 `u8` 类型的向量（`Vec<u8>`）\n"
+"    // TODO ^ 尝试注释掉 `vec.push(elem)` 这一行\n"
 
 #: src/types/inference.md:27
 msgid ""
 "No type annotation of variables was needed, the compiler is happy and so is "
 "the programmer!"
-msgstr ""
+msgstr "不需要变量的类型注解，编译器很开心，程序员也很开心！"
 
 #: src/types/alias.md:3
 msgid ""
@@ -3601,34 +3633,37 @@ msgid ""
 "Types must have `UpperCamelCase` names, or the compiler will raise a warning. "
 "The exception to this rule are the primitive types: `usize`, `f32`, etc."
 msgstr ""
+"`type` 语句可以用来给一个已存在的类型起一个新名字。类型必须有 `UpperCamelCase`（大驼峰）的名字，否则编译器会发出警告。这个规则的例外是原始类型：`usize`、`f32` 等。"
 
 #: src/types/alias.md:8
 msgid "// `NanoSecond`, `Inch`, and `U64` are new names for `u64`.\n"
-msgstr ""
+msgstr "// `NanoSecond`、`Inch` 和 `U64` 都是 `u64` 的新名字。\n"
 
 #: src/types/alias.md:14
 msgid "// `NanoSecond` = `Inch` = `U64` = `u64`.\n"
-msgstr ""
+msgstr "// `NanoSecond` = `Inch` = `U64` = `u64`。\n"
 
 #: src/types/alias.md:18
 msgid ""
 "// Note that type aliases *don't* provide any extra type safety, because\n"
 "    // aliases are *not* new types\n"
 msgstr ""
+"// 注意类型别名**不**提供任何额外的类型安全性，因为别名**不是**新的类型\n"
 
 #: src/types/alias.md:20
 msgid "\"{} nanoseconds + {} inches = {} unit?\""
-msgstr ""
+msgstr "\"{} 纳秒 + {} 英寸 = {} 单位？\""
 
 #: src/types/alias.md:27
 msgid ""
 "The main use of aliases is to reduce boilerplate; for example the `io::"
 "Result<T>` type is an alias for the `Result<T, io::Error>` type."
 msgstr ""
+"别名的主要用途是减少样板代码；例如，`io::Result<T>` 类型是 `Result<T, io::Error>` 类型的别名。"
 
 #: src/types/alias.md:32
 msgid "[Attributes](../attribute.md)"
-msgstr ""
+msgstr "[属性](../attribute.md)"
 
 #: src/conversion.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -14315,7 +14315,7 @@ msgid ""
 "(You are encouraged to test the previous example under different failure "
 "conditions: `hello.txt` doesn't exist, or `hello.txt` is not readable, etc.)"
 msgstr ""
-"（我们鼓励你在不同的失败条件下测试前面的例子：`hello.txt` 不存在，或 `hello.txt` 不可读等。）"
+"（再试试在不同的失败条件下测试前面的例子：`hello.txt` 不存在，或 `hello.txt` 不可读等。）"
 
 #: src/std_misc/file/create.md:3
 msgid ""
@@ -14354,7 +14354,7 @@ msgstr "// 以只写模式打开文件，返回 `io::Result<File>`\n"
 
 #: src/std_misc/file/create.md:27
 msgid "\"couldn't create {}: {}\""
-msgstr "\"无法创建 {}: {}\""
+msgstr "\"couldn't create {}: {}\""
 
 #: src/std_misc/file/create.md:31
 msgid "// Write the `LOREM_IPSUM` string to `file`, returns `io::Result<()>`\n"
@@ -14362,18 +14362,18 @@ msgstr "// 将 `LOREM_IPSUM` 字符串写入 `file`，返回 `io::Result<()>`\n"
 
 #: src/std_misc/file/create.md:33
 msgid "\"couldn't write to {}: {}\""
-msgstr "\"无法写入 {}: {}\""
+msgstr "\"couldn't write to {}: {}\""
 
 #: src/std_misc/file/create.md:34
 msgid "\"successfully wrote to {}\""
-msgstr "\"成功写入 {}\""
+msgstr "\"successfully wrote to {}\""
 
 #: src/std_misc/file/create.md:53
 msgid ""
 "(As in the previous example, you are encouraged to test this example under "
 "failure conditions.)"
 msgstr ""
-"（和前面的例子一样，我们鼓励你在失败条件下测试这个例子。）"
+"（和前面的例子一样，再试试在失败条件下测试这个例子。）"
 
 #: src/std_misc/file/create.md:56
 msgid ""
@@ -14392,7 +14392,7 @@ msgid ""
 "This might be a reasonable first attempt for a beginner's first "
 "implementation for reading lines from a file."
 msgstr ""
-"对于初学者来说，这可能是从文件中读取行的第一个合理尝试。"
+"对于初学者来说，这可能是从文件中读取行的第一个尝试。"
 
 #: src/std_misc/file/read_lines.md:22
 msgid ""
@@ -14532,7 +14532,7 @@ msgid ""
 "(You are encouraged to try the previous example with an incorrect flag passed "
 "to `rustc`)"
 msgstr ""
-"（我们鼓励你尝试在前面的例子中向 `rustc` 传递一个错误的标志）"
+"（试试在这个例子中向 `rustc` 传一个错误的参数）"
 
 #: src/std_misc/process/pipe.md:3
 msgid ""
@@ -14540,7 +14540,7 @@ msgid ""
 "`stdin`, `stdout` and `stderr` handles for interaction with the underlying "
 "process via pipes."
 msgstr ""
-"`std::Child` 结构体表示一个正在运行的子进程，并暴露 `stdin`、`stdout` 和 `stderr` 句柄，以通过管道与底层进程进行交互。"
+"`std::Child` 结构体表示一个正在运行的子进程，并暴露 `stdin`、`stdout` 和 `stderr` 句柄，从而通过管道与底层进程进行交互。"
 
 #: src/std_misc/process/pipe.md:11
 msgid "\"the quick brown fox jumps over the lazy dog\\n\""
@@ -14585,8 +14585,8 @@ msgid ""
 msgstr ""
 "// 向 `wc` 的 `stdin` 写入一个字符串。\n"
 "    //\n"
-"    // `stdin` 的类型是 `Option<ChildStdin>`，但由于我们知道这个实例\n"
-"    // 必定有一个，我们可以直接 `unwrap` 它。\n"
+"    // `stdin` 的类型是 `Option<ChildStdin>`，不过我们已经知道这个实例不为空值\n"
+"    // 因此我们可以直接 `unwrap` 它。\n"
 
 #: src/std_misc/process/pipe.md:36
 msgid "\"couldn't write to wc stdin: {}\""
@@ -14604,11 +14604,9 @@ msgid ""
 "    // This is very important, otherwise `wc` wouldn't start processing the\n"
 "    // input we just sent.\n"
 msgstr ""
-"// 因为 `stdin` 在上述调用后不再存活，它被 `drop` 了，\n"
-"    // 管道也被关闭。\n"
+"// 因为 `stdin` 在上述调用后不再存活，被 `drop` 了，管道也被关闭。\n"
 "    //\n"
-"    // 这非常重要，否则 `wc` 不会开始处理\n"
-"    // 我们刚刚发送的输入。\n"
+"    // 这点非常重要，否则 `wc` 就不会开始处理我们刚刚发送的输入。\n"
 
 #: src/std_misc/process/pipe.md:46
 msgid ""
@@ -14638,7 +14636,7 @@ msgstr "\"sleep\""
 
 #: src/std_misc/process/wait.md:13
 msgid "\"reached end of main\""
-msgstr "\"到达 main 的末尾\""
+msgid "\"reached end of main\""
 
 #: src/std_misc/process/wait.md:18
 msgid ""
@@ -14691,7 +14689,7 @@ msgstr "\"`echo hello > a/b.txt`\""
 msgid ""
 "// The previous match can be simplified using the `unwrap_or_else` method\n"
 msgstr ""
-"// 前面的匹配可以使用 `unwrap_or_else` 方法简化\n"
+"// 之前的匹配可以使用 `unwrap_or_else` 方法简化\n"
 
 #: src/std_misc/fs.md:51
 msgid "\"a/b.txt\""
@@ -14703,7 +14701,7 @@ msgstr "\"`mkdir -p a/c/d`\""
 
 #: src/std_misc/fs.md:56
 msgid "// Recursively create a directory, returns `io::Result<()>`\n"
-msgstr "// 递归创建目录，返回 `io::Result<()>`\n"
+msgstr "// 逐层创建目录，返回 `io::Result<()>`\n"
 
 #: src/std_misc/fs.md:57 src/std_misc/fs.md:102
 msgid "\"a/c/d\""
@@ -14865,7 +14863,7 @@ msgstr ""
 
 #: src/std_misc/arg/matching.md:3
 msgid "Matching can be used to parse simple arguments:"
-msgstr "匹配可以用于解析简单的参数："
+msgstr "可以用匹配来解析简单的参数："
 
 #: src/std_misc/arg/matching.md:17
 msgid ""
@@ -14875,11 +14873,11 @@ msgid ""
 "match_args {{increase|decrease}} <integer>\n"
 "    Increase or decrease given integer by one.\""
 msgstr ""
-"\"用法：\n"
-"match_args <字符串>\n"
-"    检查给定的字符串是否是答案。\n"
-"match_args {{increase|decrease}} <整数>\n"
-"    将给定的整数增加或减少一。\""
+"\"usage:\n"
+"match_args <string>\n"
+"    Check whether given string is the answer.\n"
+"match_args {{increase|decrease}} <integer>\n"
+"    Increase or decrease given integer by one.\""
 
 #: src/std_misc/arg/matching.md:28
 msgid "// no arguments passed\n"
@@ -14887,7 +14885,7 @@ msgstr "// 没有传递参数\n"
 
 #: src/std_misc/arg/matching.md:30
 msgid "\"My name is 'match_args'. Try passing some arguments!\""
-msgstr "\"我的名字是 'match_args'。试试传递一些参数！\""
+msgstr "\"My name is 'match_args'. Try passing some arguments!\""
 
 #: src/std_misc/arg/matching.md:32
 msgid "// one argument passed\n"
@@ -14895,11 +14893,11 @@ msgstr "// 传递了一个参数\n"
 
 #: src/std_misc/arg/matching.md:35
 msgid "\"This is the answer!\""
-msgstr "\"这就是答案！\""
+msgstr "\"This is the answer!\""
 
 #: src/std_misc/arg/matching.md:36
 msgid "\"This is not the answer.\""
-msgstr "\"这不是答案。\""
+msgstr "\"This is not the answer.\""
 
 #: src/std_misc/arg/matching.md:39
 msgid "// one command and one argument passed\n"
@@ -14911,7 +14909,7 @@ msgstr "// 解析数字\n"
 
 #: src/std_misc/arg/matching.md:49
 msgid "\"error: second argument not an integer\""
-msgstr "\"错误：第二个参数不是整数\""
+msgstr "\"error: second argument not an integer\""
 
 #: src/std_misc/arg/matching.md:54
 msgid "// parse the command\n"
@@ -14927,7 +14925,7 @@ msgstr "\"decrease\""
 
 #: src/std_misc/arg/matching.md:59
 msgid "\"error: invalid command\""
-msgstr "\"错误：无效的命令\""
+msgstr "\"error: invalid command\""
 
 #: src/std_misc/arg/matching.md:64
 msgid "// all the other cases\n"
@@ -14950,7 +14948,7 @@ msgid ""
 "functions must be declared inside an `extern` block annotated with a "
 "`#[link]` attribute containing the name of the foreign library."
 msgstr ""
-"Rust 为 C 库提供了外部函数接口（FFI）。外部函数必须在 `extern` 块内声明，并使用 `#[link]` 属性注解，其中包含外部库的名称。"
+"Rust 为 C 库提供了外部函数接口（FFI）。外部函数必须在 `extern` 块内声明，并使用 `#[link]` 属性标注外部库的名称。"
 
 #: src/std_misc/ffi.md:9
 msgid "// this extern block links to the libm library\n"
@@ -14977,8 +14975,7 @@ msgid ""
 "// Since calling foreign functions is considered unsafe,\n"
 "// it's common to write safe wrappers around them.\n"
 msgstr ""
-"// 由于调用外部函数被认为是不安全的，\n"
-"// 通常会编写安全的包装函数。\n"
+"// 由于调用外部函数被认为是不安全的，通常会封装一层安全的包装函数。\n"
 
 #: src/std_misc/ffi.md:37
 msgid "// z = -1 + 0i\n"
@@ -14994,7 +14991,7 @@ msgstr "\"{:?} 的平方根是 {:?}\""
 
 #: src/std_misc/ffi.md:45
 msgid "// calling safe API wrapped around unsafe operation\n"
-msgstr "// 调用包装了不安全操作的安全 API\n"
+msgstr "// 调用封装了不安全操作的安全 API \n"
 
 #: src/std_misc/ffi.md:46
 msgid "\"cos({:?}) = {:?}\""
@@ -15064,6 +15061,7 @@ msgid ""
 "setup, run the code we want to test, then assert whether the results are what "
 "we expect."
 msgstr ""
+"测试是用于验证非测试代码是否按预期方式运行的 Rust 函数。测试函数的主体通常执行一些设置，运行我们想要测试的代码，然后断言结果是否符合我们的预期。"
 
 #: src/testing/unit_testing.md:8
 msgid ""
@@ -15071,47 +15069,54 @@ msgid ""
 "[attribute](../attribute.md). Test functions are marked with the `#[test]` "
 "attribute."
 msgstr ""
+"大多数单元测试都放在带有 `#[cfg(test)]` [属性](../attribute.md)的 `tests` [mod](../mod.md) 中。测试函数用 `#[test]` 属性标记。"
 
 #: src/testing/unit_testing.md:11
 msgid ""
 "Tests fail when something in the test function [panics](../std/panic.md). "
 "There are some helper [macros](../macros.md):"
 msgstr ""
+"当测试函数中的某些内容[panic](../std/panic.md)时，测试就会失败。有一些辅助[宏](../macros.md)："
 
 #: src/testing/unit_testing.md:14
 msgid "`assert!(expression)` - panics if expression evaluates to `false`."
-msgstr ""
+msgstr "`assert!(expression)` - 如果表达式计算结果为 `false`，则会 panic。"
 
 #: src/testing/unit_testing.md:15
 msgid ""
 "`assert_eq!(left, right)` and `assert_ne!(left, right)` - testing left and "
 "right expressions for equality and inequality respectively."
 msgstr ""
+"`assert_eq!(left, right)` 和 `assert_ne!(left, right)` - 分别测试左右表达式的相等性和不相等性。"
 
 #: src/testing/unit_testing.md:22
 msgid ""
 "// This is a really bad adding function, its purpose is to fail in this\n"
 "// example.\n"
 msgstr ""
+"// 这是一个非常糟糕的加法函数，它的目的是在这个例子中失败。\n"
 
 #: src/testing/unit_testing.md:32
 msgid ""
 "// Note this useful idiom: importing names from outer (for mod tests) scope.\n"
 msgstr ""
+"// 注意这个有用的习惯用法：从外部（对于 mod tests）作用域导入名称。\n"
 
 #: src/testing/unit_testing.md:42
 msgid ""
 "// This assert would fire and test will fail.\n"
 "        // Please note, that private functions can be tested too!\n"
 msgstr ""
+"// 这个断言会触发，测试将失败。\n"
+"        // 请注意，私有函数也可以被测试！\n"
 
 #: src/testing/unit_testing.md:49
 msgid "Tests can be run with `cargo test`."
-msgstr ""
+msgstr "可以使用 `cargo test` 运行测试。"
 
 #: src/testing/unit_testing.md:73
 msgid "Tests and `?`"
-msgstr ""
+msgstr "测试和 `?`"
 
 #: src/testing/unit_testing.md:74
 msgid ""
@@ -15119,10 +15124,11 @@ msgid ""
 "your unit tests can return `Result<()>`, which lets you use `?` in them! This "
 "can make them much more concise."
 msgstr ""
+"之前的单元测试示例都没有返回类型。但在 Rust 2018 中，你的单元测试可以返回 `Result<()>`，这让你可以在其中使用 `?`！这可以使它们变得更加简洁。"
 
 #: src/testing/unit_testing.md:83
 msgid "\"negative floats don't have square roots\""
-msgstr ""
+msgstr "\"负浮点数没有平方根\""
 
 #: src/testing/unit_testing.md:100
 msgid ""
@@ -15130,10 +15136,11 @@ msgid ""
 "error-handling-and-panics/question-mark-in-main-and-tests.html) for more "
 "details."
 msgstr ""
+"更多详情请参见[《版本指南》](https://doc.rust-lang.org/edition-guide/rust-2018/error-handling-and-panics/question-mark-in-main-and-tests.html)。"
 
 #: src/testing/unit_testing.md:102
 msgid "Testing panics"
-msgstr ""
+msgstr "测试 panic"
 
 #: src/testing/unit_testing.md:104
 msgid ""
@@ -15142,43 +15149,47 @@ msgid ""
 "`expected = ` with the text of the panic message. If your function can panic "
 "in multiple ways, it helps make sure your test is testing the correct panic."
 msgstr ""
+"要检查在某些情况下应该 panic 的函数，请使用 `#[should_panic]` 属性。这个属性接受可选参数 `expected = `，其中包含 panic 消息的文本。如果你的函数可能以多种方式 panic，这有助于确保你的测试正在测试正确的 panic。"
 
 #: src/testing/unit_testing.md:112 src/testing/doc_testing.md:45
 msgid "\"Divide-by-zero error\""
-msgstr ""
+msgstr "\"除以零错误\""
 
 #: src/testing/unit_testing.md:114 src/testing/unit_testing.md:135
 msgid "\"Divide result is zero\""
-msgstr ""
+msgstr "\"除法结果为零\""
 
 #: src/testing/unit_testing.md:142
 msgid "Running these tests gives us:"
-msgstr ""
+msgstr "运行这些测试会得到："
 
 #: src/testing/unit_testing.md:161
 msgid "Running specific tests"
-msgstr ""
+msgstr "运行特定测试"
 
 #: src/testing/unit_testing.md:163
 msgid ""
 "To run specific tests one may specify the test name to `cargo test` command."
 msgstr ""
+"要运行特定的测试，可以在 `cargo test` 命令中指定测试名称。"
 
 #: src/testing/unit_testing.md:179
 msgid ""
 "To run multiple tests one may specify part of a test name that matches all "
 "the tests that should be run."
 msgstr ""
+"要运行多个测试，可以指定测试名称的一部分，该部分匹配所有应该运行的测试。"
 
 #: src/testing/unit_testing.md:197
 msgid "Ignoring tests"
-msgstr ""
+msgstr "忽略测试"
 
 #: src/testing/unit_testing.md:199
 msgid ""
 "Tests can be marked with the `#[ignore]` attribute to exclude some tests. Or "
 "to run them with command `cargo test -- --ignored`"
 msgstr ""
+"可以使用 `#[ignore]` 属性标记测试以排除某些测试。或者使用命令 `cargo test -- --ignored` 运行它们"
 
 #: src/testing/doc_testing.md:3
 msgid ""
@@ -15188,6 +15199,7 @@ msgid ""
 "takes care about correctness, so these code blocks are compiled and used as "
 "documentation tests."
 msgstr ""
+"Rust 项目的主要文档方式是通过注释源代码。文档注释使用 [CommonMark Markdown 规范](https://commonmark.org/)编写，并支持其中的代码块。Rust 注重正确性，因此这些代码块会被编译并用作文档测试。"
 
 #: src/testing/doc_testing.md:10
 msgid ""
@@ -15203,6 +15215,16 @@ msgid ""
 "/// assert_eq!(result, 5);\n"
 "/// ```\n"
 msgstr ""
+"/// 第一行是描述函数的简短摘要。\n"
+"///\n"
+"/// 接下来的几行是详细文档。代码块以三个反引号开始，\n"
+"/// 并且隐含了 `fn main()` 和 `extern crate <cratename>`。\n"
+"/// 假设我们正在测试 `doccomments` crate：\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::add(2, 3);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
 
 #: src/testing/doc_testing.md:23
 msgid ""
@@ -15227,16 +15249,36 @@ msgid ""
 "/// doccomments::div(10, 0);\n"
 "/// ```\n"
 msgstr ""
+"/// 通常文档注释可能包括 \"Examples\"、\"Panics\" 和 \"Failures\" 部分。\n"
+"///\n"
+"/// 下面的函数用于除法运算。\n"
+"///\n"
+"/// # 示例\n"
+"///\n"
+"/// ```\n"
+"/// let result = doccomments::div(10, 2);\n"
+"/// assert_eq!(result, 5);\n"
+"/// ```\n"
+"///\n"
+"/// # Panics\n"
+"///\n"
+"/// 如果第二个参数为零，函数会 panic。\n"
+"///\n"
+"/// ```rust,should_panic\n"
+"/// // 除以零会导致 panic\n"
+"/// doccomments::div(10, 0);\n"
+"/// ```\n"
 
 #: src/testing/doc_testing.md:52
 msgid ""
 "Code blocks in documentation are automatically tested when running the "
 "regular `cargo test` command:"
 msgstr ""
+"在运行常规的 `cargo test` 命令时，文档中的代码块会自动进行测试："
 
 #: src/testing/doc_testing.md:71
 msgid "Motivation behind documentation tests"
-msgstr ""
+msgstr "文档测试的动机"
 
 #: src/testing/doc_testing.md:73
 msgid ""
@@ -15250,6 +15292,7 @@ msgid ""
 "hide it and `unwrap` it in hidden `main`. Sounds complicated? Here's an "
 "example:"
 msgstr ""
+"文档测试的主要目的是作为练习功能的示例，这是最重要的[指南](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#examples-use--not-try-not-unwrap-c-question-mark)之一。它允许将文档中的示例作为完整的代码片段使用。但是使用 `?` 会导致编译失败，因为 `main` 返回 `unit`。隐藏文档中的某些源代码行可以解决这个问题：可以编写 `fn try_main() -> Result<(), ErrorType>`，隐藏它并在隐藏的 `main` 中 `unwrap` 它。听起来很复杂？这里有一个例子："
 
 #: src/testing/doc_testing.md:82
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -4264,215 +4264,227 @@ msgstr "// TODO ^ 尝试注释掉其中一个分支\n"
 
 #: src/flow_control/match/destructuring.md:3
 msgid "A `match` block can destructure items in a variety of ways."
-msgstr ""
+msgstr "`match` 块可以以多种方式解构项。"
 
 #: src/flow_control/match/destructuring.md:5
 msgid "[Destructuring Tuples](destructuring/destructure_tuple.md)"
-msgstr ""
+msgstr "[解构元组](destructuring/destructure_tuple.md)"
 
 #: src/flow_control/match/destructuring.md:6
 msgid "[Destructuring Arrays and Slices](destructuring/destructure_slice.md)"
-msgstr ""
+msgstr "[解构数组和切片](destructuring/destructure_slice.md)"
 
 #: src/flow_control/match/destructuring.md:7
 msgid "[Destructuring Enums](destructuring/destructure_enum.md)"
-msgstr ""
+msgstr "[解构枚举](destructuring/destructure_enum.md)"
 
 #: src/flow_control/match/destructuring.md:8
 msgid "[Destructuring Pointers](destructuring/destructure_pointers.md)"
-msgstr ""
+msgstr "[解构指针](destructuring/destructure_pointers.md)"
 
 #: src/flow_control/match/destructuring.md:9
 msgid "[Destructuring Structures](destructuring/destructure_structures.md)"
-msgstr ""
+msgstr "[解构结构体](destructuring/destructure_structures.md)"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:3
 msgid "Tuples can be destructured in a `match` as follows:"
-msgstr ""
+msgstr "元组可以在 `match` 中按如下方式解构："
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:8
 msgid "// TODO ^ Try different values for `triple`\n"
-msgstr ""
+msgstr "// TODO ^ 尝试为 `triple` 赋予不同的值\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:10
 msgid "\"Tell me about {:?}\""
-msgstr ""
+msgstr "\"Tell me about {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:11
 msgid "// Match can be used to destructure a tuple\n"
-msgstr ""
+msgstr "// match 可以用来解构一个元组\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:13
 msgid "// Destructure the second and third elements\n"
-msgstr ""
+msgstr "// 解构第二和第三个元素\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:14
 msgid "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
-msgstr ""
+msgstr "\"First is `0`, `y` is {:?}, and `z` is {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:15
 msgid "\"First is `1` and the rest doesn't matter\""
-msgstr ""
+msgstr "\"First is `1` and the rest doesn't matter\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:16
 msgid "\"last is `2` and the rest doesn't matter\""
-msgstr ""
+msgstr "\"last is `2` and the rest doesn't matter\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:17
 msgid "\"First is `3`, last is `4`, and the rest doesn't matter\""
-msgstr ""
+msgstr "\"First is `3`, last is `4`, and the rest doesn't matter\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:18
 msgid "// `..` can be used to ignore the rest of the tuple\n"
-msgstr ""
+msgstr "// `..` 可以用来忽略元组中的其余部分\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:19
 msgid "\"It doesn't matter what they are\""
-msgstr ""
+msgstr "\"It doesn't matter what they are\""
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:20
 msgid "// `_` means don't bind the value to a variable\n"
-msgstr ""
+msgstr "// `_` 表示不将值绑定到变量\n"
 
 #: src/flow_control/match/destructuring/destructure_tuple.md:27
 msgid "[Tuples](../../../primitives/tuples.md)"
-msgstr ""
+msgstr "[元组](../../../primitives/tuples.md)"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:3
 msgid "Like tuples, arrays and slices can be destructured this way:"
-msgstr ""
+msgstr "像元组一样，数组和切片也可以用这种方式解构："
 
 #: src/flow_control/match/destructuring/destructure_slice.md:7
 msgid "// Try changing the values in the array, or make it a slice!\n"
-msgstr ""
+msgstr "// 尝试改变数组中的值，或者将其变成一个切片！\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:11
 msgid "// Binds the second and the third elements to the respective variables\n"
-msgstr ""
+msgstr "// 将第二个和第三个元素分别绑定到相应的变量\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:13
 msgid "\"array[0] = 0, array[1] = {}, array[2] = {}\""
-msgstr ""
+msgstr "\"array[0] = 0, array[1] = {}, array[2] = {}\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:15
 msgid "// Single values can be ignored with _\n"
-msgstr ""
+msgstr "// 单个值可以用 _ 忽略\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:17
 msgid "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
-msgstr ""
+msgstr "\"array[0] = 1, array[2] = {} and array[1] was ignored\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:21
 msgid "// You can also bind some and ignore the rest\n"
-msgstr ""
+msgstr "// 你也可以绑定一些值并忽略其余的\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:23
 msgid "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
-msgstr ""
+msgstr "\"array[0] = -1, array[1] = {} and all the other ones were ignored\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:26
 msgid ""
 "// The code below would not compile\n"
 "        // [-1, second] => ...\n"
 msgstr ""
+"// 下面的代码无法编译\n"
+"        // [-1, second] => ...\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:29
 msgid ""
 "// Or store them in another array/slice (the type depends on\n"
 "        // that of the value that is being matched against)\n"
 msgstr ""
+"// 或者将它们存储在另一个数组/切片中（类型取决于\n"
+"        // 正在匹配的值的类型）\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:32
 msgid "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
-msgstr ""
+msgstr "\"array[0] = 3, array[1] = {} and the other elements were {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:36
 msgid ""
 "// Combining these patterns, we can, for example, bind the first and\n"
 "        // last values, and store the rest of them in a single array\n"
 msgstr ""
+"// 结合这些模式，我们可以，例如，绑定第一个和\n"
+"        // 最后一个值，并将其余的存储在一个单独的数组中\n"
 
 #: src/flow_control/match/destructuring/destructure_slice.md:39
 msgid "\"array[0] = {}, middle = {:?}, array[2] = {}\""
-msgstr ""
+msgstr "\"array[0] = {}, middle = {:?}, array[2] = {}\""
 
 #: src/flow_control/match/destructuring/destructure_slice.md:48
 msgid ""
 "[Arrays and Slices](../../../primitives/array.md) and [Binding](../binding."
 "md) for `@` sigil"
 msgstr ""
+"[数组和切片](../../../primitives/array.md) 和 [绑定](../binding."
+"md) 中的 `@` 符号"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:3
 msgid "An `enum` is destructured similarly:"
-msgstr ""
+msgstr "`enum` 的解构方式类似："
 
 #: src/flow_control/match/destructuring/destructure_enum.md:6
 msgid ""
 "// `allow` required to silence warnings because only\n"
 "// one variant is used.\n"
 msgstr ""
+"// 需要 `allow` 来消除警告，因为只使用了\n"
+"// 一个变体。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:10
 msgid "// These 3 are specified solely by their name.\n"
-msgstr ""
+msgstr "// 这 3 个仅由它们的名称指定。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:14
 msgid "// These likewise tie `u32` tuples to different names: color models.\n"
-msgstr ""
+msgstr "// 这些同样将 `u32` 元组绑定到不同的名称：颜色模型。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:24
 msgid "// TODO ^ Try different variants for `color`\n"
-msgstr ""
+msgstr "// TODO ^ 尝试为 `color` 使用不同的变体\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:26
 msgid "\"What color is it?\""
-msgstr ""
+msgstr "\"What color is it?\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:27
 msgid "// An `enum` can be destructured using a `match`.\n"
-msgstr ""
+msgstr "// 可以使用 `match` 来解构 `enum`。\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:29
 msgid "\"The color is Red!\""
-msgstr ""
+msgstr "\"The color is Red!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:30
 msgid "\"The color is Blue!\""
-msgstr ""
+msgstr "\"The color is Blue!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:31
 msgid "\"The color is Green!\""
-msgstr ""
+msgstr "\"The color is Green!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:33
 msgid "\"Red: {}, green: {}, and blue: {}!\""
-msgstr ""
+msgstr "\"Red: {}, green: {}, and blue: {}!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:35
 msgid "\"Hue: {}, saturation: {}, value: {}!\""
-msgstr ""
+msgstr "\"Hue: {}, saturation: {}, value: {}!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:37
 msgid "\"Hue: {}, saturation: {}, lightness: {}!\""
-msgstr ""
+msgstr "\"Hue: {}, saturation: {}, lightness: {}!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:39
 msgid "\"Cyan: {}, magenta: {}, yellow: {}!\""
-msgstr ""
+msgstr "\"Cyan: {}, magenta: {}, yellow: {}!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:41
 msgid "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
-msgstr ""
+msgstr "\"Cyan: {}, magenta: {}, yellow: {}, key (black): {}!\""
 
 #: src/flow_control/match/destructuring/destructure_enum.md:43
 msgid "// Don't need another arm because all variants have been examined\n"
-msgstr ""
+msgstr "// 不需要另一个分支，因为所有变体都已经被检查过了\n"
 
 #: src/flow_control/match/destructuring/destructure_enum.md:50
 msgid ""
 "[`#[allow(...)]`](../../../attribute/unused.md), [color models](https://en."
 "wikipedia.org/wiki/Color_model) and [`enum`](../../../custom_types/enum.md)"
 msgstr ""
+"[`#[allow(...)]`](../../../attribute/unused.md)，[颜色模型](https://en."
+"wikipedia.org/wiki/Color_model) 和 [`enum`](../../../custom_types/enum.md)"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:3
 msgid ""
@@ -4480,20 +4492,23 @@ msgid ""
 "dereferencing as they are different concepts which are used differently from "
 "languages like C/C++."
 msgstr ""
+"对于指针，需要区分解构（destructure）和解引用（dereference），因为它们是不同的概念，其使用方式与 C/C++ 等语言不同。"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:7
 msgid "Dereferencing uses `*`"
-msgstr ""
+msgstr "解引用使用 `*`"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:8
 msgid "Destructuring uses `&`, `ref`, and `ref mut`"
-msgstr ""
+msgstr "解构使用 `&`、`ref` 和 `ref mut`"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:12
 msgid ""
 "// Assign a reference of type `i32`. The `&` signifies there\n"
 "    // is a reference being assigned.\n"
 msgstr ""
+"// 分配一个 `i32` 类型的引用。`&` 表示\n"
+"    // 正在分配一个引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:17
 msgid ""
@@ -4504,18 +4519,24 @@ msgid ""
 "        // ^ We see that if the matching `&`s are dropped, then the `i32`\n"
 "        // should be assigned to `val`.\n"
 msgstr ""
+"// 如果 `reference` 与 `&val` 进行模式匹配，结果\n"
+"        // 就像这样的比较：\n"
+"        // `&i32`\n"
+"        // `&val`\n"
+"        // ^ 我们看到如果匹配的 `&` 被去掉，那么 `i32`\n"
+"        // 应该被赋值给 `val`。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:23
 msgid "\"Got a value via destructuring: {:?}\""
-msgstr ""
+msgstr "\"通过解构获得一个值：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:26
 msgid "// To avoid the `&`, you dereference before matching.\n"
-msgstr ""
+msgstr "// 为了避免 `&`，你可以在匹配之前解引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:28
 msgid "\"Got a value via dereferencing: {:?}\""
-msgstr ""
+msgstr "\"通过解引用获得一个值：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:31
 msgid ""
@@ -4523,6 +4544,9 @@ msgid ""
 "    // because the right side was already a reference. This is not\n"
 "    // a reference because the right side is not one.\n"
 msgstr ""
+"// 如果你一开始没有引用怎么办？`reference` 是一个 `&`\n"
+"    // 因为右侧已经是一个引用。这不是\n"
+"    // 一个引用，因为右侧不是引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:36
 msgid ""
@@ -4530,94 +4554,105 @@ msgid ""
 "    // assignment so that a reference is created for the element; this\n"
 "    // reference is assigned.\n"
 msgstr ""
+"// Rust 提供 `ref` 正是为了这个目的。它修改了\n"
+"    // 赋值，使得为元素创建一个引用；这个\n"
+"    // 引用被赋值。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:41
 msgid ""
 "// Accordingly, by defining 2 values without references, references\n"
 "    // can be retrieved via `ref` and `ref mut`.\n"
 msgstr ""
+"// 相应地，通过定义两个没有引用的值，可以\n"
+"    // 通过 `ref` 和 `ref mut` 获取引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:46
 msgid "// Use `ref` keyword to create a reference.\n"
-msgstr ""
+msgstr "// 使用 `ref` 关键字创建一个引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:48
 msgid "\"Got a reference to a value: {:?}\""
-msgstr ""
+msgstr "\"获得一个值的引用：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:51
 msgid "// Use `ref mut` similarly.\n"
-msgstr ""
+msgstr "// 类似地使用 `ref mut`。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:54
 msgid ""
 "// Got a reference. Gotta dereference it before we can\n"
 "            // add anything to it.\n"
 msgstr ""
+"// 获得一个引用。在我们能够\n"
+"            // 对其进行任何添加操作之前，必须先解引用。\n"
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:57
 msgid "\"We added 10. `mut_value`: {:?}\""
-msgstr ""
+msgstr "\"我们加了 10。`mut_value`：{:?}\""
 
 #: src/flow_control/match/destructuring/destructure_pointers.md:65
 msgid "[The ref pattern](../../../scope/borrow/ref.md)"
-msgstr ""
+msgstr "[ref 模式](../../../scope/borrow/ref.md)"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:3
 msgid "Similarly, a `struct` can be destructured as shown:"
-msgstr ""
+msgstr "类似地，`struct` 可以按如下方式解构："
 
 #: src/flow_control/match/destructuring/destructure_structures.md:12
 msgid "// Try changing the values in the struct to see what happens\n"
-msgstr ""
+msgstr "// 尝试改变结构体中的值，看看会发生什么\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:16
 msgid "\"First of x is 1, b = {},  y = {} \""
-msgstr ""
+msgstr "\"x 的第一个元素是 1，b = {}，y = {} \""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:18
 msgid ""
 "// you can destructure structs and rename the variables,\n"
 "        // the order is not important\n"
 msgstr ""
+"// 你可以解构结构体并重命名变量，\n"
+"        // 顺序并不重要\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:20
 msgid "\"y is 2, i = {:?}\""
-msgstr ""
+msgstr "\"y 是 2，i = {:?}\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:22
 msgid "// and you can also ignore some variables:\n"
-msgstr ""
+msgstr "// 你也可以忽略一些变量：\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:23
 msgid "\"y = {}, we don't care about x\""
-msgstr ""
+msgstr "\"y = {}，我们不关心 x\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:24
 msgid ""
 "// this will give an error: pattern does not mention field `x`\n"
 "        //Foo { y } => println!(\"y = {}\", y),\n"
 msgstr ""
+"// 这会产生一个错误：模式没有提到字段 `x`\n"
+"        //Foo { y } => println!(\"y = {}\", y),\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:30
 msgid "// You do not need a match block to destructure structs:\n"
-msgstr ""
+msgstr "// 你不需要 match 块来解构结构体：\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:32
 msgid "\"Outside: x0 = {x0:?}, y0 = {y0}\""
-msgstr ""
+msgstr "\"外部：x0 = {x0:?}，y0 = {y0}\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:34
 msgid "// Destructuring works with nested structs as well:\n"
-msgstr ""
+msgstr "// 解构也适用于嵌套的结构体：\n"
 
 #: src/flow_control/match/destructuring/destructure_structures.md:41
 msgid "\"Nested: nested_x = {nested_x:?}, nested_y = {nested_y:?}\""
-msgstr ""
+msgstr "\"嵌套：nested_x = {nested_x:?}，nested_y = {nested_y:?}\""
 
 #: src/flow_control/match/destructuring/destructure_structures.md:47
 msgid "[Structs](../../../custom_types/structs.md)"
-msgstr ""
+msgstr "[结构体](../../../custom_types/structs.md)"
 
 #: src/flow_control/match/guard.md:3
 msgid "A `match` _guard_ can be added to filter the arm."

--- a/po/zh.po
+++ b/po/zh.po
@@ -466,7 +466,7 @@ msgstr "派生"
 
 #: src/SUMMARY.md:139 src/trait/dyn.md:1
 msgid "Returning Traits with `dyn`"
-msgstr "使用 `dyn` 返回特性"
+msgstr "使用 `dyn` 返回 trait"
 
 #: src/SUMMARY.md:140 src/trait/ops.md:1
 msgid "Operator Overloading"
@@ -771,7 +771,7 @@ msgstr "Playground"
 
 #: src/index.md:1
 msgid "Rust by Example"
-msgstr ""
+msgstr "通过例子学 Rust"
 
 #: src/index.md:3
 msgid ""
@@ -779,6 +779,7 @@ msgid ""
 "focusing on safety, speed, and concurrency. It accomplishes these goals by "
 "being memory safe without using garbage collection."
 msgstr ""
+"[Rust](https://www.rust-lang.org/) 是一种现代的系统编程语言，专注于安全性、速度和并发性。它通过不使用垃圾回收来实现这些目标，确保了内存安全。"
 
 #: src/index.md:7
 msgid ""
@@ -789,134 +790,135 @@ msgid ""
 "std/). Additionally for the curious, you can also [check out the source code "
 "for this site](https://github.com/rust-lang/rust-by-example)."
 msgstr ""
+"《通过例子学 Rust》（Rust By Example, RBE）是一系列可运行的实例，它们展示了各种 Rust 概念和标准库。为了更好地利用这些实例，请不要忘记[本地安装 Rust](https://www.rust-lang.org/tools/install)并查看[官方文档](https://doc.rust-lang.org/)。此外，对于好奇的人来说，你也可以[查看这个网站的源代码](https://github.com/rust-lang/rust-by-example)。"
 
 #: src/index.md:12
 msgid "Now let's begin!"
-msgstr ""
+msgstr "现在让我们开始吧！"
 
 #: src/index.md:14
 msgid "[Hello World](hello.md) - Start with a traditional Hello World program."
-msgstr ""
+msgstr "[Hello World](hello.md) - 从一个传统的 Hello World 程序开始。"
 
 #: src/index.md:16
 msgid ""
 "[Primitives](primitives.md) - Learn about signed integers, unsigned integers "
 "and other primitives."
-msgstr ""
+msgstr "[Primitives](primitives.md) - 学习有关有符号整数、无符号整数和其他原始类型的信息。"
 
 #: src/index.md:18
 msgid "[Custom Types](custom_types.md) - `struct` and `enum`."
-msgstr ""
+msgstr "[自定义类型](custom_types.md) - 结构体 `struct` 和枚举 `enum`。"
 
 #: src/index.md:20
 msgid ""
 "[Variable Bindings](variable_bindings.md) - mutable bindings, scope, "
 "shadowing."
-msgstr ""
+msgstr "[变量绑定](variable_bindings.md) - 可变绑定、作用域、遮蔽。"
 
 #: src/index.md:22
 msgid "[Types](types.md) - Learn about changing and defining types."
-msgstr ""
+msgstr "[类型](types.md) - 学习如何改变和定义类型。"
 
 #: src/index.md:24
 msgid ""
 "[Conversion](conversion.md) - Convert between different types, such as "
 "strings, integers, and floats."
-msgstr ""
+msgstr "[转换](conversion.md) - 在不同类型的数据之间进行转换，如字符串、整数和浮点数。"
 
 #: src/index.md:26
 msgid ""
 "[Expressions](expression.md) - Learn about Expressions & how to use them."
-msgstr ""
+msgstr "[表达式](expression.md) - 学习表达式及其使用方法。"
 
 #: src/index.md:28
 msgid "[Flow of Control](flow_control.md) - `if`/`else`, `for`, and others."
-msgstr ""
+msgstr "[控制流](flow_control.md) - `if`/`else`、`for` 等。"
 
 #: src/index.md:30
 msgid ""
 "[Functions](fn.md) - Learn about Methods, Closures and Higher Order Functions."
-msgstr ""
+msgstr "[函数](fn.md) - 学习方法、闭包和高阶函数。"
 
 #: src/index.md:32
 msgid "[Modules](mod.md) - Organize code using modules"
-msgstr ""
+msgstr "[模块](mod.md) - 使用模块组织代码"
 
 #: src/index.md:34
 msgid ""
 "[Crates](crates.md) - A crate is a compilation unit in Rust. Learn to create "
 "a library."
-msgstr ""
+msgstr "[Crates](crates.md) - Crate 是 Rust 中的编译单元。学习如何创建库。"
 
 #: src/index.md:36
 msgid ""
 "[Cargo](cargo.md) - Go through some basic features of the official Rust "
 "package management tool."
-msgstr ""
+msgstr "[Cargo](cargo.md) - 了解官方 Rust 包管理工具的一些基本特性。"
 
 #: src/index.md:38
 msgid ""
 "[Attributes](attribute.md) - An attribute is metadata applied to some module, "
 "crate or item."
-msgstr ""
+msgstr "[属性](attribute.md) - 属性是应用于某些模块、crate 或项目项的元数据。"
 
 #: src/index.md:40
 msgid ""
 "[Generics](generics.md) - Learn about writing a function or data type which "
 "can work for multiple types of arguments."
-msgstr ""
+msgstr "[泛型](generics.md) - 学习编写可以适用于多种类型参数的函数或数据类型。"
 
 #: src/index.md:42
 msgid ""
 "[Scoping rules](scope.md) - Scopes play an important part in ownership, "
 "borrowing, and lifetimes."
-msgstr ""
+msgstr "[作用域规则](scope.md) - 作用域在所有权(ownership)、借用(borrowing)和生命周期(lifetime)中扮演重要角色。"
 
 #: src/index.md:44
 msgid ""
 "[Traits](trait.md) - A trait is a collection of methods defined for an "
 "unknown type: `Self`"
-msgstr ""
+msgstr "[特质](trait.md) - 特质(trait)是为未知类型 `Self` 定义的一组方法。"
 
 #: src/index.md:46
 msgid ""
 "[Macros](macros.md) - Macros are a way of writing code that writes other "
 "code, which is known as metaprogramming."
-msgstr ""
+msgstr "[宏](macros.md) - 宏是一种编写代码以生成其他代码的方式，这被称为元编程。"
 
 #: src/index.md:48
 msgid "[Error handling](error.md) - Learn Rust way of handling failures."
-msgstr ""
+msgstr "[错误处理](error.md) - 学习 Rust 处理失败的方式。"
 
 #: src/index.md:50
 msgid ""
 "[Std library types](std.md) - Learn about some custom types provided by `std` "
 "library."
-msgstr ""
+msgstr "[标准库类型](std.md) - 学习 `std` 标准库提供的某些自定义类型。"
 
 #: src/index.md:52
 msgid "[Std misc](std_misc.md) - More custom types for file handling, threads."
-msgstr ""
+msgstr "[标准库中的其他内容](std_misc.md) - 文件处理、线程的更多自定义类型。"
 
 #: src/index.md:54
 msgid "[Testing](testing.md) - All sorts of testing in Rust."
-msgstr ""
+msgstr "[测试](testing.md) - Rust 中的各种测试。"
 
 #: src/index.md:56
 msgid ""
 "[Unsafe Operations](unsafe.md) - Learn about entering a block of unsafe "
 "operations."
-msgstr ""
+msgstr "[不安全操作](unsafe.md) - 学习进入不安全操作块。"
 
 #: src/index.md:58
 msgid ""
 "[Compatibility](compatibility.md) - Handling Rust's evolution and potential "
 "compatibility issues."
-msgstr ""
+msgstr "[兼容性](compatibility.md) - 处理 Rust 的发展和潜在的兼容性问题。"
 
 #: src/index.md:60
 msgid "[Meta](meta.md) - Documentation, Benchmarking."
-msgstr ""
+msgstr "[补充](meta.md) - 文档，基准测试。"
 
 #: src/hello.md:3
 msgid "This is the source code of the traditional Hello World program."

--- a/po/zh.po
+++ b/po/zh.po
@@ -1137,47 +1137,49 @@ msgstr "[文档注释](../meta/doc.md)"
 msgid ""
 "Printing is handled by a series of [`macros`](../macros.md) defined in [`std::"
 "fmt`](https://doc.rust-lang.org/std/fmt/) some of which are:"
-msgstr ""
+msgstr "打印功能由定义在 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) 中的一系列 [`macros`](../macros.md) 处理，其中包括："
 
 #: src/hello/print.md:6
 msgid "`format!`: write formatted text to [`String`](../std/str.md)"
-msgstr ""
+msgstr "`format!`: 将格式化文本写入 [`String`](../std/str.md)"
 
 #: src/hello/print.md:7
 msgid ""
 "`print!`: same as `format!` but the text is printed to the console (io::"
 "stdout)."
-msgstr ""
+msgstr "`print!`: 与 `format!` 相同，但文本将被打印到控制台（io::stdout）."
 
 #: src/hello/print.md:9
 msgid "`println!`: same as `print!` but a newline is appended."
-msgstr ""
+msgstr "`println!`: 与 `print!` 相同，但会追加一个新行。"
 
 #: src/hello/print.md:10
 msgid ""
 "`eprint!`: same as `print!` but the text is printed to the standard error "
 "(io::stderr)."
-msgstr ""
+msgstr "`eprint!`: 与 `print!` 相同，但文本将被打印到标准错误输出（io::stderr）."
 
 #: src/hello/print.md:12
 msgid "`eprintln!`: same as `eprint!` but a newline is appended."
-msgstr ""
+msgstr "`eprintln!`: 与 `eprint!` 相同，但会追加一个新行。"
 
 #: src/hello/print.md:14
 msgid ""
 "All parse text in the same fashion. As a plus, Rust checks formatting "
 "correctness at compile time."
-msgstr ""
+msgstr "所有这些都以相同的方式解析文本。此外，Rust 会在编译时检查格式化的正确性。"
 
 #: src/hello/print.md:19
 msgid ""
 "// In general, the `{}` will be automatically replaced with any\n"
 "    // arguments. These will be stringified.\n"
 msgstr ""
+"// 通常，`{}` 将自动替换为任何\n"
+"    // 参数。这些将被转换为字符串。\n"
 
 #: src/hello/print.md:21
 msgid "\"{} days\""
-msgstr ""
+msgstr "\"{} 天\""
 
 #: src/hello/print.md:23
 msgid ""
@@ -1186,49 +1188,54 @@ msgid ""
 "start\n"
 "    // at 0 immediately after the format string.\n"
 msgstr ""
+"// 可以使用位置参数。在 `{}` 中指定一个整数\n"
+"    // 决定了哪个附加参数将被替换。参数\n"
+"    // 在格式字符串之后立即从 0 开始。\n"
 
 #: src/hello/print.md:26
 msgid "\"{0}, this is {1}. {1}, this is {0}\""
-msgstr ""
+msgstr "\"{0}，这是 {1}。{1}，这是 {0}\""
 
 #: src/hello/print.md:26 src/scope/move/partial_move.md:20
 msgid "\"Alice\""
-msgstr ""
+msgstr "\"Alice\""
 
 #: src/hello/print.md:26 src/flow_control/for.md:65 src/flow_control/for.md:85
 #: src/flow_control/for.md:104
 msgid "\"Bob\""
-msgstr ""
+msgstr "\"Bob\""
 
 #: src/hello/print.md:28
 msgid "// As can named arguments.\n"
-msgstr ""
+msgstr "// 也可以使用命名参数。\n"
 
 #: src/hello/print.md:29
 msgid "\"{subject} {verb} {object}\""
-msgstr ""
+msgstr "\"{subject} {verb} {object}\""
 
 #: src/hello/print.md:30
 msgid "\"the lazy dog\""
-msgstr ""
+msgstr "\"懒惰的狗\""
 
 #: src/hello/print.md:31
 msgid "\"the quick brown fox\""
-msgstr ""
+msgstr "\"快速的棕色狐狸\""
 
 #: src/hello/print.md:32
 msgid "\"jumps over\""
-msgstr ""
+msgstr "\"跳过\""
 
 #: src/hello/print.md:34
 msgid ""
 "// Different formatting can be invoked by specifying the format character\n"
 "    // after a `:`.\n"
 msgstr ""
+"// 通过在 `:` 后指定格式字符，可以调用不同的格式化\n"
+"    // 方式。\n"
 
 #: src/hello/print.md:36
 msgid "\"Base 10:               {}\""
-msgstr ""
+msgstr "\"10 进制：               {}\""
 
 #: src/hello/print.md:36
 msgid "// 69420\n"
@@ -1236,7 +1243,7 @@ msgstr ""
 
 #: src/hello/print.md:37
 msgid "\"Base 2 (binary):       {:b}\""
-msgstr ""
+msgstr "\"2 进制（二进制）：    {:b}\""
 
 #: src/hello/print.md:37
 msgid "// 10000111100101100\n"
@@ -1244,7 +1251,7 @@ msgstr ""
 
 #: src/hello/print.md:38
 msgid "\"Base 8 (octal):        {:o}\""
-msgstr ""
+msgstr "\"8 进制（八进制）：     {:o}\""
 
 #: src/hello/print.md:38
 msgid "// 207454\n"
@@ -1252,7 +1259,7 @@ msgstr ""
 
 #: src/hello/print.md:39
 msgid "\"Base 16 (hexadecimal): {:x}\""
-msgstr ""
+msgstr "\"16 进制（十六进制）：   {:x}\""
 
 #: src/hello/print.md:39
 msgid "// 10f2c\n"
@@ -1264,28 +1271,32 @@ msgid ""
 "    // output \"    1\". (Four white spaces and a \"1\", for a total width of "
 "5.)\n"
 msgstr ""
+"// 你可以使用指定的宽度对文本进行右对齐。这将\n"
+"    // 输出 \"    1\"。（四个空格和一个 \"1\"，总宽度为 5。）\n"
 
 #: src/hello/print.md:43
 msgid "\"{number:>5}\""
-msgstr ""
+msgstr "\"{number:>5}\""
 
 #: src/hello/print.md:45
 msgid "// You can pad numbers with extra zeroes,\n"
-msgstr ""
+msgstr "// 你可以用额外的零来填充数字，\n"
 
 #: src/hello/print.md:46
 msgid "\"{number:0>5}\""
-msgstr ""
+msgstr "\"{number:0>5}\""
 
 #: src/hello/print.md:46
 msgid ""
 "// 00001\n"
 "    // and left-adjust by flipping the sign. This will output \"10000\".\n"
 msgstr ""
+"// 00001\n"
+"    // 并通过翻转符号进行左对齐。这将输出 \"10000\"。\n"
 
 #: src/hello/print.md:48
 msgid "\"{number:0<5}\""
-msgstr ""
+msgstr "\"{number:0<5}\""
 
 #: src/hello/print.md:48
 msgid "// 10000\n"
@@ -1295,37 +1306,40 @@ msgstr ""
 msgid ""
 "// You can use named arguments in the format specifier by appending a `$`.\n"
 msgstr ""
+"// 你可以通过在格式说明符后附加 `$` 来使用命名参数。\n"
 
 #: src/hello/print.md:51
 msgid "\"{number:0>width$}\""
-msgstr ""
+msgstr "\"{number:0>width$}\""
 
 #: src/hello/print.md:53
 msgid ""
 "// Rust even checks to make sure the correct number of arguments are used.\n"
-msgstr ""
+msgstr "// Rust 甚至会检查使用的正确参数数量。\n"
 
 #: src/hello/print.md:54
 msgid "\"My name is {0}, {1} {0}\""
-msgstr ""
+msgstr "\"我的名字是 {0}，{1} {0}\""
 
 #: src/hello/print.md:54
 msgid "\"Bond\""
-msgstr ""
+msgstr "\"Bond\""
 
 #: src/hello/print.md:55
 msgid "// FIXME ^ Add the missing argument: \"James\"\n"
-msgstr ""
+msgstr "// FIXME ^ 添加缺失的参数：\"James\"\n"
 
 #: src/hello/print.md:57
 msgid ""
 "// Only types that implement fmt::Display can be formatted with `{}`. User-\n"
 "    // defined types do not implement fmt::Display by default.\n"
 msgstr ""
+"// 只有实现了 fmt::Display 的类型才能使用 `{}` 进行格式化。用户\n"
+"    // 定义的类型默认不会实现 fmt::Display。\n"
 
 #: src/hello/print.md:60
 msgid "// disable `dead_code` which warn against unused module\n"
-msgstr ""
+msgstr "// 禁用 `dead_code`，它用于警告未使用的模块\n"
 
 #: src/hello/print.md:63
 msgid ""
@@ -1334,6 +1348,10 @@ msgid ""
 "    // println!(\"This struct `{}` won't print...\", Structure(3));\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 这将无法编译，因为 `Structure` 没有实现\n"
+"    // fmt::Display。\n"
+"    // println!(\"这个结构体 `{}` 无法打印...\", Structure(3));\n"
+"    // TODO ^ 尝试取消注释这行\n"
 
 #: src/hello/print.md:68
 msgid ""
@@ -1341,10 +1359,12 @@ msgid ""
 "    // surrounding variable. Just like the above, this will output\n"
 "    // \"    1\", 4 white spaces and a \"1\".\n"
 msgstr ""
+"// 对于 Rust 1.58 及以上版本，你可以直接从周围的变量捕获参数。就像上面一样，这将输出\n"
+"    // \"    1\"，4个空格和一个 \"1\"。\n"
 
 #: src/hello/print.md:73
 msgid "\"{number:>width$}\""
-msgstr ""
+msgstr "\"{number:>width$}\""
 
 #: src/hello/print.md:77
 msgid ""
@@ -1352,23 +1372,25 @@ msgid ""
 "(https://doc.rust-lang.org/std/fmt/#formatting-traits) which govern the "
 "display of text. The base form of two important ones are listed below:"
 msgstr ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/) 包含许多 [`traits`]"
+"(https://doc.rust-lang.org/std/fmt/#formatting-traits)，它们控制文本的显示。下面列出了两个重要的基本形式："
 
 #: src/hello/print.md:80
 msgid ""
 "`fmt::Debug`: Uses the `{:?}` marker. Format text for debugging purposes."
-msgstr ""
+msgstr "`fmt::Debug`: 使用 `{:?}` 标记。为了调试目的格式化文本。"
 
 #: src/hello/print.md:81
 msgid ""
 "`fmt::Display`: Uses the `{}` marker. Format text in a more elegant, user "
 "friendly fashion."
-msgstr ""
+msgstr "`fmt::Display`: 使用 `{}` 标记。以更优雅、用户友好的方式格式化文本。"
 
 #: src/hello/print.md:84
 msgid ""
 "Here, we used `fmt::Display` because the std library provides implementations "
 "for these types. To print text for custom types, more steps are required."
-msgstr ""
+msgstr "这里我们使用 `fmt::Display`，因为标准库为这些类型提供了实现。要打印自定义类型的文本，需要更多的步骤。"
 
 #: src/hello/print.md:87
 msgid ""
@@ -1377,27 +1399,29 @@ msgid ""
 "which allows us to [convert](../conversion/string.md) the type to [`String`]"
 "(../std/str.md)."
 msgstr ""
+"实现 `fmt::Display` 特性会自动实现 [`ToString`](https://doc.rust-lang.org/std/string/trait.ToString.html) "
+"特性，这允许我们将该类型[转换](../conversion/string.md)为[`String`](../std/str.md)。"
 
 #: src/hello/print.md:90
 msgid ""
 "In _line 43_, `#[allow(dead_code)]` is an [attribute](../attribute.md) which "
 "only applies to the module after it."
-msgstr ""
+msgstr "在 _43 行_，`#[allow(dead_code)]`是一个 [属性(attribute)](../attribute.md)，它只适用于它之后的模块。"
 
 #: src/hello/print.md:92
 msgid "Activities"
-msgstr ""
+msgstr "动手试一试"
 
 #: src/hello/print.md:94
 msgid ""
 "Fix the issue in the above code (see FIXME) so that it runs without error."
-msgstr ""
+msgstr "修复上述代码中的问题（见 FIXME），以便它能无误运行。"
 
 #: src/hello/print.md:96
 msgid ""
 "Try uncommenting the line that attempts to format the `Structure` struct (see "
 "TODO)"
-msgstr ""
+msgstr "尝试取消注释尝试格式化 `Structure` 结构体的行（见 TODO）"
 
 #: src/hello/print.md:98
 msgid ""
@@ -1407,6 +1431,9 @@ msgid ""
 "[`std::fmt`](https://doc.rust-lang.org/std/fmt/) documentation for setting "
 "the number of decimals to display)"
 msgstr ""
+"添加一个 `println!` 宏调用，打印：`Pi 大约为 3.142`，通过控制显示的小数位数。为了这个练习的目的，使用 "
+"`let pi = 3.141592` 作为 pi 的近似值。（提示：你可能需要查看 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) "
+"文档以设置显示的小数位数）"
 
 #: src/hello/print.md:105
 msgid ""
@@ -1414,6 +1441,8 @@ msgid ""
 "[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/"
 "std/fmt/#formatting-traits), and [`dead_code`](../attribute/unused.md)"
 msgstr ""
+"[`std::fmt`](https://doc.rust-lang.org/std/fmt/),  [`macros`](../macros.md), "
+"[`struct`](../custom_types/structs.md), [`traits`](https://doc.rust-lang.org/std/fmt/#formatting-traits), 和 [`dead_code`](../attribute/unused.md)"
 
 #: src/hello/print/print_debug.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -922,7 +922,7 @@ msgstr "[补充](meta.md) - 文档，基准测试。"
 
 #: src/hello.md:3
 msgid "This is the source code of the traditional Hello World program."
-msgstr ""
+msgstr "这是传统的 Hello World 程序的源代码。"
 
 #: src/hello.md:6
 msgid ""
@@ -931,6 +931,10 @@ msgid ""
 "// or if you prefer to use your keyboard, you can use the \"Ctrl + Enter\"\n"
 "// shortcut.\n"
 msgstr ""
+"// 这是一个注释，编译器会忽略它。\n"
+"// 你可以通过点击那边的 \"运行\" 按钮来测试这段代码 ->\n"
+"// 或者，如果你更喜欢使用键盘，你可以使用 \"Ctrl + 回车\"\n"
+"// 快捷键。\n"
 
 #: src/hello.md:10
 msgid ""
@@ -938,46 +942,49 @@ msgid ""
 "// You can always return to the original code by clicking the \"Reset\" "
 "button ->\n"
 msgstr ""
+"// 这段代码是可以编辑的，随意地修改它吧！\n"
+"// 你总是可以通过点击 \"重置\" 按钮来恢复原始代码 ->\n"
 
 #: src/hello.md:13
 msgid "// This is the main function.\n"
-msgstr ""
+msgstr "// 这是主函数。\n"
 
 #: src/hello.md:16
 msgid "// Statements here are executed when the compiled binary is called.\n"
-msgstr ""
+msgstr "// 当编译后的二进制文件被调用时，这里的语句将被执行。\n"
 
 #: src/hello.md:18
 msgid "// Print text to the console.\n"
-msgstr ""
+msgstr "// 在控制台打印文本。\n"
 
 #: src/hello.md:19 src/error/result.md:55 src/meta/playground.md:12
 msgid "\"Hello World!\""
-msgstr ""
+msgstr "\"Hello World!\""
 
 #: src/hello.md:23
 msgid "`println!` is a [_macro_](macros.md) that prints text to the console."
-msgstr ""
+msgstr "`println!` 是一个[宏(macro_rule!)](macros.md)，用于在控制台打印文本。"
 
 #: src/hello.md:26
 msgid "A binary can be generated using the Rust compiler: `rustc`."
-msgstr ""
+msgstr "可以使用 Rust 编译器 `rustc` 生成二进制文件。"
 
 #: src/hello.md:32
 msgid "`rustc` will produce a `hello` binary that can be executed."
-msgstr ""
+msgstr "`rustc` 将生成一个可以执行的 `hello` 二进制文件。"
 
 #: src/hello.md:39 src/hello/print/print_display.md:107
 #: src/hello/print/print_display/testcase_list.md:53 src/hello/print/fmt.md:70
 #: src/primitives/tuples.md:64 src/custom_types/structs.md:89
 msgid "Activity"
-msgstr ""
+msgstr "动手试一试"
 
 #: src/hello.md:41
 msgid ""
 "Click 'Run' above to see the expected output. Next, add a new line with a "
 "second `println!` macro so that the output shows:"
 msgstr ""
+"点击上面的 '运行' 查看预期输出。接下来，添加一行新的代码，再次使用 `println!` 宏，输出以下结果："
 
 #: src/hello/comment.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -10646,34 +10646,35 @@ msgid ""
 "into abstract syntax trees, rather than string preprocessing, so you don't "
 "get unexpected precedence bugs."
 msgstr ""
+"Rust 提供了一个强大的宏系统，允许元编程。正如你在前面章节中看到的，宏看起来像函数，除了它们的名字以感叹号 `!` 结尾，但是宏不是生成函数调用，而是展开成源代码，然后与程序的其余部分一起编译。然而，与 C 和其他语言中的宏不同，Rust 宏被展开成抽象语法树，而不是字符串预处理，所以你不会遇到意外的优先级错误。"
 
 #: src/macros.md:11
 msgid "Macros are created using the `macro_rules!` macro."
-msgstr ""
+msgstr "宏是使用 `macro_rules!` 宏创建的。"
 
 #: src/macros.md:14
 msgid "// This is a simple macro named `say_hello`.\n"
-msgstr ""
+msgstr "// 这是一个名为 `say_hello` 的简单宏。\n"
 
 #: src/macros.md:16
 msgid "// `()` indicates that the macro takes no argument.\n"
-msgstr ""
+msgstr "// `()` 表示该宏不接受任何参数。\n"
 
 #: src/macros.md:18
 msgid "// The macro will expand into the contents of this block.\n"
-msgstr ""
+msgstr "// 宏将展开成这个块的内容。\n"
 
 #: src/macros.md:19
 msgid "\"Hello!\""
-msgstr ""
+msgstr "\"Hello!\""
 
 #: src/macros.md:24
 msgid "// This call will expand into `println!(\"Hello!\")`\n"
-msgstr ""
+msgstr "// 这个调用将展开成 `println!(\"Hello!\")`\n"
 
 #: src/macros.md:29
 msgid "So why are macros useful?"
-msgstr ""
+msgstr "那么为什么宏是有用的呢？"
 
 #: src/macros.md:31
 msgid ""
@@ -10681,12 +10682,14 @@ msgid ""
 "functionality in multiple places but with different types. Often, writing a "
 "macro is a useful way to avoid repeating code. (More on this later)"
 msgstr ""
+"不要重复自己。在许多情况下，你可能需要在多个地方使用类似的功能，但类型不同。通常，编写宏是避免重复代码的有用方法。（稍后会详细介绍）"
 
 #: src/macros.md:35
 msgid ""
 "Domain-specific languages. Macros allow you to define special syntax for a "
 "specific purpose. (More on this later)"
 msgstr ""
+"领域特定语言。宏允许你为特定目的定义特殊语法。（稍后会详细介绍）"
 
 #: src/macros.md:38
 msgid ""
@@ -10694,30 +10697,33 @@ msgid ""
 "variable number of arguments. An example is `println!` which could take any "
 "number of arguments, depending on the format string. (More on this later)"
 msgstr ""
+"可变参数接口。有时你想定义一个接受可变数量参数的接口。一个例子是 `println!`，它可以根据格式字符串接受任意数量的参数。（稍后会详细介绍）"
 
 #: src/macros/syntax.md:3
 msgid ""
 "In following subsections, we will show how to define macros in Rust. There "
 "are three basic ideas:"
 msgstr ""
+"在接下来的小节中，我们将展示如何在 Rust 中定义宏。有三个基本概念："
 
 #: src/macros/syntax.md:6
 msgid "[Patterns and Designators](designators.md)"
-msgstr ""
+msgstr "[模式和指示符](designators.md)"
 
 #: src/macros/syntax.md:7
 msgid "[Overloading](overload.md)"
-msgstr ""
+msgstr "[重载](overload.md)"
 
 #: src/macros/syntax.md:8
 msgid "[Repetition](repeat.md)"
-msgstr ""
+msgstr "[重复](repeat.md)"
 
 #: src/macros/designators.md:3
 msgid ""
 "The arguments of a macro are prefixed by a dollar sign `$` and type annotated "
 "with a _designator_:"
 msgstr ""
+"宏的参数以美元符号 `$` 为前缀，并用**指示符**来标注类型："
 
 #: src/macros/designators.md:8
 msgid ""
@@ -10725,18 +10731,21 @@ msgid ""
 "    // creates a function named `$func_name`.\n"
 "    // The `ident` designator is used for variable/function names.\n"
 msgstr ""
+"// 这个宏接受一个 `ident` 指示符的参数，\n"
+"    // 并创建一个名为 `$func_name` 的函数。\n"
+"    // `ident` 指示符用于变量/函数名。\n"
 
 #: src/macros/designators.md:13
 msgid "// The `stringify!` macro converts an `ident` into a string.\n"
-msgstr ""
+msgstr "// `stringify!` 宏将 `ident` 转换为字符串。\n"
 
 #: src/macros/designators.md:14
 msgid "\"You called {:?}()\""
-msgstr ""
+msgstr "\"You called {:?}()\""
 
 #: src/macros/designators.md:19
 msgid "// Create functions named `foo` and `bar` with the above macro.\n"
-msgstr ""
+msgstr "// 使用上面的宏创建名为 `foo` 和 `bar` 的函数。\n"
 
 #: src/macros/designators.md:25
 msgid ""
@@ -10744,102 +10753,111 @@ msgid ""
 "    // it as a string along with its result.\n"
 "    // The `expr` designator is used for expressions.\n"
 msgstr ""
+"// 这个宏接受一个 `expr` 类型的表达式，\n"
+"    // 并将其作为字符串打印出来，同时打印其结果。\n"
+"    // `expr` 指示符用于表达式。\n"
 
 #: src/macros/designators.md:29
 msgid "// `stringify!` will convert the expression *as it is* into a string.\n"
-msgstr ""
+msgstr "// `stringify!` 将表达式**原样**转换为字符串。\n"
 
 #: src/macros/designators.md:30
 msgid "\"{:?} = {:?}\""
-msgstr ""
+msgstr "\"{:?} = {:?}\""
 
 #: src/macros/designators.md:42
 msgid "// Recall that blocks are expressions too!\n"
-msgstr ""
+msgstr "// 回想一下，代码块也是表达式！\n"
 
 #: src/macros/designators.md:51
 msgid "These are some of the available designators:"
-msgstr ""
+msgstr "以下是一些可用的指示符："
 
 #: src/macros/designators.md:53
 msgid "`block`"
-msgstr ""
+msgstr "`block`"
 
 #: src/macros/designators.md:54
 msgid "`expr` is used for expressions"
-msgstr ""
+msgstr "`expr` 用于表达式"
 
 #: src/macros/designators.md:55
 msgid "`ident` is used for variable/function names"
-msgstr ""
+msgstr "`ident` 用于变量/函数名"
 
 #: src/macros/designators.md:56
 msgid "`item`"
-msgstr ""
+msgstr "`item`"
 
 #: src/macros/designators.md:57
 msgid "`literal` is used for literal constants"
-msgstr ""
+msgstr "`literal` 用于字面常量"
 
 #: src/macros/designators.md:58
 msgid "`pat` (_pattern_)"
-msgstr ""
+msgstr "`pat`（**模式** _pattern_）"
 
 #: src/macros/designators.md:59
 msgid "`path`"
-msgstr ""
+msgstr "`path`"
 
 #: src/macros/designators.md:60
 msgid "`stmt` (_statement_)"
-msgstr ""
+msgstr "`stmt`（**语句** _statement_）"
 
 #: src/macros/designators.md:61
 msgid "`tt` (_token tree_)"
-msgstr ""
+msgstr "`tt`（**标记树** _token tree_）"
 
 #: src/macros/designators.md:62
 msgid "`ty` (_type_)"
-msgstr ""
+msgstr "`ty`（**类型** _type_）"
 
 #: src/macros/designators.md:63
 msgid "`vis` (_visibility qualifier_)"
-msgstr ""
+msgstr "`vis`（**可见性限定符** _visibility qualifier_）"
 
 #: src/macros/designators.md:65
 msgid ""
 "For a complete list, see the [Rust Reference](https://doc.rust-lang.org/"
 "reference/macros-by-example.html)."
 msgstr ""
+"完整列表详见 [Rust 参考](https://doc.rust-lang.org/reference/macros-by-example.html)。"
 
 #: src/macros/overload.md:3
 msgid ""
 "Macros can be overloaded to accept different combinations of arguments. In "
 "that regard, `macro_rules!` can work similarly to a match block:"
 msgstr ""
+"宏可以被重载以接受不同的参数组合。在这方面，`macro_rules!` 的作用类似于 match 块："
 
 #: src/macros/overload.md:7
 msgid ""
 "// `test!` will compare `$left` and `$right`\n"
 "// in different ways depending on how you invoke it:\n"
 msgstr ""
+"// `test!` 将以不同的方式比较 `$left` 和 `$right`\n"
+"// 取决于你如何调用它：\n"
 
 #: src/macros/overload.md:10
 msgid ""
 "// Arguments don't need to be separated by a comma.\n"
 "    // Any template can be used!\n"
 msgstr ""
+"// 参数不需要用逗号分隔。\n"
+"    // 可以使用任何模板！\n"
 
 #: src/macros/overload.md:13
 msgid "\"{:?} and {:?} is {:?}\""
-msgstr ""
+msgstr "\"{:?} and {:?} is {:?}\""
 
 #: src/macros/overload.md:18
 msgid "// ^ each arm must end with a semicolon.\n"
-msgstr ""
+msgstr "// ^ 每个分支必须以分号结束。\n"
 
 #: src/macros/overload.md:20
 msgid "\"{:?} or {:?} is {:?}\""
-msgstr ""
+msgstr "\"{:?} 或 {:?} 是 {:?}\""
 
 #: src/macros/repeat.md:3
 msgid ""
@@ -10847,6 +10865,7 @@ msgid ""
 "repeat at least once, or `*`, to indicate that the argument may repeat zero "
 "or more times."
 msgstr ""
+"宏可以在参数列表中使用 `+` 来表示一个参数可能重复至少一次，或使用 `*` 来表示一个参数可能重复零次或多次。"
 
 #: src/macros/repeat.md:7
 msgid ""
@@ -10854,22 +10873,23 @@ msgid ""
 "one or more expression, separated by commas. Also note that the semicolon is "
 "optional on the last case."
 msgstr ""
+"在下面的例子中，用 `$(...),+` 包围匹配器将匹配一个或多个由逗号分隔的表达式。还要注意，最后一个情况的分号是可选的。"
 
 #: src/macros/repeat.md:12
 msgid "// `find_min!` will calculate the minimum of any number of arguments.\n"
-msgstr ""
+msgstr "// `find_min!` 将计算任意数量参数的最小值。\n"
 
 #: src/macros/repeat.md:14
 msgid "// Base case:\n"
-msgstr ""
+msgstr "// 基本情况：\n"
 
 #: src/macros/repeat.md:16
 msgid "// `$x` followed by at least one `$y,`\n"
-msgstr ""
+msgstr "// `$x` 后面至少跟着一个 `$y,`\n"
 
 #: src/macros/repeat.md:18
 msgid "// Call `find_min!` on the tail `$y`\n"
-msgstr ""
+msgstr "// 对尾部 `$y` 调用 `find_min!`\n"
 
 #: src/macros/dry.md:3
 msgid ""
@@ -10877,32 +10897,34 @@ msgid ""
 "and/or test suites. Here is an example that implements and tests the `+=`, "
 "`*=` and `-=` operators on `Vec<T>`:"
 msgstr ""
+"宏允许通过提取函数和/或测试套件的公共部分来编写 DRY（Don't Repeat Yourself）代码。这里有一个在 `Vec<T>` 上实现和测试 `+=`、`*=` 和 `-=` 运算符的例子："
 
 #: src/macros/dry.md:11
 msgid ""
 "// The `tt` (token tree) designator is used for\n"
 "    // operators and tokens.\n"
 msgstr ""
+"// `tt`（标记树, token tree）指示符用于运算符和标记。\n"
 
 #: src/macros/dry.md:15
 msgid "\"{:?}: dimension mismatch: {:?} {:?} {:?}\""
-msgstr ""
+msgstr "\"{:?}：维度不匹配：{:?} {:?} {:?}\""
 
 #: src/macros/dry.md:30
 msgid "// *x = x.$method(*y);\n"
-msgstr ""
+msgstr "// *x = x.$method(*y);\n"
 
 #: src/macros/dry.md:35
 msgid "// Implement `add_assign`, `mul_assign`, and `sub_assign` functions.\n"
-msgstr ""
+msgstr "// 实现 `add_assign`、`mul_assign` 和 `sub_assign` 函数。\n"
 
 #: src/macros/dry.md:60
 msgid "// Test `add_assign`, `mul_assign`, and `sub_assign`.\n"
-msgstr ""
+msgstr "// 测试 `add_assign`、`mul_assign` 和 `sub_assign`。\n"
 
 #: src/macros/dsl.md:1
 msgid "Domain Specific Languages (DSLs)"
-msgstr ""
+msgstr "领域特定语言（DSLs）"
 
 #: src/macros/dsl.md:3
 msgid ""
@@ -10911,28 +10933,30 @@ msgid ""
 "looks like a small language. This allows you to define concise or intuitive "
 "syntax for some special functionality (within bounds)."
 msgstr ""
+"DSL 是嵌入在 Rust 宏中的一种小型"语言"。它是完全有效的 Rust，因为宏系统会展开为普通的 Rust 结构，但它看起来像一种小型语言。这允许你为一些特殊功能定义简洁或直观的语法（在一定范围内）。"
 
 #: src/macros/dsl.md:8
 msgid ""
 "Suppose that I want to define a little calculator API. I would like to supply "
 "an expression and have the output printed to console."
 msgstr ""
+"假设我想定义一个小型计算器 API。我希望提供一个表达式，并将输出打印到控制台。"
 
 #: src/macros/dsl.md:15
 msgid "// Force types to be unsigned integers\n"
-msgstr ""
+msgstr "// 强制类型为无符号整数\n"
 
 #: src/macros/dsl.md:16 src/macros/variadics.md:15
 msgid "\"{} = {}\""
-msgstr ""
+msgstr "\"{} = {}\""
 
 #: src/macros/dsl.md:23
 msgid "// hehehe `eval` is _not_ a Rust keyword!\n"
-msgstr ""
+msgstr "// 看到了吧，`eval` 可并不是 Rust 的关键字！\n"
 
 #: src/macros/dsl.md:32 src/macros/variadics.md:35
 msgid "Output:"
-msgstr ""
+msgstr "输出："
 
 #: src/macros/dsl.md:39
 msgid ""
@@ -10940,16 +10964,18 @@ msgid ""
 "developed, such as [`lazy_static`](https://crates.io/crates/lazy_static) or "
 "[`clap`](https://crates.io/crates/clap)."
 msgstr ""
+"这个例子非常简单，但已经有很多利用宏开发的复杂接口，比如 [`lazy_static`](https://crates.io/crates/lazy_static) 或 [`clap`](https://crates.io/crates/clap)。"
 
 #: src/macros/dsl.md:43
 msgid ""
 "Also, note the two pairs of braces in the macro. The outer ones are part of "
 "the syntax of `macro_rules!`, in addition to `()` or `[]`."
 msgstr ""
+"另外，注意宏中的两对大括号。外层的大括号是 `macro_rules!` 语法的一部分，除此之外还可以使用 `()` 或 `[]`。"
 
 #: src/macros/variadics.md:1
 msgid "Variadic Interfaces"
-msgstr ""
+msgstr "可变参数接口"
 
 #: src/macros/variadics.md:3
 msgid ""
@@ -10957,27 +10983,29 @@ msgid ""
 "`println!` can take an arbitrary number of arguments, as determined by the "
 "format string."
 msgstr ""
+"**可变参数**接口可以接受任意数量的参数。例如，`println!` 可以接受任意数量的参数，这由格式字符串决定。"
 
 #: src/macros/variadics.md:7
 msgid ""
 "We can extend our `calculate!` macro from the previous section to be variadic:"
 msgstr ""
+"我们可以扩展前一节的 `calculate!` 宏，使其成为可变参数的："
 
 #: src/macros/variadics.md:11
 msgid "// The pattern for a single `eval`\n"
-msgstr ""
+msgstr "// 单个 `eval` 的模式\n"
 
 #: src/macros/variadics.md:14
 msgid "// Force types to be integers\n"
-msgstr ""
+msgstr "// 强制类型为整数\n"
 
 #: src/macros/variadics.md:19
 msgid "// Decompose multiple `eval`s recursively\n"
-msgstr ""
+msgstr "// 递归分解多个 `eval`\n"
 
 #: src/macros/variadics.md:27
 msgid "// Look ma! Variadic `calculate!`!\n"
-msgstr ""
+msgstr "// 妈妈快看！可变参数的 `calculate!`！\n"
 
 #: src/error.md:3
 msgid ""
@@ -10986,6 +11014,7 @@ msgid ""
 "would clearly be problematic. Noticing and explicitly managing those errors "
 "saves the rest of the program from various pitfalls."
 msgstr ""
+"错误处理是处理可能失败情况的过程。例如，读取文件失败然后继续使用那个**错误的**输入显然会有问题。注意并明确管理这些错误可以使程序的其余部分避免各种陷阱。"
 
 #: src/error.md:8
 msgid ""
@@ -10993,6 +11022,7 @@ msgid ""
 "the following subchapters. They all have more or less subtle differences and "
 "different use cases. As a rule of thumb:"
 msgstr ""
+"Rust 中有多种处理错误的方法，在接下来的小节中会一一介绍。它们或多或少都有些细微差别和不同的使用场景。总的来说："
 
 #: src/error.md:12
 msgid ""
@@ -11002,6 +11032,7 @@ msgid ""
 "descriptive `unimplemented` is better. In tests `panic` is a reasonable way "
 "to explicitly fail."
 msgstr ""
+"显式的 `panic` 主要用于测试和处理不可恢复的错误。在原型开发中这可能有用，例如在处理尚未实现的函数时，但在这些情况下，更具描述性的 `unimplemented` 更好。在测试中，`panic` 是一种合理的显式失败方式。"
 
 #: src/error.md:17
 msgid ""
@@ -11012,6 +11043,7 @@ msgid ""
 "to be a value. However `expect` is more useful since it lets you specify an "
 "error message in case something goes wrong anyway."
 msgstr ""
+"`Option` 类型用于值是可选的情况，或者缺少值不是错误条件的情况。例如目录的父目录 - `/` 和 `C:` 就没有父目录。在处理 `Option` 时，对于原型设计和绝对确定有值的情况，使用 `unwrap` 是可以的。然而，`expect` 更有用，因为它允许你指定一个错误消息，以防万一出错。"
 
 #: src/error.md:24
 msgid ""
@@ -11019,6 +11051,7 @@ msgid ""
 "with the problem, use `Result`. You can `unwrap` and `expect` them as well "
 "(please don't do that unless it's a test or quick prototype)."
 msgstr ""
+"当有可能出错且调用者必须处理问题时，使用 `Result`。你也可以对它们使用 `unwrap` 和 `expect`（除非是测试或快速原型，否则请不要这样做）。"
 
 #: src/error.md:28
 msgid ""
@@ -11026,6 +11059,7 @@ msgid ""
 "section in the [official book](https://doc.rust-lang.org/book/ch09-00-error-"
 "handling.html)."
 msgstr ""
+"关于错误处理更详尽的内容，请参阅[官方文档](https://doc.rust-lang.org/book/ch09-00-error-handling.html)中的错误处理章节。"
 
 #: src/error/panic.md:3
 msgid ""
@@ -11033,86 +11067,87 @@ msgid ""
 "error message, starts unwinding the stack, and usually exits the program. "
 "Here, we explicitly call `panic` on our error condition:"
 msgstr ""
+"我们将看到的最简单的错误处理机制是 `panic`。它会打印一条错误消息，开始展开栈，并通常会退出程序。在这里，我们在错误条件下显式调用 `panic`："
 
 #: src/error/panic.md:9 src/error/abort_unwind.md:10
 msgid "// You shouldn't drink too much sugary beverages.\n"
-msgstr ""
+msgstr "// 你不应该喝太多含糖饮料。\n"
 
 #: src/error/panic.md:10 src/error/panic.md:17 src/error/abort_unwind.md:11
 #: src/error/abort_unwind.md:24 src/error/abort_unwind.md:42
 #: src/error/abort_unwind.md:51 src/error/option_unwrap.md:32
 #: src/error/option_unwrap.md:43 src/error/option_unwrap.md:50
 msgid "\"lemonade\""
-msgstr ""
+msgstr "\"lemonade\""
 
 #: src/error/panic.md:10 src/error/option_unwrap.md:43
 msgid "\"AAAaaaaa!!!!\""
-msgstr ""
+msgstr "\"AAAaaaaa!!!!\""
 
 #: src/error/panic.md:12 src/error/abort_unwind.md:18
 #: src/error/abort_unwind.md:45
 msgid "\"Some refreshing {} is all I need.\""
-msgstr ""
+msgstr "\"{} 就是我所需要的。\""
 
 #: src/error/panic.md:16 src/error/abort_unwind.md:23
 #: src/error/abort_unwind.md:50 src/error/option_unwrap.md:49
 msgid "\"water\""
-msgstr ""
+msgstr "\"water\""
 
 #: src/error/panic.md:18
 msgid "\"still water\""
-msgstr ""
+msgstr "\"still water\""
 
 #: src/error/panic.md:22
 msgid ""
 "The first call to `drink` works. The second panics and thus the third is "
 "never called."
-msgstr ""
+msgstr "第一次调用 `drink` 正常工作。第二次调用会 panic，因此第三次调用永远不会被执行。"
 
 #: src/error/abort_unwind.md:1
 msgid "`abort` and `unwind`"
-msgstr ""
+msgstr "`abort` 和 `unwind`"
 
 #: src/error/abort_unwind.md:3
 msgid ""
 "The previous section illustrates the error handling mechanism `panic`.  "
 "Different code paths can be conditionally compiled based on the panic "
 "setting. The current values available are `unwind` and `abort`."
-msgstr ""
+msgstr "上一节说明了错误处理机制 `panic`。不同的代码路径可以根据 panic 设置进行条件编译。当前可用的值是 `unwind` 和 `abort`。"
 
 #: src/error/abort_unwind.md:6
 msgid ""
 "Building on the prior lemonade example, we explicitly use the panic strategy "
 "to exercise different lines of code."
-msgstr ""
+msgstr "基于之前的柠檬水示例，我们显式使用 panic 策略来执行不同的代码行。"
 
 #: src/error/abort_unwind.md:12
 msgid "\"abort\""
-msgstr ""
+msgstr "\"abort\""
 
 #: src/error/abort_unwind.md:13 src/error/abort_unwind.md:38
 msgid "\"This is not your party. Run!!!!\""
-msgstr ""
+msgstr "\"这不是你的派对。快跑！！！！\""
 
 #: src/error/abort_unwind.md:15 src/error/abort_unwind.md:33
 msgid "\"Spit it out!!!!\""
-msgstr ""
+msgstr "\"吐出来！！！！\""
 
 #: src/error/abort_unwind.md:28
 msgid ""
 "Here is another example focusing on rewriting `drink()` and explicitly use "
 "the `unwind` keyword."
-msgstr ""
+msgstr "这里是另一个示例，重点是重写 `drink()` 并显式使用 `unwind` 关键字。"
 
 #: src/error/abort_unwind.md:31 src/error/abort_unwind.md:36
 msgid "\"unwind\""
-msgstr ""
+msgstr "\"unwind\""
 
 #: src/error/abort_unwind.md:55
 msgid ""
 "The panic strategy can be set from the command line by using `abort` or "
 "`unwind`."
-msgstr ""
+msgstr "可以通过命令行使用 `abort` 或 `unwind` 来设置 panic 策略。"
 
 #: src/error/option_unwrap.md:3
 msgid ""
@@ -11120,34 +11155,34 @@ msgid ""
 "told our program to `panic` if we drink a sugary lemonade. But what if we "
 "expect _some_ drink but don't receive one? That case would be just as bad, so "
 "it needs to be handled!"
-msgstr ""
+msgstr "在上一个例子中，我们展示了如何主动引发程序失败。我们告诉程序在喝含糖柠檬水时 `panic`。但如果我们期望得到**某种**饮料却没有收到呢？这种情况同样糟糕，所以需要处理！"
 
 #: src/error/option_unwrap.md:8
 msgid ""
 "We _could_ test this against the null string (`\"\"`) as we do with a "
 "lemonade. Since we're using Rust, let's instead have the compiler point out "
 "cases where there's no drink."
-msgstr ""
+msgstr "我们**可以**像处理柠檬水那样对空字符串（`\"\"`）进行测试。但既然我们使用的是 Rust，不如让编译器指出没有饮料的情况。"
 
 #: src/error/option_unwrap.md:12
 msgid ""
 "An `enum` called `Option<T>` in the `std` library is used when absence is a "
 "possibility. It manifests itself as one of two \"options\":"
-msgstr ""
+msgstr "`std` 库中名为 `Option<T>` 的 `enum` 用于处理可能存在缺失的情况。它表现为两个"选项"之一："
 
 #: src/error/option_unwrap.md:15
 msgid "`Some(T)`: An element of type `T` was found"
-msgstr ""
+msgstr "`Some(T)`：找到了一个 `T` 类型的元素"
 
 #: src/error/option_unwrap.md:16
 msgid "`None`: No element was found"
-msgstr ""
+msgstr "`None`：没有找到元素"
 
 #: src/error/option_unwrap.md:18
 msgid ""
 "These cases can either be explicitly handled via `match` or implicitly with "
 "`unwrap`. Implicit handling will either return the inner element or `panic`."
-msgstr ""
+msgstr "这些情况可以通过 `match` 显式处理，也可以用 `unwrap` 隐式处理。隐式处理要么返回内部元素，要么 `panic`。"
 
 #: src/error/option_unwrap.md:21
 msgid ""
@@ -11156,47 +11191,51 @@ msgid ""
 "otherwise leaves us with a less meaningful output than explicit handling. In "
 "the following example, explicit handling yields a more controlled result "
 "while retaining the option to `panic` if desired."
-msgstr ""
+msgstr "注意，可以使用 [expect](https://doc.rust-lang.org/std/option/enum.Option.html#method.expect) 手动自定义 `panic`，但 `unwrap` 相比显式处理会留下一个不太有意义的输出。在下面的例子中，显式处理产生了一个更可控的结果，同时保留了在需要时 `panic` 的选项。"
 
 #: src/error/option_unwrap.md:27
 msgid ""
 "// The adult has seen it all, and can handle any drink well.\n"
 "// All drinks are handled explicitly using `match`.\n"
 msgstr ""
+"// 成年人见多识广，可以很好地处理任何饮料。\n"
+"// 所有饮料都使用 `match` 显式处理。\n"
 
 #: src/error/option_unwrap.md:30
 msgid "// Specify a course of action for each case.\n"
-msgstr ""
+msgstr "// 为每种情况指定一个行动方案。\n"
 
 #: src/error/option_unwrap.md:32
 msgid "\"Yuck! Too sugary.\""
-msgstr ""
+msgstr "\"呸！太甜了。\""
 
 #: src/error/option_unwrap.md:33
 msgid "\"{}? How nice.\""
-msgstr ""
+msgstr "\"{}？真不错。\""
 
 #: src/error/option_unwrap.md:34
 msgid "\"No drink? Oh well.\""
-msgstr ""
+msgstr "\"没有饮料？好吧。\""
 
 #: src/error/option_unwrap.md:37
 msgid ""
 "// Others will `panic` before drinking sugary drinks.\n"
 "// All drinks are handled implicitly using `unwrap`.\n"
 msgstr ""
+"// 其他人在喝含糖饮料前会 `panic`。\n"
+"// 所有饮料都使用 `unwrap` 隐式处理。\n"
 
 #: src/error/option_unwrap.md:41
 msgid "// `unwrap` returns a `panic` when it receives a `None`.\n"
-msgstr ""
+msgstr "// 当 `unwrap` 收到 `None` 时会返回一个 `panic`。\n"
 
 #: src/error/option_unwrap.md:45
 msgid "\"I love {}s!!!!!\""
-msgstr ""
+msgstr "\"我爱 {}！！！！！\""
 
 #: src/error/option_unwrap.md:57
 msgid "\"coffee\""
-msgstr ""
+msgstr "\"coffee\""
 
 #: src/error/option_unwrap/question_mark.md:3
 msgid ""
@@ -11204,7 +11243,7 @@ msgid ""
 "to use the `?` operator. If `x` is an `Option`, then evaluating `x?` will "
 "return the underlying value if `x` is `Some`, otherwise it will terminate "
 "whatever function is being executed and return `None`."
-msgstr ""
+msgstr "你可以使用 `match` 语句来解包 `Option`，但使用 `?` 运算符通常更容易。如果 `x` 是一个 `Option`，那么求值 `x?` 将在 `x` 是 `Some` 时返回底层值，否则它将终止正在执行的函数并返回 `None`。"
 
 #: src/error/option_unwrap/question_mark.md:10
 msgid ""
@@ -11212,19 +11251,22 @@ msgid ""
 "\t// If `current_age` is `Some`, the inner `u8` value + 1\n"
 "    // gets assigned to `next_age`\n"
 msgstr ""
+"// 如果 `current_age` 是 `None`，这将返回 `None`。\n"
+"\t// 如果 `current_age` 是 `Some`，内部的 `u8` 值 + 1\n"
+"    // 被赋值给 `next_age`\n"
 
 #: src/error/option_unwrap/question_mark.md:14
 msgid "\"Next year I will be {}\""
-msgstr ""
+msgstr "\"明年我将会 {} 岁\""
 
 #: src/error/option_unwrap/question_mark.md:18
 msgid "You can chain many `?`s together to make your code much more readable."
-msgstr ""
+msgstr "你可以将多个 `?` 链接在一起，使你的代码更易读。"
 
 #: src/error/option_unwrap/question_mark.md:38
 msgid ""
 "// Gets the area code of the phone number of the person's job, if it exists.\n"
-msgstr ""
+msgstr "// 如果存在，获取此人工作电话号码的区号。\n"
 
 #: src/error/option_unwrap/question_mark.md:40
 msgid ""
@@ -11233,6 +11275,8 @@ msgid ""
 "which\n"
 "        // is easier.\n"
 msgstr ""
+"// 如果没有 `?` 运算符，这将需要许多嵌套的 `match` 语句。\n"
+"        // 这将需要更多的代码 - 试着自己写一下，看看哪个更容易。\n"
 
 #: src/error/option_unwrap/map.md:3
 msgid ""
@@ -11241,67 +11285,73 @@ msgid ""
 "input. In these cases, [combinators](https://doc.rust-lang.org/reference/"
 "glossary.html#combinator) can be used to manage control flow in a modular "
 "fashion."
-msgstr ""
+msgstr "`match` 是处理 `Option` 的有效方法。然而，你最终可能会发现大量使用它会变得乏味，特别是对于只在有输入时才有效的操作。在这些情况下，可以使用[组合器](https://doc.rust-lang.org/reference/glossary.html#combinator)以模块化的方式管理控制流。"
 
 #: src/error/option_unwrap/map.md:8
 msgid ""
 "`Option` has a built in method called `map()`, a combinator for the simple "
 "mapping of `Some -> Some` and `None -> None`. Multiple `map()` calls can be "
 "chained together for even more flexibility."
-msgstr ""
+msgstr "`Option` 有一个内置方法叫做 `map()`，它是一个组合器，用于简单地将 `Some -> Some` 和 `None -> None` 进行映射。多个 `map()` 调用可以链接在一起，以获得更大的灵活性。"
 
 #: src/error/option_unwrap/map.md:12
 msgid ""
 "In the following example, `process()` replaces all functions previous to it "
 "while staying compact."
-msgstr ""
+msgstr "在下面的例子中，`process()` 替换了之前的所有函数，同时保持代码简洁。"
 
 #: src/error/option_unwrap/map.md:23
 msgid ""
 "// Peeling food. If there isn't any, then return `None`.\n"
 "// Otherwise, return the peeled food.\n"
 msgstr ""
+"// 剥皮食物。如果没有食物，则返回 `None`。\n"
+"// 否则，返回剥皮后的食物。\n"
 
 #: src/error/option_unwrap/map.md:32
 msgid ""
 "// Chopping food. If there isn't any, then return `None`.\n"
 "// Otherwise, return the chopped food.\n"
 msgstr ""
+"// 切碎食物。如果没有食物，则返回 `None`。\n"
+"// 否则，返回切碎后的食物。\n"
 
 #: src/error/option_unwrap/map.md:41
 msgid ""
 "// Cooking food. Here, we showcase `map()` instead of `match` for case "
 "handling.\n"
-msgstr ""
+msgstr "// 烹饪食物。这里，我们展示了使用 `map()` 而不是 `match` 来处理情况。\n"
 
 #: src/error/option_unwrap/map.md:46
 msgid ""
 "// A function to peel, chop, and cook food all in sequence.\n"
 "// We chain multiple uses of `map()` to simplify the code.\n"
 msgstr ""
+"// 一个按顺序剥皮、切碎和烹饪食物的函数。\n"
+"// 我们链接多个 `map()` 的使用来简化代码。\n"
 
 #: src/error/option_unwrap/map.md:54
 msgid "// Check whether there's food or not before trying to eat it!\n"
-msgstr ""
+msgstr "// 在尝试吃之前检查是否有食物！\n"
 
 #: src/error/option_unwrap/map.md:58
 msgid "\"Mmm. I love {:?}\""
-msgstr ""
+msgstr "\"嗯。我喜欢 {:?}\""
 
 #: src/error/option_unwrap/map.md:59
 msgid "\"Oh no! It wasn't edible.\""
-msgstr ""
+msgstr "\"哦不！这不能吃。\""
 
 #: src/error/option_unwrap/map.md:70
 msgid "// Let's try the simpler looking `process()` now.\n"
-msgstr ""
+msgstr "// 现在让我们试试看起来更简单的 `process()`。\n"
 
 #: src/error/option_unwrap/map.md:81
 msgid ""
 "[closures](../../fn/closures.md), [`Option`](https://doc.rust-lang.org/std/"
 "option/enum.Option.html), [`Option::map()`](https://doc.rust-lang.org/std/"
 "option/enum.Option.html#method.map)"
-msgstr ""
+msgstr "[闭包](../../fn/closures.md)，[`Option`](https://doc.rust-lang.org/std/option/enum.Option.html)，[`Option::map()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.map)"
 
 #: src/error/option_unwrap/and_then.md:3
 msgid ""
@@ -11310,53 +11360,57 @@ msgid ""
 "the nested `Option<Option<T>>`. Chaining multiple calls together can then "
 "become confusing. That's where another combinator called `and_then()`, known "
 "in some languages as flatmap, comes in."
-msgstr ""
+msgstr "`map()` 被描述为一种可链式调用的方式来简化 `match` 语句。然而，在返回 `Option<T>` 的函数上使用 `map()` 会导致嵌套的 `Option<Option<T>>`。链接多个调用可能会变得令人困惑。这就是另一个称为 `and_then()` 的组合器（在一些语言中称为 flatmap）发挥作用的地方。"
 
 #: src/error/option_unwrap/and_then.md:9
 msgid ""
 "`and_then()` calls its function input with the wrapped value and returns the "
 "result. If the `Option` is `None`, then it returns `None` instead."
-msgstr ""
+msgstr "`and_then()` 使用包装的值调用其函数输入并返回结果。如果 `Option` 是 `None`，则返回 `None`。"
 
 #: src/error/option_unwrap/and_then.md:11
 msgid ""
 "In the following example, `cookable_v3()` results in an `Option<Food>`. Using "
 "`map()` instead of `and_then()` would have given an `Option<Option<Food>>`, "
 "which is an invalid type for `eat()`."
-msgstr ""
+msgstr "在下面的例子中，`cookable_v3()` 的结果是一个 `Option<Food>`。如果使用 `map()` 而不是 `and_then()`，将会得到一个 `Option<Option<Food>>`，这对于 `eat()` 来说是一个无效的类型。"
 
 #: src/error/option_unwrap/and_then.md:20
 msgid "// We don't have the ingredients to make Sushi.\n"
-msgstr ""
+msgstr "// 我们没有制作寿司的原料。\n"
 
 #: src/error/option_unwrap/and_then.md:28
 msgid "// We have the recipe for everything except Cordon Bleu.\n"
-msgstr ""
+msgstr "// 我们有除了蓝带猪排以外所有菜的食谱。\n"
 
 #: src/error/option_unwrap/and_then.md:36
 msgid ""
 "// To make a dish, we need both the recipe and the ingredients.\n"
 "// We can represent the logic with a chain of `match`es:\n"
 msgstr ""
+"// 要做一道菜，我们需要食谱和原料。\n"
+"// 我们可以用一系列的 `match` 来表示这个逻辑：\n"
 
 #: src/error/option_unwrap/and_then.md:45
 msgid ""
 "// This can conveniently be rewritten more compactly with `and_then()`:\n"
-msgstr ""
+msgstr "// 这可以方便地用 `and_then()` 更紧凑地重写：\n"
 
 #: src/error/option_unwrap/and_then.md:50
 msgid ""
 "// Otherwise we'd need to `flatten()` an `Option<Option<Food>>`\n"
 "// to get an `Option<Food>`:\n"
 msgstr ""
+"// 否则我们需要 `flatten()` 一个 `Option<Option<Food>>`\n"
+"// 来获得一个 `Option<Food>`：\n"
 
 #: src/error/option_unwrap/and_then.md:59
 msgid "\"Yay! On {:?} we get to eat {:?}.\""
-msgstr ""
+msgstr "\"太好了！在 {:?} 我们可以吃 {:?}。\""
 
 #: src/error/option_unwrap/and_then.md:60
 msgid "\"Oh no. We don't get to eat on {:?}?\""
-msgstr ""
+msgstr "\"哦不。我们在 {:?} 没有东西吃吗？\""
 
 #: src/error/option_unwrap/and_then.md:75
 msgid ""
@@ -11364,46 +11418,46 @@ msgid ""
 "option/enum.Option.html), [`Option::and_then()`](https://doc.rust-lang.org/"
 "std/option/enum.Option.html#method.and_then), and [`Option::flatten()`]"
 "(https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
-msgstr ""
+msgstr "[闭包](../../fn/closures.md)，[`Option`](https://doc.rust-lang.org/std/option/enum.Option.html)，[`Option::and_then()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.and_then)，以及 [`Option::flatten()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.flatten)"
 
 #: src/error/option_unwrap/defaults.md:1
 msgid "Unpacking options and defaults"
-msgstr ""
+msgstr "解包 Option 和默认值"
 
 #: src/error/option_unwrap/defaults.md:3
 msgid ""
 "There is more than one way to unpack an `Option` and fall back on a default "
 "if it is `None`. To choose the one that meets our needs, we need to consider "
 "the following:"
-msgstr ""
+msgstr "有多种方法可以解包 `Option` 并在其为 `None` 时回退到默认值。为了选择满足我们需求的方法，我们需要考虑以下几点："
 
 #: src/error/option_unwrap/defaults.md:4
 msgid "do we need eager or lazy evaluation?"
-msgstr ""
+msgstr "我们需要立即求值还是惰性求值？"
 
 #: src/error/option_unwrap/defaults.md:5
 msgid ""
 "do we need to keep the original empty value intact, or modify it in place?"
-msgstr ""
+msgstr "我们需要保持原始的空值不变，还是就地修改它？"
 
 #: src/error/option_unwrap/defaults.md:7
 msgid "`or()` is chainable, evaluates eagerly, keeps empty value intact"
-msgstr ""
+msgstr "`or()` 可链式调用，立即求值，保持空值不变"
 
 #: src/error/option_unwrap/defaults.md:9
 msgid ""
 "`or()`is chainable and eagerly evaluates its argument, as is shown in the "
 "following example. Note that because `or`'s arguments are evaluated eagerly, "
 "the variable passed to `or` is moved."
-msgstr ""
+msgstr "`or()` 可链式调用，并且立即地求值其参数，如下例所示。注意，由于 `or` 的参数是立即求值的，传递给 `or` 的变量会被移动。"
 
 #: src/error/option_unwrap/defaults.md:21 src/error/option_unwrap/defaults.md:54
 msgid "\"first_available_fruit: {:?}\""
-msgstr ""
+msgstr "\"第一个可用的水果：{:?}\""
 
 #: src/error/option_unwrap/defaults.md:22
 msgid "// first_available_fruit: Some(Orange)\n"
-msgstr ""
+msgstr "// first_available_fruit: Some(Orange)\n"
 
 #: src/error/option_unwrap/defaults.md:24
 msgid ""
@@ -11416,34 +11470,41 @@ msgid ""
 "{:?}\", apple);\n"
 "    // TODO: uncomment the line above to see the compiler error\n"
 msgstr ""
+"// `or` 移动了它的参数。\n"
+"    // 在上面的例子中，`or(orange)` 返回了一个 `Some`，所以 `or(apple)` 没有被调用。\n"
+"    // 但是名为 `apple` 的变量无论如何都被移动了，不能再使用。\n"
+"    // println!(\"变量 apple 被移动了，所以这行不会编译：{:?}\", apple);\n"
+"    // TODO: 取消上面这行的注释来查看编译器错误\n"
 
 #: src/error/option_unwrap/defaults.md:32
 msgid "`or_else()` is chainable, evaluates lazily, keeps empty value intact"
-msgstr ""
+msgstr "`or_else()` 可链式调用，惰性求值，保持空值不变"
 
 #: src/error/option_unwrap/defaults.md:34
 msgid ""
 "Another alternative is to use `or_else`, which is also chainable, and "
 "evaluates lazily, as is shown in the following example:"
-msgstr ""
+msgstr "另一种选择是使用 `or_else`，它也是可链式调用的，并且是惰性求值的，如下例所示："
 
 #: src/error/option_unwrap/defaults.md:43
 msgid "\"Providing kiwi as fallback\""
-msgstr ""
+msgstr "\"提供猕猴桃作为后备\""
 
 #: src/error/option_unwrap/defaults.md:47 src/error/option_unwrap/defaults.md:91
 msgid "\"Providing lemon as fallback\""
-msgstr ""
+msgstr "\"提供柠檬作为后备\""
 
 #: src/error/option_unwrap/defaults.md:55
 msgid ""
 "// Providing kiwi as fallback\n"
 "    // first_available_fruit: Some(Kiwi)\n"
 msgstr ""
+"// 提供猕猴桃作为后备\n"
+"    // first_available_fruit: Some(Kiwi)\n"
 
 #: src/error/option_unwrap/defaults.md:60
 msgid "`get_or_insert()` evaluates eagerly, modifies empty value in place"
-msgstr ""
+msgstr "`get_or_insert()` 立即求值，就地修改空值"
 
 #: src/error/option_unwrap/defaults.md:62
 msgid ""
@@ -11452,14 +11513,15 @@ msgid ""
 "example. Note that `get_or_insert` eagerly evaluates its parameter, so "
 "variable `apple` is moved:"
 msgstr ""
+"为了确保 `Option` 包含一个值，我们可以使用 `get_or_insert` 来就地修改它，使用一个后备值，如下例所示。注意 `get_or_insert` 会立即求值其参数，所以变量 `apple` 被移动了："
 
 #: src/error/option_unwrap/defaults.md:72 src/error/option_unwrap/defaults.md:96
 msgid "\"first_available_fruit is: {:?}\""
-msgstr ""
+msgstr "\"first_available_fruit is: {:?}\""
 
 #: src/error/option_unwrap/defaults.md:73 src/error/option_unwrap/defaults.md:97
 msgid "\"my_fruit is: {:?}\""
-msgstr ""
+msgstr "\"my_fruit is: {:?}\""
 
 #: src/error/option_unwrap/defaults.md:74
 msgid ""
@@ -11468,16 +11530,20 @@ msgid ""
 "    //println!(\"Variable named `apple` is moved: {:?}\", apple);\n"
 "    // TODO: uncomment the line above to see the compiler error\n"
 msgstr ""
+"// first_available_fruit is: Apple\n"
+"    // my_fruit is: Some(Apple)\n"
+"    //println!(\"名为 `apple` 的变量被移动了：{:?}\", apple);\n"
+"    // TODO：取消上面这行的注释来查看编译器错误\n"
 
 #: src/error/option_unwrap/defaults.md:81
 msgid "`get_or_insert_with()` evaluates lazily, modifies empty value in place"
-msgstr ""
+msgstr "`get_or_insert_with()` 惰性求值，就地修改空值"
 
 #: src/error/option_unwrap/defaults.md:83
 msgid ""
 "Instead of explicitly providing a value to fall back on, we can pass a "
 "closure to `get_or_insert_with`, as follows:"
-msgstr ""
+msgstr "我们可以传递一个闭包给 `get_or_insert_with`，而不是显式提供一个后备值，如下所示："
 
 #: src/error/option_unwrap/defaults.md:98
 msgid ""
@@ -11485,20 +11551,23 @@ msgid ""
 "    // first_available_fruit is: Lemon\n"
 "    // my_fruit is: Some(Lemon)\n"
 msgstr ""
+"// 提供柠檬作为后备\n"
+"    // first_available_fruit is: Lemon\n"
+"    // my_fruit is: Some(Lemon)\n"
 
 #: src/error/option_unwrap/defaults.md:102
 msgid ""
 "// If the Option has a value, it is left unchanged, and the closure is not "
 "invoked\n"
-msgstr ""
+msgstr "// 如果 Option 有值，它保持不变，闭包不会被调用\n"
 
 #: src/error/option_unwrap/defaults.md:105
 msgid "\"should_be_apple is: {:?}\""
-msgstr ""
+msgstr "\"should_be_apple is: {:?}\""
 
 #: src/error/option_unwrap/defaults.md:106
 msgid "\"my_apple is unchanged: {:?}\""
-msgstr ""
+msgstr "\"my_apple is unchanged: {:?}\""
 
 #: src/error/option_unwrap/defaults.md:107
 msgid ""
@@ -11507,6 +11576,9 @@ msgid ""
 "    // should_be_apple is: Apple\n"
 "    // my_apple is unchanged: Some(Apple)\n"
 msgstr ""
+"// 输出如下。注意闭包 `get_lemon_as_fallback` 没有被调用\n"
+"    // should_be_apple is: Apple\n"
+"    // my_apple is unchanged: Some(Apple)\n"
 
 #: src/error/option_unwrap/defaults.md:115
 msgid ""
@@ -11519,6 +11591,14 @@ msgid ""
 "[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
 "or_else)"
 msgstr ""
+"[`闭包`](https://doc.rust-lang.org/book/ch13-01-closures.html), "
+"[`get_or_insert`](https://doc.rust-lang.org/core/option/enum.Option."
+"html#method.get_or_insert), [`get_or_insert_with`](https://doc.rust-lang.org/"
+"core/option/enum.Option.html#method.get_or_insert_with), [`移动变量`]"
+"(https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html), [`or`]"
+"(https://doc.rust-lang.org/core/option/enum.Option.html#method.or), "
+"[`or_else`](https://doc.rust-lang.org/core/option/enum.Option.html#method."
+"or_else)"
 
 #: src/error/result.md:3
 msgid ""
@@ -11526,24 +11606,26 @@ msgid ""
 "version of the [`Option`](https://doc.rust-lang.org/std/option/enum.Option."
 "html) type that describes possible _error_ instead of possible _absence_."
 msgstr ""
+"[`Result`](https://doc.rust-lang.org/std/result/enum.Result.html) 是 [`Option`](https://doc.rust-lang.org/std/option/enum.Option."
+"html) 类型的更丰富版本，它描述可能的**错误**而不是可能的**缺失**。"
 
 #: src/error/result.md:6
 msgid "That is, `Result<T, E>` could have one of two outcomes:"
-msgstr ""
+msgstr "也就是说，`Result<T, E>` 可能有两种结果之一："
 
 #: src/error/result.md:8
 msgid "`Ok(T)`: An element `T` was found"
-msgstr ""
+msgstr "`Ok(T)`：找到了一个元素 `T`"
 
 #: src/error/result.md:9
 msgid "`Err(E)`: An error was found with element `E`"
-msgstr ""
+msgstr "`Err(E)`：找到了一个错误，错误类型为 `E`"
 
 #: src/error/result.md:11
 msgid ""
 "By convention, the expected outcome is `Ok` while the unexpected outcome is "
 "`Err`."
-msgstr ""
+msgstr "按照惯例，预期的结果是 `Ok`，而意外的结果是 `Err`。"
 
 #: src/error/result.md:13
 msgid ""
@@ -11551,6 +11633,7 @@ msgid ""
 "example, either yields the element `T` or `panic`s. For case handling, there "
 "are many combinators between `Result` and `Option` that overlap."
 msgstr ""
+"与 `Option` 类似，`Result` 也有许多与之关联的方法。例如，`unwrap()` 要么产生元素 `T`，要么 `panic`。对于情况处理，`Result` 和 `Option` 之间有许多重叠的组合子。"
 
 #: src/error/result.md:17
 msgid ""
@@ -11560,16 +11643,19 @@ msgid ""
 "parse a string into the other type, so `parse()` returns a `Result` "
 "indicating possible failure."
 msgstr ""
+"在使用 Rust 时，你可能会遇到返回 `Result` 类型的方法，比如 [`parse()`](https://doc.rust-lang.org/std/"
+"primitive.str.html#method.parse) 方法。将字符串解析为其他类型并不总是可能的，所以 `parse()` 返回一个 `Result` "
+"来表示可能的失败。"
 
 #: src/error/result.md:22
 msgid ""
 "Let's see what happens when we successfully and unsuccessfully `parse()` a "
 "string:"
-msgstr ""
+msgstr "让我们看看成功和失败地 `parse()` 一个字符串会发生什么："
 
 #: src/error/result.md:26
 msgid "// Let's try using `unwrap()` to get the number out. Will it bite us?\n"
-msgstr ""
+msgstr "// 让我们尝试使用 `unwrap()` 来获取数字。它会咬我们吗？\n"
 
 #: src/error/result.md:33 src/error/result.md:36
 #: src/error/result/result_map.md:42 src/error/result/result_map.md:46
@@ -11581,11 +11667,11 @@ msgstr ""
 #: src/error/result/enter_question_mark.md:67
 #: src/error/result/enter_question_mark.md:68
 msgid "\"2\""
-msgstr ""
+msgstr "\"2\""
 
 #: src/error/result.md:34 src/error/result.md:37
 msgid "\"double is {}\""
-msgstr ""
+msgstr "\"double is {}\""
 
 #: src/error/result.md:36 src/error/result/result_map.md:46
 #: src/error/result/result_map.md:79 src/error/result/result_alias.md:37
@@ -11593,7 +11679,7 @@ msgstr ""
 #: src/error/result/enter_question_mark.md:35
 #: src/error/result/enter_question_mark.md:68
 msgid "\"t\""
-msgstr ""
+msgstr "\"t\""
 
 #: src/error/result.md:41
 msgid ""
@@ -11601,22 +11687,25 @@ msgid ""
 "`panic` on. Additionally, the `panic` exits our program and provides an "
 "unpleasant error message."
 msgstr ""
+"在失败的情况下，`parse()` 给我们留下了一个错误，`unwrap()` 会在这个错误上 `panic`。此外，`panic` 会退出我们的程序并提供一个令人不愉快的错误消息。"
 
 #: src/error/result.md:45
 msgid ""
 "To improve the quality of our error message, we should be more specific about "
 "the return type and consider explicitly handling the error."
 msgstr ""
+"为了改善我们的错误消息的质量，我们应该更具体地指定返回类型，并考虑显式地处理错误。"
 
 #: src/error/result.md:48
 msgid "Using `Result` in `main`"
-msgstr ""
+msgstr "在 `main` 中使用 `Result`"
 
 #: src/error/result.md:50
 msgid ""
 "The `Result` type can also be the return type of the `main` function if "
 "specified explicitly. Typically the `main` function will be of the form:"
 msgstr ""
+"`Result` 类型也可以是 `main` 函数的返回类型，如果显式指定的话。通常，`main` 函数的形式如下："
 
 #: src/error/result.md:59
 msgid ""
@@ -11627,6 +11716,7 @@ msgid ""
 "scenario and touches on aspects covered in [the following section](result/"
 "early_returns.md)."
 msgstr ""
+"然而，`main` 函数也可以有 `Result` 的返回类型。如果在 `main` 函数内发生错误，它将返回一个错误代码并打印错误的调试表示（使用 [`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html) trait）。以下示例展示了这样一个场景，并涉及了[下一节](result/early_returns.md)中涵盖的方面。"
 
 #: src/error/result/result_map.md:3
 msgid ""
@@ -11634,6 +11724,7 @@ msgid ""
 "Generally, we want to return the error to the caller so it can decide what is "
 "the right way to respond to errors."
 msgstr ""
+"在前面示例的 `multiply` 中使用 panic 并不能产生健壮的代码。通常，我们希望将错误返回给调用者，以便它可以决定如何正确地响应错误。"
 
 #: src/error/result/result_map.md:7
 msgid ""
@@ -11645,25 +11736,28 @@ msgid ""
 "`Err` type is specified as [`ParseIntError`](https://doc.rust-lang.org/std/"
 "num/struct.ParseIntError.html)."
 msgstr ""
+"首先，我们需要知道我们正在处理的错误类型。为了确定 `Err` 类型，我们查看 [`parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse)，它是通过 [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait 为 [`i32`](https://doc.rust-lang.org/std/primitive.i32.html) 实现的。因此，`Err` 类型被指定为 [`ParseIntError`](https://doc.rust-lang.org/std/num/struct.ParseIntError.html)。"
 
 #: src/error/result/result_map.md:12
 msgid ""
 "In the example below, the straightforward `match` statement leads to code "
 "that is overall more cumbersome."
 msgstr ""
+"在下面的示例中，直接使用 `match` 语句会导致整体代码更加繁琐。"
 
 #: src/error/result/result_map.md:17
 msgid ""
 "// With the return type rewritten, we use pattern matching without "
 "`unwrap()`.\n"
 msgstr ""
+"// 重写返回类型后，我们使用模式匹配而不是 `unwrap()`。\n"
 
 #: src/error/result/result_map.md:35 src/error/result/result_map.md:68
 #: src/error/result/result_alias.md:30 src/error/result/early_returns.md:30
 #: src/error/result/enter_question_mark.md:28
 #: src/error/result/enter_question_mark.md:61
 msgid "\"n is {}\""
-msgstr ""
+msgstr "\"n is {}\""
 
 #: src/error/result/result_map.md:36 src/error/result/result_map.md:69
 #: src/error/result/result_alias.md:31 src/error/result/early_returns.md:31
@@ -11674,15 +11768,15 @@ msgstr ""
 #: src/error/multiple_error_types/reenter_question_mark.md:54
 #: src/error/multiple_error_types/wrap_error.md:68
 msgid "\"Error: {}\""
-msgstr ""
+msgstr "\"Error: {}\""
 
 #: src/error/result/result_map.md:41 src/error/result/result_map.md:74
 msgid "// This still presents a reasonable answer.\n"
-msgstr ""
+msgstr "// 这仍然给出了一个合理的答案。\n"
 
 #: src/error/result/result_map.md:45 src/error/result/result_map.md:78
 msgid "// The following now provides a much more helpful error message.\n"
-msgstr ""
+msgstr "// 以下现在提供了一个更有帮助的错误消息。\n"
 
 #: src/error/result/result_map.md:51
 msgid ""
@@ -11690,6 +11784,8 @@ msgid ""
 "implemented for `Result`. [`Result`](https://doc.rust-lang.org/std/result/"
 "enum.Result.html) contains a complete listing."
 msgstr ""
+"幸运的是，`Option` 的 `map`、`and_then` 和许多其他组合器也为 `Result` 实现了。[`Result`](https://doc.rust-lang.org/std/result/"
+"enum.Result.html) 包含了完整的列表。"
 
 #: src/error/result/result_map.md:56
 msgid ""
@@ -11698,6 +11794,9 @@ msgid ""
 "// Multiply if both values can be parsed from str, otherwise pass on the "
 "error.\n"
 msgstr ""
+"// 与 `Option` 一样，我们可以使用诸如 `map()` 之类的组合器。\n"
+"// 这个函数除此之外与上面的函数相同，其含义为：\n"
+"// 如果两个值都可以从字符串解析，则相乘，否则传递错误。\n"
 
 #: src/error/result/result_alias.md:3
 msgid ""
@@ -11705,6 +11804,8 @@ msgid ""
 "that Rust allows us to create [aliases](../../types/alias.md). Conveniently, "
 "we can define one for the specific `Result` in question."
 msgstr ""
+"当我们想多次重用特定的 `Result` 类型时该怎么办？回想一下，Rust 允许我们创建[别名](../../types/alias.md)。方便的是，"
+"我们可以为特定的 `Result` 定义一个别名。"
 
 #: src/error/result/result_alias.md:7
 msgid ""
@@ -11714,28 +11815,32 @@ msgid ""
 "`std` library even supplies one: [`io::Result`](https://doc.rust-lang.org/std/"
 "io/type.Result.html)!"
 msgstr ""
+"在模块级别，创建别名可能特别有用。在特定模块中发现的错误通常具有相同的 `Err` 类型，因此单个别名可以简洁地定义**所有**相关的 `Results`。这非常有用，以至于 "
+"`std` 库甚至提供了一个：[`io::Result`](https://doc.rust-lang.org/std/"
+"io/type.Result.html)！"
 
 #: src/error/result/result_alias.md:12
 msgid "Here's a quick example to show off the syntax:"
-msgstr ""
+msgstr "这里有一个快速示例来展示语法："
 
 #: src/error/result/result_alias.md:16
 msgid ""
 "// Define a generic alias for a `Result` with the error type "
 "`ParseIntError`.\n"
 msgstr ""
+"// 为错误类型为 `ParseIntError` 的 `Result` 定义一个泛型别名。\n"
 
 #: src/error/result/result_alias.md:19
 msgid "// Use the above alias to refer to our specific `Result` type.\n"
-msgstr ""
+msgstr "// 使用上面的别名来引用我们特定的 `Result` 类型。\n"
 
 #: src/error/result/result_alias.md:26
 msgid "// Here, the alias again allows us to save some space.\n"
-msgstr ""
+msgstr "// 在这里，别名再次让我们节省了一些空间。\n"
 
 #: src/error/result/result_alias.md:43
 msgid "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
-msgstr ""
+msgstr "[`io::Result`](https://doc.rust-lang.org/std/io/type.Result.html)"
 
 #: src/error/result/early_returns.md:3
 msgid ""
@@ -11743,6 +11848,7 @@ msgid ""
 "Another way to deal with this case analysis is to use a combination of "
 "`match` statements and _early returns_."
 msgstr ""
+"在前面的例子中，我们使用组合器显式地处理了错误。处理这种情况分析的另一种方法是使用 `match` 语句和**提前返回**的组合。"
 
 #: src/error/result/early_returns.md:7
 msgid ""
@@ -11750,6 +11856,8 @@ msgid ""
 "one occurs. For some, this form of code can be easier to both read and write. "
 "Consider this version of the previous example, rewritten using early returns:"
 msgstr ""
+"也就是说，如果发生错误，我们可以简单地停止执行函数并返回错误。对某些人来说，这种形式的代码可能更容易阅读和编写。"
+"考虑使用提前返回重写的前面示例的这个版本："
 
 #: src/error/result/early_returns.md:41
 msgid ""
@@ -11757,12 +11865,14 @@ msgid ""
 "and early returns. While we generally want to avoid panicking, explicitly "
 "handling all of our errors is cumbersome."
 msgstr ""
+"到目前为止，我们已经学会了使用组合器和提前返回来显式处理错误。虽然我们通常想避免 panic，但显式处理所有错误是很麻烦的。"
 
 #: src/error/result/early_returns.md:45
 msgid ""
 "In the next section, we'll introduce `?` for the cases where we simply need "
 "to `unwrap` without possibly inducing `panic`."
 msgstr ""
+"在下一节中，我们将介绍 `?`，用于我们只需要 `unwrap` 而不可能引发 `panic` 的情况。"
 
 #: src/error/result/enter_question_mark.md:3
 msgid ""
@@ -11771,18 +11881,20 @@ msgid ""
 "what we really wanted was to get the variable _out_. This is exactly the "
 "purpose of `?`."
 msgstr ""
+"有时我们只想要 `unwrap` 的简单性，而不希望有 `panic` 的可能性。到目前为止，当我们真正想要的是获取变量**出来**时，`unwrap` 迫使我们不断地嵌套。"
+"这正是 `?` 的目的。"
 
 #: src/error/result/enter_question_mark.md:7
 msgid "Upon finding an `Err`, there are two valid actions to take:"
-msgstr ""
+msgstr "在发现 `Err` 时，有两种有效的行动："
 
 #: src/error/result/enter_question_mark.md:9
 msgid "`panic!` which we already decided to try to avoid if possible"
-msgstr ""
+msgstr "`panic!`，我们已经决定尽可能避免"
 
 #: src/error/result/enter_question_mark.md:10
 msgid "`return` because an `Err` means it cannot be handled"
-msgstr ""
+msgstr "`return`，因为 `Err` 意味着它无法被处理"
 
 #: src/error/result/enter_question_mark.md:12
 msgid ""
@@ -11790,10 +11902,11 @@ msgid ""
 "of `panic`king on `Err`s. Let's see how we can simplify the earlier example "
 "that used combinators:"
 msgstr ""
+"`?` **几乎**[^†]完全等同于在 `Err` 上 `return` 而不是 `panic` 的 `unwrap`。让我们看看如何简化之前使用组合器的例子："
 
 #: src/error/result/enter_question_mark.md:39
 msgid "The `try!` macro"
-msgstr ""
+msgstr "`try!` 宏"
 
 #: src/error/result/enter_question_mark.md:41
 msgid ""
@@ -11802,6 +11915,8 @@ msgid ""
 "when looking at older code. The same `multiply` function from the previous "
 "example would look like this using `try!`:"
 msgstr ""
+"在有 `?` 之前，相同的功能是通过 `try!` 宏实现的。现在推荐使用 `?` 运算符，但在查看旧代码时，你可能仍会看到 `try!`。"
+"前面例子中的相同 `multiply` 函数使用 `try!` 看起来像这样："
 
 #: src/error/result/enter_question_mark.md:47
 msgid ""
@@ -11810,18 +11925,22 @@ msgid ""
 "// of the `edition` field, in the `[package]` section of the `Cargo.toml` "
 "file, to \"2015\".\n"
 msgstr ""
+"// 要在使用 Cargo 时编译并运行此示例而不出错，请更改\n"
+"// `Cargo.toml` 文件的 `[package]` 部分中 `edition` 字段的值为 \"2015\"。\n"
 
 #: src/error/result/enter_question_mark.md:73
 msgid ""
 "See [re-enter ?](../multiple_error_types/reenter_question_mark.md) for more "
 "details."
 msgstr ""
+"更多详情请 [重新回顾 ?](../multiple_error_types/reenter_question_mark.md)。"
 
 #: src/error/multiple_error_types.md:3
 msgid ""
 "The previous examples have always been very convenient; `Result`s interact "
 "with other `Result`s and `Option`s interact with other `Option`s."
 msgstr ""
+"前面的例子一直都很方便；`Result` 与其他 `Result` 交互，`Option` 与其他 `Option` 交互。"
 
 #: src/error/multiple_error_types.md:6
 msgid ""
@@ -11830,6 +11949,8 @@ msgid ""
 "want to manage our different error types in a way that makes them composable "
 "and easy to interact with."
 msgstr ""
+"有时 `Option` 需要与 `Result` 交互，或者 `Result<T, Error1>` 需要与 `Result<T, Error2>` 交互。在这些情况下，"
+"我们希望以一种使它们可组合且易于交互的方式来管理不同的错误类型。"
 
 #: src/error/multiple_error_types.md:11
 msgid ""
@@ -11837,14 +11958,16 @@ msgid ""
 "types. `Vec::first` returns an `Option`, while `parse::<i32>` returns a "
 "`Result<i32, ParseIntError>`:"
 msgstr ""
+"在下面的代码中，两个 `unwrap` 实例生成不同的错误类型。`Vec::first` 返回一个 `Option`，而 `parse::<i32>` 返回一个 "
+"`Result<i32, ParseIntError>`："
 
 #: src/error/multiple_error_types.md:17
 msgid "// Generate error 1\n"
-msgstr ""
+msgstr "// 生成错误 1\n"
 
 #: src/error/multiple_error_types.md:18
 msgid "// Generate error 2\n"
-msgstr ""
+msgstr "// 生成错误 2\n"
 
 #: src/error/multiple_error_types.md:22
 #: src/error/multiple_error_types/option_result.md:16
@@ -11854,7 +11977,7 @@ msgstr ""
 #: src/error/multiple_error_types/reenter_question_mark.md:59
 #: src/error/multiple_error_types/wrap_error.md:77 src/error/iter_result.md:40
 msgid "\"42\""
-msgstr ""
+msgstr "\"42\""
 
 #: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
 #: src/error/multiple_error_types/option_result.md:16
@@ -11873,7 +11996,7 @@ msgstr ""
 #: src/error/iter_result.md:60 src/error/iter_result.md:75
 #: src/error/iter_result.md:90
 msgid "\"93\""
-msgstr ""
+msgstr "\"93\""
 
 #: src/error/multiple_error_types.md:22 src/error/multiple_error_types.md:24
 #: src/error/multiple_error_types/option_result.md:16
@@ -11892,7 +12015,7 @@ msgstr ""
 #: src/error/iter_result.md:60 src/error/iter_result.md:75
 #: src/error/iter_result.md:90
 msgid "\"18\""
-msgstr ""
+msgstr "\"18\""
 
 #: src/error/multiple_error_types.md:24
 #: src/error/multiple_error_types/option_result.md:18
@@ -11905,7 +12028,7 @@ msgstr ""
 #: src/error/iter_result.md:60 src/error/iter_result.md:75
 #: src/error/iter_result.md:90
 msgid "\"tofu\""
-msgstr ""
+msgstr "\"tofu\""
 
 #: src/error/multiple_error_types.md:26 src/error/multiple_error_types.md:28
 #: src/error/multiple_error_types.md:31
@@ -11914,29 +12037,29 @@ msgstr ""
 #: src/error/multiple_error_types/reenter_question_mark.md:53
 #: src/error/multiple_error_types/wrap_error.md:66
 msgid "\"The first doubled is {}\""
-msgstr ""
+msgstr "\"第一个数的两倍是 {}\""
 
 #: src/error/multiple_error_types.md:29
 #: src/error/multiple_error_types/option_result.md:23
 msgid "// Error 1: the input vector is empty\n"
-msgstr ""
+msgstr "// 错误 1：输入向量为空\n"
 
 #: src/error/multiple_error_types.md:32
 #: src/error/multiple_error_types/option_result.md:26
 msgid "// Error 2: the element doesn't parse to a number\n"
-msgstr ""
+msgstr "// 错误 2：元素无法解析为数字\n"
 
 #: src/error/multiple_error_types.md:36
 msgid ""
 "Over the next sections, we'll see several strategies for handling these kind "
 "of problems."
-msgstr ""
+msgstr "在接下来的章节中，我们将看到几种处理这类问题的策略。"
 
 #: src/error/multiple_error_types/option_result.md:3
 msgid ""
 "The most basic way of handling mixed error types is to just embed them in "
 "each other."
-msgstr ""
+msgstr "处理混合错误类型最基本的方法就是将它们相互嵌套。"
 
 #: src/error/multiple_error_types/option_result.md:20
 #: src/error/multiple_error_types/option_result.md:22
@@ -11945,7 +12068,7 @@ msgstr ""
 #: src/error/multiple_error_types/option_result.md:50
 #: src/error/multiple_error_types/option_result.md:51
 msgid "\"The first doubled is {:?}\""
-msgstr ""
+msgstr "\"第一个数的两倍是 {:?}\""
 
 #: src/error/multiple_error_types/option_result.md:30
 msgid ""
@@ -11954,54 +12077,56 @@ msgid ""
 "`None`. The `transpose` function comes in handy to swap the `Result` and "
 "`Option`."
 msgstr ""
+"有时我们希望在遇到错误时停止处理（就像使用 [`?`](../result/enter_question_mark.md) 一样），但在 `Option` 为 `None` 时继续执行。"
+"`transpose` 函数在交换 `Result` 和 `Option` 时非常有用。"
 
 #: src/error/multiple_error_types/define_error_type.md:3
 msgid ""
 "Sometimes it simplifies the code to mask all of the different errors with a "
 "single type of error.  We'll show this with a custom error."
-msgstr ""
+msgstr "有时，用单一类型的错误来掩盖所有不同的错误可以简化代码。我们将通过自定义错误来展示这一点。"
 
 #: src/error/multiple_error_types/define_error_type.md:6
 msgid ""
 "Rust allows us to define our own error types. In general, a \"good\" error "
 "type:"
-msgstr ""
+msgstr "Rust 允许我们定义自己的错误类型。通常，一个"好的"错误类型："
 
 #: src/error/multiple_error_types/define_error_type.md:8
 msgid "Represents different errors with the same type"
-msgstr ""
+msgstr "用相同的类型表示不同的错误"
 
 #: src/error/multiple_error_types/define_error_type.md:9
 msgid "Presents nice error messages to the user"
-msgstr ""
+msgstr "向用户呈现友好的错误消息"
 
 #: src/error/multiple_error_types/define_error_type.md:10
 msgid "Is easy to compare with other types"
-msgstr ""
+msgstr "易于与其他类型进行比较"
 
 #: src/error/multiple_error_types/define_error_type.md:11
 msgid "Good: `Err(EmptyVec)`"
-msgstr ""
+msgstr "示例：`Err(EmptyVec)`"
 
 #: src/error/multiple_error_types/define_error_type.md:12
 msgid "Bad: `Err(\"Please use a vector with at least one element\".to_owned())`"
-msgstr ""
+msgstr "反例：`Err(\"Please use a vector with at least one element\".to_owned())`"
 
 #: src/error/multiple_error_types/define_error_type.md:13
 msgid "Can hold information about the error"
-msgstr ""
+msgstr "可以保存有关错误的信息"
 
 #: src/error/multiple_error_types/define_error_type.md:14
 msgid "Good: `Err(BadChar(c, position))`"
-msgstr ""
+msgstr "示例：`Err(BadChar(c, position))`"
 
 #: src/error/multiple_error_types/define_error_type.md:15
 msgid "Bad: `Err(\"+ cannot be used here\".to_owned())`"
-msgstr ""
+msgstr "反例：`Err(\"+ cannot be used here\".to_owned())`"
 
 #: src/error/multiple_error_types/define_error_type.md:16
 msgid "Composes well with other errors"
-msgstr ""
+msgstr "能够与其他错误很好地组合"
 
 #: src/error/multiple_error_types/define_error_type.md:22
 msgid ""
@@ -12010,6 +12135,9 @@ msgid ""
 "// Now we will be able to write our own errors, defer to an underlying error\n"
 "// implementation, or do something in between.\n"
 msgstr ""
+"// 定义我们的错误类型。这些可以根据我们的错误处理情况进行自定义。\n"
+"// 现在我们将能够编写自己的错误，依赖于底层的错误实现，\n"
+"// 或者在两者之间做些处理。\n"
 
 #: src/error/multiple_error_types/define_error_type.md:28
 msgid ""
@@ -12022,20 +12150,25 @@ msgid ""
 "// which string failed to parse without modifying our types to carry that "
 "information.\n"
 msgstr ""
+"// 错误的生成与其显示方式完全分离。\n"
+"// 不需要担心用显示样式使复杂的逻辑变得混乱。\n"
+"//\n"
+"// 注意，我们没有存储关于错误的任何额外信息。这意味着我们无法说明\n"
+"// 哪个字符串解析失败，除非修改我们的类型以携带该信息。\n"
 
 #: src/error/multiple_error_types/define_error_type.md:36
 #: src/error/multiple_error_types/boxing_errors.md:23
 #: src/error/multiple_error_types/reenter_question_mark.md:37
 msgid "\"invalid first item to double\""
-msgstr ""
+msgstr "\"无效的第一个要加倍的项\""
 
 #: src/error/multiple_error_types/define_error_type.md:42
 msgid "// Change the error to our new type.\n"
-msgstr ""
+msgstr "// 将错误改为我们的新类型。\n"
 
 #: src/error/multiple_error_types/define_error_type.md:46
 msgid "// Update to the new error type here also.\n"
-msgstr ""
+msgstr "// 这里也更新为新的错误类型。\n"
 
 #: src/error/multiple_error_types/boxing_errors.md:3
 msgid ""
@@ -12045,6 +12178,8 @@ msgid ""
 "determined](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-"
 "objects-perform-dynamic-dispatch)."
 msgstr ""
+"如果又想写简单的代码，又想保存原始错误信息，一个方法是把它们装箱（[`Box`](https://doc.rust-lang.org/std/boxed/struct.Box.html)）。"
+"缺点是底层错误类型只在运行时才知道，而不是[静态确定的](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)。"
 
 #: src/error/multiple_error_types/boxing_errors.md:7
 msgid ""
@@ -12053,16 +12188,18 @@ msgid ""
 "`Box<Error>`, via [`From`](https://doc.rust-lang.org/std/convert/trait.From."
 "html)."
 msgstr ""
+"标准库通过让 `Box` 实现从任何实现 `Error` trait 的类型到 trait 对象 `Box<Error>` 的转换，来帮助我们将错误装箱，"
+"这是通过 [`From`](https://doc.rust-lang.org/std/convert/trait.From.html) 实现的。"
 
 #: src/error/multiple_error_types/boxing_errors.md:14
 #: src/error/multiple_error_types/reenter_question_mark.md:28
 msgid "// Change the alias to use `Box<dyn error::Error>`.\n"
-msgstr ""
+msgstr "// 更改别名以使用 `Box<dyn error::Error>`。\n"
 
 #: src/error/multiple_error_types/boxing_errors.md:31
 #: src/error/multiple_error_types/boxing_errors.md:34
 msgid "// Converts to Box\n"
-msgstr ""
+msgstr "// 转换为 Box\n"
 
 #: src/error/multiple_error_types/boxing_errors.md:59
 msgid ""
@@ -12070,12 +12207,16 @@ msgid ""
 "html#trait-objects-perform-dynamic-dispatch) and [`Error` trait](https://doc."
 "rust-lang.org/std/error/trait.Error.html)"
 msgstr ""
+"[动态分发](https://doc.rust-lang.org/book/ch17-02-trait-objects."
+"html#trait-objects-perform-dynamic-dispatch)和 [`Error` trait](https://doc."
+"rust-lang.org/std/error/trait.Error.html)"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:3
 msgid ""
 "Notice in the previous example that our immediate reaction to calling `parse` "
 "is to `map` the error from a library error into a boxed error:"
 msgstr ""
+"注意在前面的例子中，我们对调用 `parse` 的直接反应是将库错误 `map` 到一个装箱的错误中："
 
 #: src/error/multiple_error_types/reenter_question_mark.md:12
 msgid ""
@@ -12083,6 +12224,8 @@ msgid ""
 "could be elided. Alas, because `and_then` is not sufficiently flexible, it "
 "cannot. However, we can instead use `?`."
 msgstr ""
+"因为这个操作很简单常见，如果有省略写法就好了。可惜的是，因为 `and_then` 不够灵活，所以实现不了。"
+"不过，我们可以使用 `?` 来代替。"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:16
 msgid ""
@@ -12092,18 +12235,24 @@ msgid ""
 "types, this means that if you `?` where the error is convertible to the "
 "return type, it will convert automatically."
 msgstr ""
+"`?` 之前被解释为 `unwrap` 或 `return Err(err)`。这只是大部分正确。它实际上意味着 `unwrap` 或 "
+"`return Err(From::from(err))`。由于 `From::from` 是不同类型之间的转换工具，这意味着如果你在错误可转换为返回类型的地方使用 `?`，"
+"它将自动转换。"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:22
 msgid ""
 "Here, we rewrite the previous example using `?`. As a result, the `map_err` "
 "will go away when `From::from` is implemented for our error type:"
 msgstr ""
+"在这里，我们使用 `?` 重写了前面的例子。因此，当为我们的错误类型实现 `From::from` 时，`map_err` 将会消失："
 
 #: src/error/multiple_error_types/reenter_question_mark.md:42
 msgid ""
 "// The same structure as before but rather than chain all `Results`\n"
 "// and `Options` along, we `?` to get the inner value out immediately.\n"
 msgstr ""
+"// 结构与之前相同，但我们不再链接所有的 `Results` 和 `Options`，\n"
+"// 而是使用 `?` 来立即获取内部值。\n"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:69
 msgid ""
@@ -12111,6 +12260,8 @@ msgid ""
 "very similar to replacing the `unwrap` calls with `?` except that the return "
 "types are `Result`. As a result, they must be destructured at the top level."
 msgstr ""
+"这段代码已经相当清晰了。与原始的 `panic` 相比，它非常类似于用 `?` 替换 `unwrap` 调用，"
+"只是返回类型是 `Result`。因此，它们必须在顶层进行解构。"
 
 #: src/error/multiple_error_types/reenter_question_mark.md:76
 msgid ""
@@ -12118,30 +12269,36 @@ msgid ""
 "`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
 "question-mark-operator)"
 msgstr ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 [`?"
+"`](https://doc.rust-lang.org/reference/expressions/operator-expr.html#the-"
+"question-mark-operator)"
 
 #: src/error/multiple_error_types/wrap_error.md:3
 msgid "An alternative to boxing errors is to wrap them in your own error type."
-msgstr ""
+msgstr "另一种替代装箱错误的方法是将它们包装在你自己的错误类型中。"
 
 #: src/error/multiple_error_types/wrap_error.md:16
 msgid ""
 "// We will defer to the parse error implementation for their error.\n"
 "    // Supplying extra info requires adding more data to the type.\n"
 msgstr ""
+"// 我们将延迟到解析错误实现中处理它们的错误。\n"
+"    // 提供额外信息需要向类型添加更多数据。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:25
 msgid "\"please use a vector with at least one element\""
-msgstr ""
+msgstr "\"请使用至少包含一个元素的向量\""
 
 #: src/error/multiple_error_types/wrap_error.md:26
 msgid ""
 "// The wrapped error contains additional information and is available\n"
 "            // via the source() method.\n"
 msgstr ""
+"// 包装的错误包含额外信息，可以通过 source() 方法获取。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:29
 msgid "\"the provided string could not be parsed as int\""
-msgstr ""
+msgstr "\"提供的字符串无法解析为整数\""
 
 #: src/error/multiple_error_types/wrap_error.md:38
 msgid ""
@@ -12150,6 +12307,9 @@ msgid ""
 "the\n"
 "            // underlying type already implements the `Error` trait.\n"
 msgstr ""
+"// 原因是底层实现的错误类型。它被隐式地\n"
+"            // 转换为 trait 对象 `&error::Error`。这是可行的，因为\n"
+"            // 底层类型已经实现了 `Error` trait。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:45
 msgid ""
@@ -12157,17 +12317,21 @@ msgid ""
 "// This will be automatically called by `?` if a `ParseIntError`\n"
 "// needs to be converted into a `DoubleError`.\n"
 msgstr ""
+"// 实现从 `ParseIntError` 到 `DoubleError` 的转换。\n"
+"// 如果需要将 `ParseIntError` 转换为 `DoubleError`，\n"
+"// 这将被 `?` 自动调用。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:57
 msgid ""
-"// Here we implicitly use the `ParseIntError` implementation of `From` "
-"(which\n"
+"// Here we implicitly use the `ParseIntError` implementation of `From` (which\n"
 "    // we defined above) in order to create a `DoubleError`.\n"
 msgstr ""
+"// 这里我们隐式使用 `ParseIntError` 的 `From` 实现（我们在上面定义的）\n"
+"    // 来创建一个 `DoubleError`。\n"
 
 #: src/error/multiple_error_types/wrap_error.md:70
 msgid "\"  Caused by: {}\""
-msgstr ""
+msgstr "\"  原因：{}\""
 
 #: src/error/multiple_error_types/wrap_error.md:87
 msgid ""
@@ -12175,67 +12339,73 @@ msgid ""
 "in all applications. There are some libraries that can take care of the "
 "boilerplate for you."
 msgstr ""
+"这增加了一些处理错误的样板代码，可能并不是所有应用程序都需要。有一些库可以为你处理这些样板代码。"
 
 #: src/error/multiple_error_types/wrap_error.md:93
 msgid ""
 "[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) and "
 "[`Enums`](../../custom_types/enum.md)"
 msgstr ""
+"[`From::from`](https://doc.rust-lang.org/std/convert/trait.From.html) 和 "
+"[`枚举`](../../custom_types/enum.md)"
 
 #: src/error/multiple_error_types/wrap_error.md:96
 msgid ""
 "[`Crates for handling errors`](https://crates.io/keywords/error-handling)"
 msgstr ""
+"[`处理错误的 crate`](https://crates.io/keywords/error-handling)"
 
 #: src/error/iter_result.md:3
 msgid "An `Iter::map` operation might fail, for example:"
-msgstr ""
+msgstr "`Iter::map` 操作可能会失败，例如："
 
 #: src/error/iter_result.md:12 src/error/iter_result.md:29
 #: src/error/iter_result.md:65
 msgid "\"Results: {:?}\""
-msgstr ""
+msgstr "\"结果：{:?}\""
 
 #: src/error/iter_result.md:16
 msgid "Let's step through strategies for handling this."
-msgstr ""
+msgstr "让我们逐步介绍处理这种情况的策略。"
 
 #: src/error/iter_result.md:18
 msgid "Ignore the failed items with `filter_map()`"
-msgstr ""
+msgstr "使用 `filter_map()` 忽略失败的项"
 
 #: src/error/iter_result.md:20
 msgid ""
 "`filter_map` calls a function and filters out the results that are `None`."
-msgstr ""
+msgstr "`filter_map` 调用一个函数并过滤掉结果为 `None` 的项。"
 
 #: src/error/iter_result.md:33
 msgid "Collect the failed items with `map_err()` and `filter_map()`"
-msgstr ""
+msgstr "使用 `map_err()` 和 `filter_map()` 收集失败的项"
 
 #: src/error/iter_result.md:35
 msgid ""
 "`map_err` calls a function with the error, so by adding that to the previous "
 "`filter_map` solution we can save them off to the side while iterating."
 msgstr ""
+"`map_err` 使用错误调用一个函数，所以通过将其添加到之前的 `filter_map` 解决方案中，"
+"我们可以在迭代时将它们保存到一边。"
 
 #: src/error/iter_result.md:40
 msgid "\"999\""
-msgstr ""
+msgstr "\"999\""
 
 #: src/error/iter_result.md:47 src/error/iter_result.md:80
 #: src/error/iter_result.md:97
 msgid "\"Numbers: {:?}\""
-msgstr ""
+msgstr "\"数字：{:?}\""
 
 #: src/error/iter_result.md:48 src/error/iter_result.md:81
 #: src/error/iter_result.md:98
 msgid "\"Errors: {:?}\""
-msgstr ""
+msgstr "\"错误：{:?}\""
 
 #: src/error/iter_result.md:52
 msgid "Fail the entire operation with `collect()`"
-msgstr ""
+msgstr "使用 `collect()` 使整个操作失败"
 
 #: src/error/iter_result.md:54
 msgid ""
@@ -12244,20 +12414,23 @@ msgid ""
 "(`Result<Vec<T>, E>`). Once an `Result::Err` is found, the iteration will "
 "terminate."
 msgstr ""
+"`Result` 实现了 `FromIterator`，因此结果的向量（`Vec<Result<T, E>>`）可以转换为包裹着向量的结果"
+"（`Result<Vec<T>, E>`）。一旦找到 `Result::Err`，迭代将终止。"
 
 #: src/error/iter_result.md:69
 msgid "This same technique can be used with `Option`."
-msgstr ""
+msgstr "这种方式也可以用于 `Option`。"
 
 #: src/error/iter_result.md:71
 msgid "Collect all valid values and failures with `partition()`"
-msgstr ""
+msgstr "使用 `partition()` 收集所有有效值和错误"
 
 #: src/error/iter_result.md:85
 msgid ""
 "When you look at the results, you'll note that everything is still wrapped in "
 "`Result`.  A little more boilerplate is needed for this."
 msgstr ""
+"当你查看结果时，你会注意到所有内容仍然被包装在 `Result` 中。这需要一些额外的样板代码。"
 
 #: src/std.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -1580,26 +1580,32 @@ msgid ""
 "Display`](https://doc.rust-lang.org/std/fmt/), which uses the `{}` print "
 "marker. Implementing it looks like this:"
 msgstr ""
+"`fmt::Debug` 看起来并不简洁美观，因此通常需要进一步自定义输出的形式。"
+"这可以通过手动实现 [`fmt::Display`](https://doc.rust-lang.org/std/fmt/) 来完成，"
+"它使用 `{}` 打印标记。实现方式看起来像这样："
 
 #: src/hello/print/print_display.md:9
 msgid "// Import (via `use`) the `fmt` module to make it available.\n"
-msgstr ""
+msgstr "// 导入（通过 `use`）`fmt` 模块使其可用。\n"
 
 #: src/hello/print/print_display.md:11
 msgid ""
 "// Define a structure for which `fmt::Display` will be implemented. This is\n"
 "// a tuple struct named `Structure` that contains an `i32`.\n"
 msgstr ""
+"// 定义一个结构体，我们将为它实现 `fmt::Display`。这是一个包含\n"
+"// 单个 `i32` 的元组结构体，名为 `Structure`。\n"
 
 #: src/hello/print/print_display.md:15
 msgid ""
 "// To use the `{}` marker, the trait `fmt::Display` must be implemented\n"
 "// manually for the type.\n"
 msgstr ""
+"// 为了使用 `{}` 标记，必须手动为类型实现 `fmt::Display` trait。\n"
 
 #: src/hello/print/print_display.md:19
 msgid "// This trait requires `fmt` with this exact signature.\n"
-msgstr ""
+msgstr "// 这个 trait 要求 `fmt` 使用与此完全一致的函数签名。\n"
 
 #: src/hello/print/print_display.md:21
 msgid ""
@@ -1609,6 +1615,9 @@ msgid ""
 "which\n"
 "        // is very similar to `println!`.\n"
 msgstr ""
+"// 将第一个元素写入到提供的输出流 `f` 中。\n"
+"        // 返回 `fmt::Result`，指示操作是否成功。\n"
+"        // 注意 `write!` 的用法和 `println!` 非常相似。\n"
 
 #: src/hello/print/print_display.md:25
 #: src/hello/print/print_display/testcase_list.md:13
@@ -1626,7 +1635,7 @@ msgstr ""
 #: src/std_misc/file/read_lines.md:60 src/std_misc/arg/matching.md:9
 #: src/std_misc/arg/matching.md:13
 msgid "\"{}\""
-msgstr ""
+msgstr "\"{}\""
 
 #: src/hello/print/print_display.md:30
 msgid ""
@@ -1635,14 +1644,17 @@ msgid ""
 "if the `std` library implemented a single style for all `Vec<T>`, what style "
 "should it be? Would it be either of these two?"
 msgstr ""
+"`fmt::Display` 可能比 `fmt::Debug` 更整洁，但这给 `std` 库带来了一个问题。"
+"应该如何显示含糊不清的类型？例如，如果 `std` 库为所有的 `Vec<T>` 实现了一种风格，"
+"那应该是什么风格？是下面两种中的哪一个？"
 
 #: src/hello/print/print_display.md:35
 msgid "`Vec<path>`: `/:/etc:/home/username:/bin` (split on `:`)"
-msgstr ""
+msgstr "`Vec<path>`：`/:/etc:/home/username:/bin`（以 `:` 分隔）"
 
 #: src/hello/print/print_display.md:36
 msgid "`Vec<number>`: `1,2,3` (split on `,`)"
-msgstr ""
+msgstr "`Vec<number>`：`1,2,3`（以 `,` 分隔）"
 
 #: src/hello/print/print_display.md:38
 msgid ""
@@ -1651,16 +1663,20 @@ msgid ""
 "`Vec<T>` or for any other generic containers. `fmt::Debug` must then be used "
 "for these generic cases."
 msgstr ""
+"答案是否定的，因为对于所有类型来说没有一种理想的风格，而且 `std` 库也不应该擅自规定一种风格。"
+"`fmt::Display` 没有为 `Vec<T>` 或其他任何泛型容器实现。"
+"因此，这些泛型的情况必须使用 `fmt::Debug`。"
 
 #: src/hello/print/print_display.md:43
 msgid ""
 "This is not a problem though because for any new _container_ type which is "
 "_not_ generic, `fmt::Display` can be implemented."
 msgstr ""
+"不过这不是问题，因为对于任何新的非泛型的容器类型，都可以实现 `fmt::Display`。"
 
 #: src/hello/print/print_display.md:47
 msgid "// Import `fmt`\n"
-msgstr ""
+msgstr "// 导入 `fmt`\n"
 
 #: src/hello/print/print_display.md:48
 msgid ""
@@ -1668,54 +1684,56 @@ msgid ""
 "can\n"
 "// be contrasted with `Display`.\n"
 msgstr ""
+"// 带有两个数字的结构体。推导出 `Debug`，以便\n"
+"// 与 `Display` 的输出进行比较。\n"
 
 #: src/hello/print/print_display.md:53
 msgid "// Implement `Display` for `MinMax`.\n"
-msgstr ""
+msgstr "// 为 `MinMax` 实现 `Display`。\n"
 
 #: src/hello/print/print_display.md:57
 msgid "// Use `self.number` to refer to each positional data point.\n"
-msgstr ""
+msgstr "// 使用 `self.number` 来表示每个数据点。\n"
 
 #: src/hello/print/print_display.md:58
 msgid "\"({}, {})\""
-msgstr ""
+msgstr "\"({}, {})\""
 
 #: src/hello/print/print_display.md:61
 msgid "// Define a structure where the fields are nameable for comparison.\n"
-msgstr ""
+msgstr "// 定义一个结构体，使其字段可命名以进行比较。\n"
 
 #: src/hello/print/print_display.md:68
 msgid "// Similarly, implement `Display` for `Point2D`.\n"
-msgstr ""
+msgstr "// 类似地，为 `Point2D` 实现 `Display`。\n"
 
 #: src/hello/print/print_display.md:72
 msgid "// Customize so only `x` and `y` are denoted.\n"
-msgstr ""
+msgstr "// 自定义，使得只有 `x` 和 `y` 被表示。\n"
 
 #: src/hello/print/print_display.md:73
 msgid "\"x: {}, y: {}\""
-msgstr ""
+msgstr "\"x: {}, y: {}\""
 
 #: src/hello/print/print_display.md:80
 msgid "\"Compare structures:\""
-msgstr ""
+msgstr "\"Compare structures:\""
 
 #: src/hello/print/print_display.md:81 src/hello/print/print_display.md:94
 msgid "\"Display: {}\""
-msgstr ""
+msgstr "\"Display: {}\""
 
 #: src/hello/print/print_display.md:82 src/hello/print/print_display.md:95
 msgid "\"Debug: {:?}\""
-msgstr ""
+msgstr "\"Debug: {:?}\""
 
 #: src/hello/print/print_display.md:87
 msgid "\"The big range is {big} and the small is {small}\""
-msgstr ""
+msgstr "\"The big range is {big} and the small is {small}\""
 
 #: src/hello/print/print_display.md:93
 msgid "\"Compare points:\""
-msgstr ""
+msgstr "\"Compare points:\""
 
 #: src/hello/print/print_display.md:97
 msgid ""
@@ -1723,6 +1741,9 @@ msgid ""
 "    // requires `fmt::Binary` to be implemented. This will not work.\n"
 "    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
 msgstr ""
+"// 报错。`Debug` 和 `Display` 都已经实现，但 `{:b}` 需要\n"
+"    // `fmt::Binary` 得到实现。这行不通。\n"
+"    // println!(\"What does Point2D look like in binary: {:b}?\", point);\n"
 
 #: src/hello/print/print_display.md:103
 msgid ""
@@ -1732,6 +1753,9 @@ msgid ""
 "implementation. This is detailed further in [`std::fmt`](https://doc.rust-"
 "lang.org/std/fmt/)."
 msgstr ""
+"因此，`fmt::Display` 已经实现，但 `fmt::Binary` 没有，所以不能使用。"
+"`std::fmt` 中有很多这样的 [`traits`](https://doc.rust-lang.org/std/fmt/#formatting-traits)，"
+"每个都需要自己的实现。这在 [`std::fmt`](https://doc.rust-lang.org/std/fmt/) 中有更详细的说明。"
 
 #: src/hello/print/print_display.md:109
 msgid ""
@@ -1739,6 +1763,8 @@ msgid ""
 "guide to add a `Complex` struct to the example. When printed in the same way, "
 "the output should be:"
 msgstr ""
+"在检查了上面例子的输出后，以 `Point2D` 结构体为示例，向例子中添加一个 `Complex` 结构体。"
+"当以相同方式打印时，输出应该是："
 
 #: src/hello/print/print_display.md:120
 msgid ""
@@ -1747,6 +1773,9 @@ msgid ""
 "md), [`trait`](https://doc.rust-lang.org/std/fmt/#formatting-traits), and "
 "[`use`](../../mod/use.md)"
 msgstr ""
+"[`derive`](../../trait/derive.md)、[`std::fmt`](https://doc.rust-lang.org/std/fmt/)、"
+"[`macros`](../../macros.md)、[`struct`](../../custom_types/structs.md)、"
+"[`trait`](https://doc.rust-lang.org/std/fmt/#formatting-traits) 和 [`use`](../../mod/use.md)"
 
 #: src/hello/print/print_display/testcase_list.md:3
 msgid ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -12501,7 +12501,7 @@ msgid ""
 "// (all the type annotations are superfluous)\n"
 "    // Stack allocated variables\n"
 msgstr ""
-"// （所有的类型注解都不是必须的）\n"
+"// （所有的类型标注都不是必须的）\n"
 "    // 栈分配的变量\n"
 
 #: src/std/box.md:47
@@ -12708,7 +12708,7 @@ msgid ""
 "// (all the type annotations are superfluous)\n"
 "    // A reference to a string allocated in read only memory\n"
 msgstr ""
-"// （所有的类型注解都是多余的）\n"
+"// （所有的类型标注都是多余的）\n"
 "    // 一个指向只读内存中分配的字符串的引用\n"
 
 #: src/std/str.md:16
@@ -12940,7 +12940,7 @@ msgstr "\"一些转义的字节：{:?}\""
 
 #: src/std/str.md:135
 msgid "// Raw byte strings work just like raw strings\n"
-msgstr "// 原始字节字符串的工作方式就像原始字符串\n"
+msgstr "// 原始字节字符串和原始字符串的写法一样\n"
 
 #: src/std/str.md:136
 msgid "br\"\\u{211D} is not escaped here\""
@@ -12959,8 +12959,9 @@ msgid ""
 "br#\"You can also use \"fancier\" formatting, \\\n"
 "                    like with normal raw strings\"#"
 msgstr ""
-"br#\"你也可以使用"更花哨的"格式化，\\\n"
-"                    就像普通的原始字符串一样\"#"
+"br#\"You can also use \"fancier\" formatting, \\\n"
+"                    like with normal raw strings\"#"
+"/*你也可以使用"更花哨的"格式，就像普通的原始字符串一样*/"
 
 #: src/std/str.md:147
 msgid "// Byte strings don't have to be UTF-8\n"
@@ -13007,62 +13008,63 @@ msgid ""
 "Sometimes it's desirable to catch the failure of some parts of a program "
 "instead of calling `panic!`; this can be accomplished using the `Option` enum."
 msgstr ""
+"有时我们希望捕获程序某些部分的失败，而不是调用 `panic!`；这可以通过使用 `Option` 枚举来实现。"
 
 #: src/std/option.md:6
 msgid "The `Option<T>` enum has two variants:"
-msgstr ""
+msgstr "`Option<T>` 枚举有两个变体："
 
 #: src/std/option.md:8
 msgid "`None`, to indicate failure or lack of value, and"
-msgstr ""
+msgstr "`None`，表示失败或缺少值，以及"
 
 #: src/std/option.md:9
 msgid "`Some(value)`, a tuple struct that wraps a `value` with type `T`."
-msgstr ""
+msgstr "`Some(value)`，一个包装了类型为 `T` 的 `value` 的元组结构体。"
 
 #: src/std/option.md:12
 msgid "// An integer division that doesn't `panic!`\n"
-msgstr ""
+msgstr "// 一个不会 `panic!` 的整数除法\n"
 
 #: src/std/option.md:15
 msgid "// Failure is represented as the `None` variant\n"
-msgstr ""
+msgstr "// 失败表示为 `None` 变体\n"
 
 #: src/std/option.md:18
 msgid "// Result is wrapped in a `Some` variant\n"
-msgstr ""
+msgstr "// 结果被包装在 `Some` 变体中\n"
 
 #: src/std/option.md:22
 msgid "// This function handles a division that may not succeed\n"
-msgstr ""
+msgstr "// 这个函数处理可能不成功的除法\n"
 
 #: src/std/option.md:25
 msgid "// `Option` values can be pattern matched, just like other enums\n"
-msgstr ""
+msgstr "// `Option` 值可以被模式匹配，就像其他枚举一样\n"
 
 #: src/std/option.md:27
 msgid "\"{} / {} failed!\""
-msgstr ""
+msgstr "\"{} / {} 失败！\""
 
 #: src/std/option.md:29
 msgid "\"{} / {} = {}\""
-msgstr ""
+msgstr "\"{} / {} = {}\""
 
 #: src/std/option.md:38
 msgid "// Binding `None` to a variable needs to be type annotated\n"
-msgstr ""
+msgstr "// 将 `None` 绑定到变量需要类型标注\n"
 
 #: src/std/option.md:44
 msgid "// Unwrapping a `Some` variant will extract the value wrapped.\n"
-msgstr ""
+msgstr "// 解包 `Some` 变体将提取被包装的值。\n"
 
 #: src/std/option.md:45 src/std/option.md:48
 msgid "\"{:?} unwraps to {:?}\""
-msgstr ""
+msgstr "\"{:?} 解包为 {:?}\""
 
 #: src/std/option.md:47
 msgid "// Unwrapping a `None` variant will `panic!`\n"
-msgstr ""
+msgstr "// 解包 `None` 变体将会 `panic!`\n"
 
 #: src/std/result.md:3
 msgid ""
@@ -13071,48 +13073,53 @@ msgid ""
 "However, sometimes it is important to express _why_ an operation failed. To "
 "do this we have the `Result` enum."
 msgstr ""
+"我们已经看到 `Option` 枚举可以用作可能失败的函数的返回值，其中 `None` 可以用来表示失败。"
+"然而，有时表达操作**为什么**失败很重要。为此，我们有 `Result` 枚举。"
 
 #: src/std/result.md:8
 msgid "The `Result<T, E>` enum has two variants:"
-msgstr ""
+msgstr "`Result<T, E>` 枚举有两个变体："
 
 #: src/std/result.md:10
 msgid ""
 "`Ok(value)` which indicates that the operation succeeded, and wraps the "
 "`value` returned by the operation. (`value` has type `T`)"
 msgstr ""
+"`Ok(value)` 表示操作成功，并包装了操作返回的 `value`。（`value` 的类型为 `T`）"
 
 #: src/std/result.md:12
 msgid ""
 "`Err(why)`, which indicates that the operation failed, and wraps `why`, which "
 "(hopefully) explains the cause of the failure. (`why` has type `E`)"
 msgstr ""
+"`Err(why)`，表示操作失败，并包装了 `why`，它解释了失败的原因（但愿如此）。（`why` 的类型为 `E`）"
 
 #: src/std/result.md:17
 msgid "// Mathematical \"errors\" we want to catch\n"
-msgstr ""
+msgstr "// 我们想要捕获的数学"错误"\n"
 
 #: src/std/result.md:29
 msgid ""
 "// This operation would `fail`, instead let's return the reason of\n"
 "            // the failure wrapped in `Err`\n"
 msgstr ""
+"// 这个操作会"失败"，那么（与其让程序崩溃）不如让我们把失败原因包装在 `Err` 中返回\n"
 
 #: src/std/result.md:33
 msgid "// This operation is valid, return the result wrapped in `Ok`\n"
-msgstr ""
+msgstr "// 这个操作是有效的，返回包装在 `Ok` 中的结果\n"
 
 #: src/std/result.md:54
 msgid "// `op(x, y)` === `sqrt(ln(x / y))`\n"
-msgstr ""
+msgstr "// `op(x, y)` === `sqrt(ln(x / y))`\n"
 
 #: src/std/result.md:57
 msgid "// This is a three level match pyramid!\n"
-msgstr ""
+msgstr "// 这是一个三层的匹配金字塔！\n"
 
 #: src/std/result.md:71
 msgid "// Will this fail?\n"
-msgstr ""
+msgstr "// 这会失败吗？\n"
 
 #: src/std/result/question_mark.md:3
 msgid ""
@@ -13122,36 +13129,42 @@ msgid ""
 "where the `Err(err)` branch expands to an early `return Err(From::"
 "from(err))`, and the `Ok(ok)` branch expands to an `ok` expression."
 msgstr ""
+"嵌套使用 match 处理 result 可能会变得相当混乱；幸运的是，`?` 运算符可以让代码变得整洁。"
+"`?` 用在返回 `Result` 的表达式的末尾，相当于一个 match 表达式，"
+"其中 `Err(err)` 分支展开为提前返回的 `return Err(From::from(err))`，"
+"而 `Ok(ok)` 分支展开为 `ok` 表达式。"
 
 #: src/std/result/question_mark.md:44
 msgid "// Intermediate function\n"
-msgstr ""
+msgstr "// 中间函数\n"
 
 #: src/std/result/question_mark.md:46
 msgid "// if `div` \"fails\", then `DivisionByZero` will be `return`ed\n"
-msgstr ""
+msgstr "// 如果 `div` "失败"，那么 `DivisionByZero` 将被 `return`\n"
 
 #: src/std/result/question_mark.md:49
 msgid "// if `ln` \"fails\", then `NonPositiveLogarithm` will be `return`ed\n"
-msgstr ""
+msgstr "// 如果 `ln` "失败"，那么 `NonPositiveLogarithm` 将被 `return`\n"
 
 #: src/std/result/question_mark.md:59
 msgid "\"logarithm of non-positive number\""
-msgstr ""
+msgstr "\"非正数的对数\""
 
 #: src/std/result/question_mark.md:61 src/std/panic.md:15
 msgid "\"division by zero\""
-msgstr ""
+msgstr "\"除以零\""
 
 #: src/std/result/question_mark.md:63
 msgid "\"square root of negative number\""
-msgstr ""
+msgstr "\"负数的平方根\""
 
 #: src/std/result/question_mark.md:75
 msgid ""
 "Be sure to check the [documentation](https://doc.rust-lang.org/std/result/"
 "index.html), as there are many methods to map/compose `Result`."
 msgstr ""
+"记得查看[文档](https://doc.rust-lang.org/std/result/index.html)，"
+"因为其中有许多方法可以映射/组合 `Result`。"
 
 #: src/std/panic.md:3
 msgid ""
@@ -13159,44 +13172,47 @@ msgid ""
 "stack. While unwinding, the runtime will take care of freeing all the "
 "resources _owned_ by the thread by calling the destructor of all its objects."
 msgstr ""
+"`panic!` 宏可以用来产生一个 panic 并开始展开（unwind）栈。在展开过程中，"
+"运行时将通过调用所有对象的析构函数来释放线程**拥有**的所有资源。"
 
 #: src/std/panic.md:7
 msgid ""
 "Since we are dealing with programs with only one thread, `panic!` will cause "
 "the program to report the panic message and exit."
 msgstr ""
+"由于我们处理的是只有一个线程的程序，`panic!` 将导致程序报告 panic 消息并退出。"
 
 #: src/std/panic.md:11
 msgid "// Re-implementation of integer division (/)\n"
-msgstr ""
+msgstr "// 重新实现整数除法 (/)\n"
 
 #: src/std/panic.md:14
 msgid "// Division by zero triggers a panic\n"
-msgstr ""
+msgstr "// 除以零触发 panic\n"
 
 #: src/std/panic.md:20
 msgid "// The `main` task\n"
-msgstr ""
+msgstr "// `main` 任务\n"
 
 #: src/std/panic.md:23
 msgid "// Heap allocated integer\n"
-msgstr ""
+msgstr "// 堆分配的整数\n"
 
 #: src/std/panic.md:26
 msgid "// This operation will trigger a task failure\n"
-msgstr ""
+msgstr "// 这个操作将触发任务失败\n"
 
 #: src/std/panic.md:29
 msgid "\"This point won't be reached!\""
-msgstr ""
+msgstr "\"这个点不会被达到！\""
 
 #: src/std/panic.md:31
 msgid "// `_x` should get destroyed at this point\n"
-msgstr ""
+msgstr "// `_x` 应该在这一点被销毁\n"
 
 #: src/std/panic.md:35
 msgid "Let's check that `panic!` doesn't leak memory."
-msgstr ""
+msgstr "让我们检查 `panic!` 是否不会泄漏内存。"
 
 #: src/std/hash.md:3
 msgid ""
@@ -13204,6 +13220,8 @@ msgid ""
 "key. `HashMap` keys can be booleans, integers, strings, or any other type "
 "that implements the `Eq` and `Hash` traits. More on this in the next section."
 msgstr ""
+"动态数组（Vector）通过整数索引存储值，而 `HashMap` 通过键存储值。`HashMap` 的键可以是布尔值、"
+"整数、字符串，或任何其他实现了 `Eq` 和 `Hash` trait 的类型。下一节将详细介绍这一点。"
 
 #: src/std/hash.md:8
 msgid ""
@@ -13213,94 +13231,105 @@ msgid ""
 "`HashMap::new()` to get a HashMap with a default initial capacity "
 "(recommended)."
 msgstr ""
+"与动态数组类似，`HashMap` 也是可增长的，但 HashMap 在有多余空间时也可以自行收缩。"
+"你可以使用 `HashMap::with_capacity(uint)` 创建一个具有特定初始容量的 HashMap，"
+"或者使用 `HashMap::new()` 来获得一个具有默认初始容量的 HashMap（推荐）。"
 
 #: src/std/hash.md:19 src/std/hash.md:30
 msgid "\"798-1364\""
-msgstr ""
+msgstr "\"798-1364\""
 
 #: src/std/hash.md:19
 msgid ""
 "\"We're sorry, the call cannot be completed as dialed. \n"
 "            Please hang up and try again.\""
 msgstr ""
+"\"很抱歉，无法完成您拨打的电话。\n"
+"            请挂机后重试。\""
 
 #: src/std/hash.md:21 src/std/hash.md:31
 msgid "\"645-7689\""
-msgstr ""
+msgstr "\"645-7689\""
 
 #: src/std/hash.md:21
 msgid ""
 "\"Hello, this is Mr. Awesome's Pizza. My name is Fred.\n"
 "            What can I get for you today?\""
 msgstr ""
+"\"你好，这里是 Awesome 先生的披萨店。我是 Fred。\n"
+"            今天您想点些什么？\""
 
 #: src/std/hash.md:23
 msgid "\"Hi! Who is this again?\""
-msgstr ""
+msgstr "\"嗨！请问是哪位？\""
 
 #: src/std/hash.md:30 src/std/hash.md:36 src/std/hash.md:43
 msgid "\"Daniel\""
-msgstr ""
+msgstr "\"Daniel\""
 
 #: src/std/hash.md:31 src/std/hash.md:45 src/std/hash.md:50
 msgid "\"Ashley\""
-msgstr ""
+msgstr "\"Ashley\""
 
 #: src/std/hash.md:32
 msgid "\"Katie\""
-msgstr ""
+msgstr "\"Katie\""
 
 #: src/std/hash.md:32
 msgid "\"435-8291\""
-msgstr ""
+msgstr "\"435-8291\""
 
 #: src/std/hash.md:33
 msgid "\"Robert\""
-msgstr ""
+msgstr "\"Robert\""
 
 #: src/std/hash.md:33
 msgid "\"956-1745\""
-msgstr ""
+msgstr "\"956-1745\""
 
 #: src/std/hash.md:35
 msgid "// Takes a reference and returns Option<&V>\n"
-msgstr ""
+msgstr "// 接受一个引用并返回 Option<&V>\n"
 
 #: src/std/hash.md:37
 msgid "\"Calling Daniel: {}\""
-msgstr ""
+msgstr "\"正在呼叫 Daniel：{}\""
 
 #: src/std/hash.md:38
 msgid "\"Don't have Daniel's number.\""
-msgstr ""
+msgstr "\"没有 Daniel 的号码。\""
 
 #: src/std/hash.md:41
 msgid ""
 "// `HashMap::insert()` returns `None`\n"
 "    // if the inserted value is new, `Some(value)` otherwise\n"
 msgstr ""
+"// `HashMap::insert()` 在插入新值时返回 `None`\n"
+"    // 否则返回 `Some(value)`\n"
 
 #: src/std/hash.md:43
 msgid "\"164-6743\""
-msgstr ""
+msgstr "\"164-6743\""
 
 #: src/std/hash.md:46
 msgid "\"Calling Ashley: {}\""
-msgstr ""
+msgstr "\"正在呼叫 Ashley：{}\""
 
 #: src/std/hash.md:47
 msgid "\"Don't have Ashley's number.\""
-msgstr ""
+msgstr "\"没有 Ashley 的号码。\""
 
 #: src/std/hash.md:52
 msgid ""
 "// `HashMap::iter()` returns an iterator that yields \n"
 "    // (&'a key, &'a value) pairs in arbitrary order.\n"
 msgstr ""
+"// `HashMap::iter()` 返回一个迭代器，该迭代器以任意顺序产生\n"
+"    // (&'a key, &'a value) 对。\n"
 
 #: src/std/hash.md:55
 msgid "\"Calling {}: {}\""
-msgstr ""
+msgstr "\"正在呼叫 {}：{}\""
 
 #: src/std/hash.md:60
 msgid ""
@@ -13308,26 +13337,31 @@ msgid ""
 "tables) work, have a look at [Hash Table Wikipedia](https://en.wikipedia.org/"
 "wiki/Hash_table)"
 msgstr ""
+"要了解更多关于哈希和哈希映射（有时称为哈希表）的工作原理，可以查看 "
+"[哈希表维基百科](https://en.wikipedia.org/wiki/Hash_table)"
 
 #: src/std/hash/alt_key_types.md:3
 msgid ""
 "Any type that implements the `Eq` and `Hash` traits can be a key in "
 "`HashMap`. This includes:"
 msgstr ""
+"任何实现了 `Eq` 和 `Hash` trait 的类型都可以作为 `HashMap` 的键。这包括："
 
 #: src/std/hash/alt_key_types.md:6
 msgid "`bool` (though not very useful since there are only two possible keys)"
-msgstr ""
+msgstr "`bool`（虽然不是很有用，因为只有两个可能的键）"
 
 #: src/std/hash/alt_key_types.md:7
 msgid "`int`, `uint`, and all variations thereof"
-msgstr ""
+msgstr "`int`、`uint` 及其所有变体"
 
 #: src/std/hash/alt_key_types.md:8
 msgid ""
 "`String` and `&str` (protip: you can have a `HashMap` keyed by `String` and "
 "call `.get()` with an `&str`)"
 msgstr ""
+"`String` 和 `&str`（专业提示：你可以使用 `String` 作为 `HashMap` 的键，"
+"并用 `&str` 调用 `.get()`）"
 
 #: src/std/hash/alt_key_types.md:11
 msgid ""
@@ -13336,6 +13370,9 @@ msgid ""
 "Floating_point#Accuracy_problems) would make using them as hashmap keys "
 "horribly error-prone."
 msgstr ""
+"注意，`f32` 和 `f64` **没有**实现 `Hash`，这很大程度上是由于"
+"[浮点精度误差](https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems)，"
+"因此使用它们作为哈希映射键容易出错。"
 
 #: src/std/hash/alt_key_types.md:15
 msgid ""
@@ -13343,12 +13380,15 @@ msgid ""
 "respectively implements `Eq` and `Hash`. For example, `Vec<T>` will implement "
 "`Hash` if `T` implements `Hash`."
 msgstr ""
+"如果集合类中包含的类型分别实现了 `Eq` 和 `Hash`，那么这些集合类也就实现了 `Eq` 和 `Hash`。"
+"例如，如果 `T` 实现了 `Hash`，那么 `Vec<T>` 也实现了 `Hash`。"
 
 #: src/std/hash/alt_key_types.md:19
 msgid ""
 "You can easily implement `Eq` and `Hash` for a custom type with just one "
 "line: `#[derive(PartialEq, Eq, Hash)]`"
 msgstr ""
+"你可以通过一行代码轻松地为自定义类型实现 `Eq` 和 `Hash`：`#[derive(PartialEq, Eq, Hash)]`"
 
 #: src/std/hash/alt_key_types.md:22
 msgid ""
@@ -13356,77 +13396,82 @@ msgid ""
 "can implement `Eq` and/or `Hash` yourself. This guide will not cover the "
 "specifics of implementing `Hash`."
 msgstr ""
+"编译器会完成剩下的工作。如果你想对细节有更多控制，可以自己实现 `Eq` 和/或 `Hash`。"
+"本指南不会涉及实现 `Hash` 的具体细节。"
 
 #: src/std/hash/alt_key_types.md:26
 msgid ""
 "To play around with using a `struct` in `HashMap`, let's try making a very "
 "simple user logon system:"
 msgstr ""
+"为了尝试在 `HashMap` 中使用 `struct`，让我们试着制作一个非常简单的用户登录系统："
 
 #: src/std/hash/alt_key_types.md:31
 msgid "// Eq requires that you derive PartialEq on the type.\n"
-msgstr ""
+msgstr "// Eq 要求你在类型上派生 PartialEq。\n"
 
 #: src/std/hash/alt_key_types.md:48
 msgid "\"Username: {}\""
-msgstr ""
+msgstr "\"用户名：{}\""
 
 #: src/std/hash/alt_key_types.md:49
 msgid "\"Password: {}\""
-msgstr ""
+msgstr "\"密码：{}\""
 
 #: src/std/hash/alt_key_types.md:50
 msgid "\"Attempting logon...\""
-msgstr ""
+msgstr "\"尝试登录...\""
 
 #: src/std/hash/alt_key_types.md:59
 msgid "\"Successful logon!\""
-msgstr ""
+msgstr "\"登录成功！\""
 
 #: src/std/hash/alt_key_types.md:60
 msgid "\"Name: {}\""
-msgstr ""
+msgstr "\"姓名：{}\""
 
 #: src/std/hash/alt_key_types.md:61
 msgid "\"Email: {}\""
-msgstr ""
+msgstr "\"邮箱：{}\""
 
 #: src/std/hash/alt_key_types.md:63
 msgid "\"Login failed!\""
-msgstr ""
+msgstr "\"登录失败！\""
 
 #: src/std/hash/alt_key_types.md:71 src/std/hash/alt_key_types.md:82
 #: src/std/hash/alt_key_types.md:84
 msgid "\"j.everyman\""
-msgstr ""
+msgstr "\"j.everyman\""
 
 #: src/std/hash/alt_key_types.md:72 src/std/hash/alt_key_types.md:84
 msgid "\"password123\""
-msgstr ""
+msgstr "\"password123\""
 
 #: src/std/hash/alt_key_types.md:76
 msgid "\"John Everyman\""
-msgstr ""
+msgstr "\"John Everyman\""
 
 #: src/std/hash/alt_key_types.md:77
 msgid "\"j.everyman@email.com\""
-msgstr ""
+msgstr "\"j.everyman@email.com\""
 
 #: src/std/hash/alt_key_types.md:82
 msgid "\"psasword123\""
-msgstr ""
+msgstr "\"psasword123\""
 
 #: src/std/hash/hashset.md:3
 msgid ""
 "Consider a `HashSet` as a `HashMap` where we just care about the keys "
 "( `HashSet<T>` is, in actuality, just a wrapper around `HashMap<T, ()>`)."
 msgstr ""
+"可以将 `HashSet` 视为一个只关心键的 `HashMap`（实际上，`HashSet<T>` 只是 `HashMap<T, ()>` 的一个封装）。"
 
 #: src/std/hash/hashset.md:6
 msgid ""
 "\"What's the point of that?\" you ask. \"I could just store the keys in a "
 "`Vec`.\""
 msgstr ""
+"你可能会问："这有什么意义？我可以直接把键存储在 `Vec` 中。""
 
 #: src/std/hash/hashset.md:8
 msgid ""
@@ -13435,6 +13480,7 @@ msgid ""
 "just one implementation. (see also: [`BTreeSet`](https://doc.rust-lang.org/"
 "std/collections/struct.BTreeSet.html))"
 msgstr ""
+"`HashSet` 的独特之处在于它保证不会有重复的元素。这是任何集合类型都应该满足的契约。`HashSet` 只是其中一种实现。（另见：[`BTreeSet`](https://doc.rust-lang.org/std/collections/struct.BTreeSet.html)）"
 
 #: src/std/hash/hashset.md:13
 msgid ""
@@ -13442,56 +13488,60 @@ msgid ""
 "value is equal to the existing and they both have the same hash), then the "
 "new value will replace the old."
 msgstr ""
+"如果你插入一个已经存在于 `HashSet` 中的值（即新值等于现有值，且它们的哈希值相同），那么新值将替换旧值。"
 
 #: src/std/hash/hashset.md:17
 msgid ""
 "This is great for when you never want more than one of something, or when you "
 "want to know if you've already got something."
 msgstr ""
+"当你不希望某样东西出现多次，或者想知道是否已经拥有某样东西时，这非常有用。"
 
 #: src/std/hash/hashset.md:20
 msgid "But sets can do more than that."
-msgstr ""
+msgstr "但是集合的功能不仅限于此。"
 
 #: src/std/hash/hashset.md:22
 msgid ""
 "Sets have 4 primary operations (all of the following calls return an "
 "iterator):"
 msgstr ""
+"集合有 4 种主要操作（以下所有调用都返回一个迭代器）："
 
 #: src/std/hash/hashset.md:24
 msgid "`union`: get all the unique elements in both sets."
-msgstr ""
+msgstr "`union`：获取两个集合中的所有唯一元素。"
 
 #: src/std/hash/hashset.md:26
 msgid ""
 "`difference`: get all the elements that are in the first set but not the "
 "second."
-msgstr ""
+msgstr "`difference`：获取存在于第一个集合但不在第二个集合中的所有元素。"
 
 #: src/std/hash/hashset.md:28
 msgid "`intersection`: get all the elements that are only in _both_ sets."
-msgstr ""
+msgstr "`intersection`：获取**同时**存在于两个集合中的所有元素。"
 
 #: src/std/hash/hashset.md:30
 msgid ""
 "`symmetric_difference`: get all the elements that are in one set or the "
 "other, but _not_ both."
-msgstr ""
+msgstr "`symmetric_difference`：获取存在于其中一个集合中，但**不**同时存在于两个集合中的所有元素。"
 
 #: src/std/hash/hashset.md:33
 msgid "Try all of these in the following example:"
-msgstr ""
+msgstr "在下面的例子中尝试所有这些操作："
 
 #: src/std/hash/hashset.md:45
 msgid ""
 "// `HashSet::insert()` returns false if\n"
 "    // there was a value already present.\n"
 msgstr ""
+"// 如果值已经存在，`HashSet::insert()` 返回 false。\n"
 
 #: src/std/hash/hashset.md:47
 msgid "\"Value 4 is already in set B!\""
-msgstr ""
+msgstr "\"值 4 已经在集合 B 中！\""
 
 #: src/std/hash/hashset.md:52
 msgid ""
@@ -13499,52 +13549,56 @@ msgid ""
 "    // then the collection implements `Debug`.\n"
 "    // It usually prints its elements in the format `[elem1, elem2, ...]`\n"
 msgstr ""
+"// 如果集合的元素类型实现了 `Debug`，\n"
+"    // 那么该集合也实现了 `Debug`。\n"
+"    // 它通常以 `[elem1, elem2, ...]` 的格式打印其元素\n"
 
 #: src/std/hash/hashset.md:55
 msgid "\"A: {:?}\""
-msgstr ""
+msgstr "\"A: {:?}\""
 
 #: src/std/hash/hashset.md:56
 msgid "\"B: {:?}\""
-msgstr ""
+msgstr "\"B: {:?}\""
 
 #: src/std/hash/hashset.md:58
 msgid "// Print [1, 2, 3, 4, 5] in arbitrary order\n"
-msgstr ""
+msgstr "// 以任意顺序打印 [1, 2, 3, 4, 5]\n"
 
 #: src/std/hash/hashset.md:59
 msgid "\"Union: {:?}\""
-msgstr ""
+msgstr "\"并集：{:?}\""
 
 #: src/std/hash/hashset.md:61
 msgid "// This should print [1]\n"
-msgstr ""
+msgstr "// 这应该打印 [1]\n"
 
 #: src/std/hash/hashset.md:62
 msgid "\"Difference: {:?}\""
-msgstr ""
+msgstr "\"差集：{:?}\""
 
 #: src/std/hash/hashset.md:64
 msgid "// Print [2, 3, 4] in arbitrary order.\n"
-msgstr ""
+msgstr "// 以任意顺序打印 [2, 3, 4]。\n"
 
 #: src/std/hash/hashset.md:65
 msgid "\"Intersection: {:?}\""
-msgstr ""
+msgstr "\"交集：{:?}\""
 
 #: src/std/hash/hashset.md:67
 msgid "// Print [1, 5]\n"
-msgstr ""
+msgstr "// 打印 [1, 5]\n"
 
 #: src/std/hash/hashset.md:68
 msgid "\"Symmetric Difference: {:?}\""
-msgstr ""
+msgstr "\"对称差：{:?}\""
 
 #: src/std/hash/hashset.md:73
 msgid ""
 "(Examples are adapted from the [documentation.](https://doc.rust-lang.org/std/"
 "collections/struct.HashSet.html#method.difference))"
 msgstr ""
+"（示例改编自[文档。](https://doc.rust-lang.org/std/collections/struct.HashSet.html#method.difference)）"
 
 #: src/std/rc.md:3
 msgid ""
@@ -13552,6 +13606,7 @@ msgid ""
 "keeps track of the number of the references which means the number of owners "
 "of the value wrapped inside an `Rc`."
 msgstr ""
+"当需要多重所有权时，可以使用 `Rc`（引用计数）。`Rc` 会跟踪引用的数量，也就是包裹在 `Rc` 内部的值的所有者数量。"
 
 #: src/std/rc.md:5
 msgid ""
@@ -13560,60 +13615,62 @@ msgid ""
 "`Rc`'s reference count becomes zero (which means there are no remaining "
 "owners), both the `Rc` and the value are all dropped."
 msgstr ""
+"每当克隆一个 `Rc` 时，引用计数就会增加 1，每当一个克隆的 `Rc` 离开作用域时，引用计数就会减少 1。当 `Rc` 的引用计数变为零（这意味着没有剩余的所有者）时，`Rc` 和其中的值都会被丢弃。"
 
 #: src/std/rc.md:7
 msgid ""
 "Cloning an `Rc` never performs a deep copy. Cloning creates just another "
 "pointer to the wrapped value, and increments the count."
 msgstr ""
+"克隆 `Rc` 从不执行深拷贝。克隆只是创建另一个指向包裹值的指针，并增加计数。"
 
 #: src/std/rc.md:13
 msgid "\"Rc examples\""
-msgstr ""
+msgstr "\"Rc 示例\""
 
 #: src/std/rc.md:15
 msgid "\"--- rc_a is created ---\""
-msgstr ""
+msgstr "\"--- rc_a 被创建 ---\""
 
 #: src/std/rc.md:18 src/std/rc.md:25 src/std/rc.md:37
 msgid "\"Reference Count of rc_a: {}\""
-msgstr ""
+msgstr "\"rc_a 的引用计数：{}\""
 
 #: src/std/rc.md:21
 msgid "\"--- rc_a is cloned to rc_b ---\""
-msgstr ""
+msgstr "\"--- rc_a 被克隆到 rc_b ---\""
 
 #: src/std/rc.md:24
 msgid "\"Reference Count of rc_b: {}\""
-msgstr ""
+msgstr "\"rc_b 的引用计数：{}\""
 
 #: src/std/rc.md:27
 msgid "// Two `Rc`s are equal if their inner values are equal\n"
-msgstr ""
+msgstr "// 如果两个 `Rc` 的内部值相等，则它们相等\n"
 
 #: src/std/rc.md:28
 msgid "\"rc_a and rc_b are equal: {}\""
-msgstr ""
+msgstr "\"rc_a 和 rc_b 相等：{}\""
 
 #: src/std/rc.md:30
 msgid "// We can use methods of a value directly\n"
-msgstr ""
+msgstr "// 我们可以直接使用值的方法\n"
 
 #: src/std/rc.md:31
 msgid "\"Length of the value inside rc_a: {}\""
-msgstr ""
+msgstr "\"rc_a 内部值的长度：{}\""
 
 #: src/std/rc.md:32
 msgid "\"Value of rc_b: {}\""
-msgstr ""
+msgstr "\"rc_b 的值：{}\""
 
 #: src/std/rc.md:34
 msgid "\"--- rc_b is dropped out of scope ---\""
-msgstr ""
+msgstr "\"--- rc_b 离开作用域 ---\""
 
 #: src/std/rc.md:39
 msgid "\"--- rc_a is dropped out of scope ---\""
-msgstr ""
+msgstr "\"--- rc_a 离开作用域 ---\""
 
 #: src/std/rc.md:42
 msgid ""
@@ -13622,16 +13679,22 @@ msgid ""
 "    // println!(\"rc_examples: {}\", rc_examples);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！`rc_examples` 已经被移动到 `rc_a` 中\n"
+"    // 当 `rc_a` 被丢弃时，`rc_examples` 也会一起被丢弃\n"
+"    // println!(\"rc_examples: {}\", rc_examples);\n"
+"    // TODO ^ 尝试取消注释这一行\n"
 
 #: src/std/rc.md:51
 msgid ""
 "[std::rc](https://doc.rust-lang.org/std/rc/index.html) and [std::sync::arc]"
 "(https://doc.rust-lang.org/std/sync/struct.Arc.html)."
 msgstr ""
+"[std::rc](https://doc.rust-lang.org/std/rc/index.html) 和 [std::sync::arc]"
+"(https://doc.rust-lang.org/std/sync/struct.Arc.html)。"
 
 #: src/std/arc.md:1
 msgid "Arc"
-msgstr ""
+msgstr "Arc"
 
 #: src/std/arc.md:3
 msgid ""
@@ -13642,75 +13705,82 @@ msgid ""
 "when the last reference pointer to a value is out of scope, the variable is "
 "dropped."
 msgstr ""
+"当需要在线程间共享所有权时，可以使用 `Arc`（原子引用计数）。这个结构体通过 `Clone` 实现可以为内存堆中值的位置创建一个引用指针，同时增加引用计数。由于它在线程间共享所有权，当最后一个指向某个值的引用指针离开作用域时，该变量就会被丢弃。"
 
 #: src/std/arc.md:15
 msgid "// This variable declaration is where its value is specified.\n"
-msgstr ""
+msgstr "// 这个变量声明指定了它的值。\n"
 
 #: src/std/arc.md:16
 msgid "\"the same apple\""
-msgstr ""
+msgstr "\"同一个苹果\""
 
 #: src/std/arc.md:19
 msgid ""
 "// Here there is no value specification as it is a pointer to a\n"
 "        // reference in the memory heap.\n"
 msgstr ""
+"// 这里没有值的指定，因为它是指向内存堆中引用的指针。\n"
+"        // \n"
 
 #: src/std/arc.md:24
 msgid ""
 "// As Arc was used, threads can be spawned using the value allocated\n"
 "            // in the Arc variable pointer's location.\n"
 msgstr ""
+"// 由于使用了 Arc，可以使用 Arc 变量指针位置中分配的值来生成线程。\n"
+"            // \n"
 
 #: src/std/arc.md:30
 msgid "// Make sure all Arc instances are printed from spawned threads.\n"
-msgstr ""
+msgstr "// 确保所有 Arc 实例都从生成的线程中打印出来。\n"
 
 #: src/std_misc.md:3
 msgid ""
 "Many other types are provided by the std library to support things such as:"
-msgstr ""
+msgstr "标准库提供了许多其他类型来支持诸如以下功能："
 
 #: src/std_misc.md:10
 msgid "These expand beyond what the [primitives](primitives.md) provide."
-msgstr ""
+msgstr "这些扩展了[原生类型](primitives.md)所提供的功能。"
 
 #: src/std_misc/threads.md:3
 msgid ""
 "Rust provides a mechanism for spawning native OS threads via the `spawn` "
 "function, the argument of this function is a moving closure."
 msgstr ""
+"Rust 通过 `spawn` 函数提供了一种生成本地操作系统线程的机制，这个函数的参数是一个移动（moving）闭包。"
 
 #: src/std_misc/threads.md:10 src/std_misc/threads/testcase_mapreduce.md:28
 msgid "// This is the `main` thread\n"
-msgstr ""
+msgstr "// 这是 `main` 线程\n"
 
 #: src/std_misc/threads.md:13
 msgid "// Make a vector to hold the children which are spawned.\n"
-msgstr ""
+msgstr "// 创建一个动态数组来保存生成的子线程。\n"
 
 #: src/std_misc/threads.md:17
 msgid "// Spin up another thread\n"
-msgstr ""
+msgstr "// 启动另一个线程\n"
 
 #: src/std_misc/threads.md:19
 msgid "\"this is thread number {}\""
-msgstr ""
+msgstr "\"这是线程 {}\""
 
 #: src/std_misc/threads.md:24
 msgid "// Wait for the thread to finish. Returns a result.\n"
-msgstr ""
+msgstr "// 等待线程结束。返回一个结果。\n"
 
 #: src/std_misc/threads.md:30
 msgid "These threads will be scheduled by the OS."
-msgstr ""
+msgstr "这些线程将由操作系统调度。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:3
 msgid ""
 "Rust makes it very easy to parallelise data processing, without many of the "
 "headaches traditionally associated with such an attempt."
 msgstr ""
+"Rust 使得并行化数据处理变得非常容易，避免了传统上与此类尝试相关的许多麻烦。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:5
 msgid ""
@@ -13718,6 +13788,7 @@ msgid ""
 "These, combined with Rust's concept of Ownership and aliasing rules, "
 "automatically prevent data races."
 msgstr ""
+"标准库提供了现成的优秀线程原语。这些原语结合 Rust 的所有权概念和别名规则，自动防止了数据竞争。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:9
 msgid ""
@@ -13726,6 +13797,7 @@ msgid ""
 "threads. (Where synchronisation is needed, there are synchronisation "
 "primitives like `Mutex`es or `Channel`s.)"
 msgstr ""
+"别名规则（一个可写引用或多个可读引用）自动防止你操作对其他线程可见的状态。（在需要同步的地方，有像 `Mutex` 或 `Channel` 这样的同步原语。）"
 
 #: src/std_misc/threads/testcase_mapreduce.md:14
 msgid ""
@@ -13734,6 +13806,7 @@ msgid ""
 "threads. Each thread will sum its tiny block of digits, and subsequently we "
 "will sum the intermediate sums produced by each thread."
 msgstr ""
+"在这个例子中，我们将计算一个数字块中所有数字的总和。我们将通过将块的不同部分分配给不同的线程来完成这个任务。每个线程将计算其小块数字的总和，随后我们将汇总每个线程产生的中间总和。"
 
 #: src/std_misc/threads/testcase_mapreduce.md:19
 msgid ""
@@ -13745,6 +13818,7 @@ msgid ""
 "data between threads, you can use a smart pointer like `Arc` to keep the data "
 "alive and avoid non-`static` lifetimes.)"
 msgstr ""
+"注意，尽管我们在线程边界之间传递引用，Rust 理解我们只是传递只读引用，因此不会发生不安全或数据竞争的情况。此外，因为我们传递的引用具有 `'static` 生命周期，Rust 理解我们的数据在这些线程仍在运行时不会被销毁。（当你需要在线程之间共享非 `static` 数据时，你可以使用像 `Arc` 这样的智能指针来保持数据的存活并避免非 `static` 生命周期。）"
 
 #: src/std_misc/threads/testcase_mapreduce.md:32
 msgid ""
@@ -13756,6 +13830,11 @@ msgid ""
 "    //\n"
 "    // TODO: see what happens to the output if you insert spaces!\n"
 msgstr ""
+"// 这是我们要处理的数据。\n"
+"    // 我们将通过一个线程化的 map-reduce 算法计算所有数字的总和。\n"
+"    // 每个由空格分隔的块将在不同的线程中处理。\n"
+"    //\n"
+"    // TODO：看看如果你插入空格会发生什么！\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:37
 msgid ""
@@ -13768,10 +13847,18 @@ msgid ""
 "69920216438980873548808413720956532\n"
 "16278424637452589860345374828574668\""
 msgstr ""
+"\"86967897737416471853297327050364959\n"
+"11861322575564723963297542624962850\n"
+"70856234701860851907960690014725639\n"
+"38397966707106094172783238747669219\n"
+"52380795257888236525459303330302837\n"
+"58495327135744041048897885734297812\n"
+"69920216438980873548808413720956532\n"
+"16278424637452589860345374828574668\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:46
 msgid "// Make a vector to hold the child-threads which we will spawn.\n"
-msgstr ""
+msgstr "// 创建一个动态数组来保存我们将要生成的子线程。\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:49
 msgid ""
@@ -13781,12 +13868,19 @@ msgid ""
 "     * Divide our data into segments, and apply initial processing\n"
 "     ************************************************************************/"
 msgstr ""
+"/*************************************************************************\n"
+"     * \"Map\" 阶段\n"
+"     *\n"
+"     * 将我们的数据分成段，并进行初始处理\n"
+"     ************************************************************************/"
 
 #: src/std_misc/threads/testcase_mapreduce.md:55
 msgid ""
 "// split our data into segments for individual calculation\n"
 "    // each chunk will be a reference (&str) into the actual data\n"
 msgstr ""
+"// 将我们的数据分成段以进行单独计算\n"
+"    // 每个块将是对实际数据的引用 (&str)\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:59
 msgid ""
@@ -13797,10 +13891,15 @@ msgid ""
 "a\n"
 "    // \"destructuring assignment\"\n"
 msgstr ""
+"// 遍历数据段。\n"
+"    // .enumerate() 为迭代的每个元素添加当前循环索引\n"
+"    // 结果元组 \"(index, element)\" 然后立即\n"
+"    // 通过 \"解构赋值\" 被 \"解构\" 为两个变量，\"i\" 和 \"data_segment\"\n"
+"    // \n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:65
 msgid "\"data segment {} is \\\"{}\\\"\""
-msgstr ""
+msgstr "\"数据段 {} 是 \\\"{}\\\"\""
 
 #: src/std_misc/threads/testcase_mapreduce.md:67
 msgid ""
@@ -13819,6 +13918,19 @@ msgid ""
 "        //\n"
 "        // TODO: try removing the 'move' and see what happens\n"
 msgstr ""
+"// 在单独的线程中处理每个数据段\n"
+"        //\n"
+"        // spawn() 返回新线程的句柄，\n"
+"        // 我们必须保留它以访问返回值\n"
+"        //\n"
+"        // 'move || -> u32' 是一个闭包的语法，它：\n"
+"        // * 不接受参数（'||'）\n"
+"        // * 获取其捕获变量的所有权（'move'）并\n"
+"        // * 返回一个无符号 32 位整数（'-> u32'）\n"
+"        //\n"
+"        // Rust 足够聪明，能从闭包本身推断出 '-> u32'，\n"
+"        // 所以我们可以省略它。\n"
+"        //\n"
 
 #: src/std_misc/threads/testcase_mapreduce.md:82
 msgid "// Calculate the intermediate sum of this segment:\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -3027,7 +3027,7 @@ msgstr "[`Box`](../../std/box.md) 和 [方法](../../fn/methods.md)"
 msgid ""
 "Rust has two different types of constants which can be declared in any scope "
 "including global. Both require explicit type annotation:"
-msgstr "Rust 有两种不同类型的常量，可以在包括全局作用域在内的任何作用域中声明。两者都需要显式的类型注解："
+msgstr "Rust 有两种不同类型的常量，可以在包括全局作用域在内的任何作用域中声明。两者都需要显式的类型标注："
 
 #: src/custom_types/constants.md:6
 msgid "`const`: An unchangeable value (the common case)."
@@ -3108,7 +3108,7 @@ msgid ""
 "infer the type of the variable from the context, heavily reducing the "
 "annotation burden."
 msgstr ""
-"Rust 通过静态类型提供类型安全。变量绑定在声明时可以进行类型注解。然而，在大多数情况下，编译器能够从上下文中推断出变量的类型，大大减少了注解的负担。"
+"Rust 通过静态类型提供类型安全。变量绑定在声明时可以进行类型标注。然而，在大多数情况下，编译器能够从上下文中推断出变量的类型，大大减少了注解的负担。"
 
 #: src/variable_bindings.md:8
 msgid ""
@@ -3523,7 +3523,7 @@ msgid ""
 "example, to specify that the literal `42` should have the type `i32`, write "
 "`42i32`."
 msgstr ""
-"数字字面值可以通过添加类型作为后缀来进行类型注解。例如，要指定字面值 `42` 应该具有 `i32` 类型，可以写成 `42i32`。"
+"数字字面值可以通过添加类型作为后缀来进行类型标注。例如，要指定字面值 `42` 应该具有 `i32` 类型，可以写成 `42i32`。"
 
 #: src/types/literals.md:6
 msgid ""
@@ -3625,7 +3625,7 @@ msgstr ""
 msgid ""
 "No type annotation of variables was needed, the compiler is happy and so is "
 "the programmer!"
-msgstr "不需要变量的类型注解，编译器很开心，程序员也很开心！"
+msgstr "不需要变量的类型标注，编译器很开心，程序员也很开心！"
 
 #: src/types/alias.md:3
 msgid ""
@@ -3741,7 +3741,7 @@ msgstr ""
 
 #: src/conversion/from_into.md:66
 msgid "// Try removing the type annotation\n"
-msgstr "// 尝试移除类型注解\n"
+msgstr "// 尝试移除类型标注\n"
 
 #: src/conversion/from_into.md:72
 msgid "`From` and `Into` are interchangable"
@@ -5573,7 +5573,7 @@ msgid ""
 "closure does with captured value. In order of decreasing restriction, they "
 "are:"
 msgstr ""
-"虽然 Rust 在大多数情况下可以自动选择如何捕获变量而无需类型注解，但在编写函数时不允许这种模糊性。当将闭包作为输入参数时，必须使用以下 `traits` 中的一个来注解闭包的完整类型，这些 traits 由闭包对捕获值的处理方式决定。按限制程度递减的顺序，它们是："
+"虽然 Rust 在大多数情况下可以自动选择如何捕获变量而无需类型标注，但在编写函数时不允许这种模糊性。当将闭包作为输入参数时，必须使用以下 `traits` 中的一个来注解闭包的完整类型，这些 traits 由闭包对捕获值的处理方式决定。按限制程度递减的顺序，它们是："
 
 #: src/fn/closures/input_parameters.md:10
 msgid "`Fn`: the closure uses the captured value by reference (`&T`)"
@@ -9280,7 +9280,7 @@ msgid ""
 "    // than that of `_y`. A short lifetime cannot be coerced into a longer "
 "one.\n"
 msgstr ""
-"// 尝试在函数内部使用生命周期 `'a` 作为显式类型注解\n"
+"// 尝试在函数内部使用生命周期 `'a` 作为显式类型标注\n"
 "    // 会失败，因为 `&_x` 的生命周期比 `_y` 的短。\n"
 "    // 短生命周期不能被强制转换为长生命周期。\n"
 
@@ -9798,6 +9798,7 @@ msgid ""
 "A `trait` is a collection of methods defined for an unknown type: `Self`. "
 "They can access other methods declared in the same trait."
 msgstr ""
+"`trait` 是为未知类型 `Self` 定义的一组方法的集合。它们可以访问在同一个 trait 中声明的其他方法。"
 
 #: src/trait.md:6
 msgid ""
@@ -9806,75 +9807,77 @@ msgid ""
 "the `Sheep` data type, allowing the use of methods from `Animal` with a "
 "`Sheep`."
 msgstr ""
+"trait 可以为任何数据类型实现。在下面的例子中，我们定义了 `Animal`，一组方法的集合。然后为 `Sheep` 数据类型实现 `Animal` `trait`，这样就可以对 `Sheep` 使用 `Animal` 中的方法。"
 
 #: src/trait.md:15
 msgid ""
 "// Associated function signature; `Self` refers to the implementor type.\n"
 msgstr ""
+"// 关联函数签名；`Self` 指代实现者类型。\n"
 
 #: src/trait.md:18
 msgid "// Method signatures; these will return a string.\n"
-msgstr ""
+msgstr "// 方法签名；这些方法将返回一个字符串。\n"
 
 #: src/trait.md:22
 msgid "// Traits can provide default method definitions.\n"
-msgstr ""
+msgstr "// trait 可以提供默认的方法定义。\n"
 
 #: src/trait.md:24
 msgid "\"{} says {}\""
-msgstr ""
+msgstr "\"{} 说 {}\""
 
 #: src/trait.md:35
 msgid "// Implementor methods can use the implementor's trait methods.\n"
-msgstr ""
+msgstr "// 实现者的方法可以使用实现者的 trait 方法。\n"
 
 #: src/trait.md:36
 msgid "\"{} is already naked...\""
-msgstr ""
+msgstr "\"{} 已经剃过毛了...\""
 
 #: src/trait.md:38
 msgid "\"{} gets a haircut!\""
-msgstr ""
+msgstr "\"{} 剃了个毛！\""
 
 #: src/trait.md:44 src/trait/dyn.md:17
 msgid "// Implement the `Animal` trait for `Sheep`.\n"
-msgstr ""
+msgstr "// 为 `Sheep` 实现 `Animal` trait。\n"
 
 #: src/trait.md:47
 msgid "// `Self` is the implementor type: `Sheep`.\n"
-msgstr ""
+msgstr "// `Self` 是实现者类型：`Sheep`。\n"
 
 #: src/trait.md:58
 msgid "\"baaaaah?\""
-msgstr ""
+msgstr "\"咩~?\""
 
 #: src/trait.md:60 src/trait/dyn.md:21
 msgid "\"baaaaah!\""
-msgstr ""
+msgstr "\"咩~！\""
 
 #: src/trait.md:64
 msgid "// Default trait methods can be overridden.\n"
-msgstr ""
+msgstr "// 默认的 trait 方法可以被重写。\n"
 
 #: src/trait.md:66
 msgid "// For example, we can add some quiet contemplation.\n"
-msgstr ""
+msgstr "// 例如，我们可以添加一些安静的沉思。\n"
 
 #: src/trait.md:67
 msgid "\"{} pauses briefly... {}\""
-msgstr ""
+msgstr "\"{} 短暂停顿... {}\""
 
 #: src/trait.md:72
 msgid "// Type annotation is necessary in this case.\n"
-msgstr ""
+msgstr "// 在这种情况下类型标注是必要的。\n"
 
 #: src/trait.md:73
 msgid "\"Dolly\""
-msgstr ""
+msgstr "\"多莉\""
 
 #: src/trait.md:74
 msgid "// TODO ^ Try removing the type annotations.\n"
-msgstr ""
+msgstr "// TODO ^ 尝试移除类型标注。\n"
 
 #: src/trait/derive.md:3
 msgid ""
@@ -9882,10 +9885,11 @@ msgid ""
 "via the `#[derive]` [attribute](../attribute.md). These traits can still be "
 "manually implemented if a more complex behavior is required."
 msgstr ""
+"编译器能够通过 `#[derive]` [属性](../attribute.md)为一些 trait 提供基本实现。如果需要更复杂的行为，这些 trait 仍然可以手动实现。"
 
 #: src/trait/derive.md:7
 msgid "The following is a list of derivable traits:"
-msgstr ""
+msgstr "以下是可派生 trait 的列表："
 
 #: src/trait/derive.md:8
 msgid ""
@@ -9894,48 +9898,57 @@ msgid ""
 "(https://doc.rust-lang.org/std/cmp/trait.Ord.html), [`PartialOrd`](https://"
 "doc.rust-lang.org/std/cmp/trait.PartialOrd.html)."
 msgstr ""
+"比较 trait：[`Eq`](https://doc.rust-lang.org/std/cmp/trait.Eq.html)、"
+"[`PartialEq`](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html)、[`Ord`]"
+"(https://doc.rust-lang.org/std/cmp/trait.Ord.html)、[`PartialOrd`](https://"
+"doc.rust-lang.org/std/cmp/trait.PartialOrd.html)。"
 
 #: src/trait/derive.md:10
 msgid ""
 "[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), to create "
 "`T` from `&T` via a copy."
 msgstr ""
+"[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html)，通过复制 `&T` 创建 `T`。"
 
 #: src/trait/derive.md:11
 msgid ""
 "[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html), to give a "
 "type 'copy semantics' instead of 'move semantics'."
 msgstr ""
+"[`Copy`](https://doc.rust-lang.org/core/marker/trait.Copy.html)，使类型具备"复制语义"而不是"移动语义"。"
 
 #: src/trait/derive.md:12
 msgid ""
 "[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html), to compute a "
 "hash from `&T`."
 msgstr ""
+"[`Hash`](https://doc.rust-lang.org/std/hash/trait.Hash.html)，从 `&T` 计算哈希值。"
 
 #: src/trait/derive.md:13
 msgid ""
 "[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html), to "
 "create an empty instance of a data type."
 msgstr ""
+"[`Default`](https://doc.rust-lang.org/std/default/trait.Default.html)，创建一个数据类型的空实例。"
 
 #: src/trait/derive.md:14
 msgid ""
 "[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html), to format a "
 "value using the `{:?}` formatter."
 msgstr ""
+"[`Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html)，使用 `{:?}` 格式化器来格式化一个值。"
 
 #: src/trait/derive.md:17
 msgid "// `Centimeters`, a tuple struct that can be compared\n"
-msgstr ""
+msgstr "// `Centimeters`，一个可以比较的元组结构体\n"
 
 #: src/trait/derive.md:20
 msgid "// `Inches`, a tuple struct that can be printed\n"
-msgstr ""
+msgstr "// `Inches`，一个可以打印的元组结构体\n"
 
 #: src/trait/derive.md:32
 msgid "// `Seconds`, a tuple struct with no additional attributes\n"
-msgstr ""
+msgstr "// `Seconds`，一个没有额外属性的元组结构体\n"
 
 #: src/trait/derive.md:39
 msgid ""
@@ -9943,6 +9956,9 @@ msgid ""
 "    //println!(\"One second looks like: {:?}\", _one_second);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误：`Seconds` 不能被打印；它没有实现 `Debug` trait\n"
+"    //println!(\"One second looks like: {:?}\", _one_second);\n"
+"    // TODO ^ 尝试取消这行的注释\n"
 
 #: src/trait/derive.md:43
 msgid ""
@@ -9951,26 +9967,29 @@ msgid ""
 "    //let _this_is_true = (_one_second == _one_second);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误：`Seconds` 不能被比较；它没有实现 `PartialEq` trait\n"
+"    //let _this_is_true = (_one_second == _one_second);\n"
+"    // TODO ^ 尝试取消这行的注释\n"
 
 #: src/trait/derive.md:49
 msgid "\"One foot equals {:?}\""
-msgstr ""
+msgstr "\"一英尺等于 {:?}\""
 
 #: src/trait/derive.md:55
 msgid "\"smaller\""
-msgstr ""
+msgstr "\"更小\""
 
 #: src/trait/derive.md:57
 msgid "\"bigger\""
-msgstr ""
+msgstr "\"更大\""
 
 #: src/trait/derive.md:60
 msgid "\"One foot is {} than one meter.\""
-msgstr ""
+msgstr "\"一英尺比一米 {}。\""
 
 #: src/trait/derive.md:65
 msgid "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
-msgstr ""
+msgstr "[`derive`](https://doc.rust-lang.org/reference/attributes.html#derive)"
 
 #: src/trait/dyn.md:3
 msgid ""
@@ -9980,6 +9999,7 @@ msgid ""
 "function that returns `Animal`, because its different implementations will "
 "need different amounts of memory."
 msgstr ""
+"Rust 编译器需要知道每个函数的返回类型需要多少空间。这意味着所有的函数都必须返回一个具体的类型。与其他语言不同，如果你有一个像 `Animal` 这样的 trait，你不能编写一个返回 `Animal` 的函数，因为它的不同实现需要不同的内存量。"
 
 #: src/trait/dyn.md:5
 msgid ""
@@ -9989,6 +10009,7 @@ msgid ""
 "a statically-known size, and the compiler can guarantee it points to a heap-"
 "allocated `Animal`, we can return a trait from our function!"
 msgstr ""
+"然而，有一个简单的解决方法。我们的函数不直接返回一个 trait 对象，而是返回一个**包含**某个 `Animal` 的 `Box`。`box` 只是一个指向堆上某些内存的引用。因为引用有一个静态已知的大小，并且编译器可以保证它指向一个堆分配的 `Animal`，因此我们可以从函数中返回一个 trait！"
 
 #: src/trait/dyn.md:7
 msgid ""
@@ -9996,28 +10017,29 @@ msgid ""
 "heap. So if your function returns a pointer-to-trait-on-heap in this way, you "
 "need to write the return type with the `dyn` keyword, e.g. `Box<dyn Animal>`."
 msgstr ""
+"Rust 在堆上分配内存时尽可能地明确。所以如果你的函数以这种方式返回一个指向堆上 trait 的指针，则需要使用 `dyn` 关键字来写返回类型，例如 `Box<dyn Animal>`。"
 
 #: src/trait/dyn.md:14
 msgid "// Instance method signature\n"
-msgstr ""
+msgstr "// 实例方法签名\n"
 
 #: src/trait/dyn.md:24
 msgid "// Implement the `Animal` trait for `Cow`.\n"
-msgstr ""
+msgstr "// 为 `Cow` 实现 `Animal` trait。\n"
 
 #: src/trait/dyn.md:28
 msgid "\"moooooo!\""
-msgstr ""
+msgstr "\"哞哞哞！\""
 
 #: src/trait/dyn.md:31
 msgid ""
 "// Returns some struct that implements Animal, but we don't know which one at "
 "compile time.\n"
-msgstr ""
+msgstr "// 返回某个实现了 Animal 的结构体，但在编译时我们并不知道是哪一个。\n"
 
 #: src/trait/dyn.md:44
 msgid "\"You've randomly chosen an animal, and it says {}\""
-msgstr ""
+msgstr "\"你随机选择了一个动物，它说 {}\""
 
 #: src/trait/ops.md:3
 msgid ""
@@ -10028,12 +10050,14 @@ msgid ""
 "`a.add(b)`). This `add` method is part of the `Add` trait. Hence, the `+` "
 "operator can be used by any implementor of the `Add` trait."
 msgstr ""
+"在 Rust 中，许多运算符可以通过 trait 来重载。也就是说，一些运算符可以根据其输入参数来完成不同的任务。这是可能的，因为运算符是方法调用的语法糖。例如，`a + b` 中的 `+` 运算符调用 `add` 方法（如 `a.add(b)`）。这个 `add` 方法是 `Add` trait 的一部分。因此，`+` 运算符可以被任何实现了 `Add` trait 的类型使用。"
 
 #: src/trait/ops.md:9
 msgid ""
 "A list of the traits, such as `Add`, that overload operators can be found in "
 "[`core::ops`](https://doc.rust-lang.org/core/ops/)."
 msgstr ""
+"可以在 [`core::ops`](https://doc.rust-lang.org/core/ops/) 中找到重载运算符的 trait 列表，如 `Add`。"
 
 #: src/trait/ops.md:22
 msgid ""
@@ -10042,10 +10066,13 @@ msgid ""
 "`Bar`.\n"
 "// The following block implements the operation: Foo + Bar = FooBar\n"
 msgstr ""
+"// `std::ops::Add` trait 用于指定 `+` 的功能。\n"
+"// 这里，我们创建 `Add<Bar>` - 这个 trait 用于与 `Bar` 类型的右操作数相加。\n"
+"// 下面的代码块实现了操作：Foo + Bar = FooBar\n"
 
 #: src/trait/ops.md:30
 msgid "\"> Foo.add(Bar) was called\""
-msgstr ""
+msgstr "\"> 调用了 Foo.add(Bar)\""
 
 #: src/trait/ops.md:35
 msgid ""
@@ -10054,29 +10081,34 @@ msgid ""
 "`Foo`.\n"
 "// This block implements the operation: Bar + Foo = BarFoo\n"
 msgstr ""
+"// 通过颠倒类型，我们最终实现了非交换加法。\n"
+"// 这里，我们创建 `Add<Foo>` - 这个 trait 用于与 `Foo` 类型的右操作数相加。\n"
+"// 这个代码块实现了操作：Bar + Foo = BarFoo\n"
 
 #: src/trait/ops.md:43
 msgid "\"> Bar.add(Foo) was called\""
-msgstr ""
+msgstr "\"> 调用了 Bar.add(Foo)\""
 
 #: src/trait/ops.md:50
 msgid "\"Foo + Bar = {:?}\""
-msgstr ""
+msgstr "\"Foo + Bar = {:?}\""
 
 #: src/trait/ops.md:51
 msgid "\"Bar + Foo = {:?}\""
-msgstr ""
+msgstr "\"Bar + Foo = {:?}\""
 
 #: src/trait/ops.md:55 src/testing.md:16 src/testing/doc_testing.md:104
 #: src/testing/dev_dependencies.md:36
 msgid "See Also"
-msgstr ""
+msgstr "另见"
 
 #: src/trait/ops.md:57
 msgid ""
 "[Add](https://doc.rust-lang.org/core/ops/trait.Add.html), [Syntax Index]"
 "(https://doc.rust-lang.org/book/appendix-02-operators.html)"
 msgstr ""
+"[Add](https://doc.rust-lang.org/core/ops/trait.Add.html)，[语法索引]"
+"(https://doc.rust-lang.org/book/appendix-02-operators.html)"
 
 #: src/trait/drop.md:3
 msgid ""
@@ -10085,6 +10117,7 @@ msgid ""
 "of scope. The main use of the `Drop` trait is to free the resources that the "
 "implementor instance owns."
 msgstr ""
+"[`Drop`](https://doc.rust-lang.org/std/ops/trait.Drop.html) trait 只有一个方法：`drop`，当对象离开作用域时会自动调用该方法。`Drop` trait 的主要用途是释放实现者实例拥有的资源。"
 
 #: src/trait/drop.md:7
 msgid ""
@@ -10092,85 +10125,90 @@ msgid ""
 "implement the `Drop` trait to free resources. The `Drop` trait can also be "
 "manually implemented for any custom data type."
 msgstr ""
+"`Box`、`Vec`、`String`、`File` 和 `Process` 是一些实现了 `Drop` trait 以释放资源的类型例子。`Drop` trait 也可以为任何自定义数据类型手动实现。"
 
 #: src/trait/drop.md:11
 msgid ""
 "The following example adds a print to console to the `drop` function to "
 "announce when it is called."
 msgstr ""
+"下面的例子在 `drop` 函数中添加了一个控制台打印，以宣告它何时被调用。"
 
 #: src/trait/drop.md:18
 msgid "// This trivial implementation of `drop` adds a print to console.\n"
-msgstr ""
+msgstr "// 这个简单的 `drop` 实现添加了一个控制台打印。\n"
 
 #: src/trait/drop.md:22
 msgid "\"> Dropping {}\""
-msgstr ""
+msgstr "\"> 正在丢弃 {}\""
 
 #: src/trait/drop.md:27 src/std_misc/path.md:33 src/std_misc/fs.md:44
 #: src/std_misc/fs.md:87
 msgid "\"a\""
-msgstr ""
+msgstr "\"a\""
 
 #: src/trait/drop.md:29
 msgid "// block A\n"
-msgstr ""
+msgstr "// 块 A\n"
 
 #: src/trait/drop.md:31 src/std_misc/path.md:33
 msgid "\"b\""
-msgstr ""
+msgstr "\"b\""
 
 #: src/trait/drop.md:33
 msgid "// block B\n"
-msgstr ""
+msgstr "// 块 B\n"
 
 #: src/trait/drop.md:35 src/std_misc/path.md:36
 msgid "\"c\""
-msgstr ""
+msgstr "\"c\""
 
 #: src/trait/drop.md:36
 msgid "\"d\""
-msgstr ""
+msgstr "\"d\""
 
 #: src/trait/drop.md:38
 msgid "\"Exiting block B\""
-msgstr ""
+msgstr "\"正在退出块 B\""
 
 #: src/trait/drop.md:40
 msgid "\"Just exited block B\""
-msgstr ""
+msgstr "\"刚刚退出了块 B\""
 
 #: src/trait/drop.md:42
 msgid "\"Exiting block A\""
-msgstr ""
+msgstr "\"正在退出块 A\""
 
 #: src/trait/drop.md:44
 msgid "\"Just exited block A\""
-msgstr ""
+msgstr "\"刚刚退出了块 A\""
 
 #: src/trait/drop.md:46
 msgid "// Variable can be manually dropped using the `drop` function\n"
-msgstr ""
+msgstr "// 变量可以使用 `drop` 函数手动丢弃\n"
 
 #: src/trait/drop.md:48
 msgid "// TODO ^ Try commenting this line\n"
-msgstr ""
+msgstr "// TODO ^ 尝试注释掉这一行\n"
 
 #: src/trait/drop.md:50
 msgid "\"end of the main function\""
-msgstr ""
+msgstr "\"main 函数结束\""
 
 #: src/trait/drop.md:52
 msgid ""
 "// `_a` *won't* be `drop`ed again here, because it already has been\n"
 "    // (manually) `drop`ed\n"
 msgstr ""
+"// `_a` 在这里**不会**被再次 `drop`，因为它已经被\n"
+"    // （手动）`drop` 过了\n"
 
 #: src/trait/iter.md:3
 msgid ""
 "The [`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) "
 "trait is used to implement iterators over collections such as arrays."
 msgstr ""
+"[`Iterator`](https://doc.rust-lang.org/core/iter/trait.Iterator.html) trait 用于实现对诸如数组等集合的迭代器。"
 
 #: src/trait/iter.md:6
 msgid ""
@@ -10178,6 +10216,7 @@ msgid ""
 "may be manually defined in an `impl` block or automatically defined (as in "
 "arrays and ranges)."
 msgstr ""
+"该 trait 只要求为 `next` 元素定义一个方法，这个方法可以在 `impl` 块中手动定义，也可以自动定义（如在数组和区间中）。"
 
 #: src/trait/iter.md:10
 msgid ""
@@ -10185,6 +10224,7 @@ msgid ""
 "some collections into iterators using the [`.into_iter()`](https://doc.rust-"
 "lang.org/std/iter/trait.IntoIterator.html) method."
 msgstr ""
+"为方便起见, `for` 结构使用 [`.into_iter()`](https://doc.rust-lang.org/std/iter/trait.IntoIterator.html) 方法将一些集合转换为迭代器。"
 
 #: src/trait/iter.md:18
 msgid ""
@@ -10192,10 +10232,12 @@ msgid ""
 "// The `Iterator` trait only requires a method to be defined for the `next` "
 "element.\n"
 msgstr ""
+"// 为 `Fibonacci` 实现 `Iterator`。\n"
+"// `Iterator` trait 只要求为 `next` 元素定义一个方法。\n"
 
 #: src/trait/iter.md:22
 msgid "// We can refer to this type using Self::Item\n"
-msgstr ""
+msgstr "// 我们可以使用 Self::Item 引用这个类型\n"
 
 #: src/trait/iter.md:25
 msgid ""
@@ -10206,127 +10248,137 @@ msgid ""
 "    // We use Self::Item in the return type, so we can change\n"
 "    // the type without having to update the function signatures.\n"
 msgstr ""
+"// 这里，我们使用 `.curr` 和 `.next` 定义序列。\n"
+"    // 返回类型是 `Option<T>`：\n"
+"    //     * 当 `Iterator` 结束时，返回 `None`。\n"
+"    //     * 否则，下一个值被包装在 `Some` 中并返回。\n"
+"    // 我们在返回类型中使用 Self::Item，这样我们可以更改\n"
+"    // 类型而不必更新函数签名。\n"
 
 #: src/trait/iter.md:37
 msgid ""
 "// Since there's no endpoint to a Fibonacci sequence, the `Iterator` \n"
 "        // will never return `None`, and `Some` is always returned.\n"
 msgstr ""
+"// 由于斐波那契序列没有终点，`Iterator` \n"
+"        // 永远不会返回 `None`，总是返回 `Some`。\n"
 
 #: src/trait/iter.md:42
 msgid "// Returns a Fibonacci sequence generator\n"
-msgstr ""
+msgstr "// 返回一个斐波那契序列生成器\n"
 
 #: src/trait/iter.md:49
 msgid "// `0..3` is an `Iterator` that generates: 0, 1, and 2.\n"
-msgstr ""
+msgstr "// `0..3` 是一个生成：0、1 和 2 的 `Iterator`。\n"
 
 #: src/trait/iter.md:52
 msgid "\"Four consecutive `next` calls on 0..3\""
-msgstr ""
+msgstr "\"对 0..3 连续调用四次 `next`\""
 
 #: src/trait/iter.md:53 src/trait/iter.md:54 src/trait/iter.md:55
 #: src/trait/iter.md:56 src/std_misc/fs.md:90
 msgid "\"> {:?}\""
-msgstr ""
+msgstr "\"> {:?}\""
 
 #: src/trait/iter.md:58
 msgid ""
 "// `for` works through an `Iterator` until it returns `None`.\n"
 "    // Each `Some` value is unwrapped and bound to a variable (here, `i`).\n"
 msgstr ""
+"// `for` 遍历 `Iterator` 直到它返回 `None`。\n"
+"    // 每个 `Some` 值被解包并绑定到一个变量（这里是 `i`）。\n"
 
 #: src/trait/iter.md:60
 msgid "\"Iterate through 0..3 using `for`\""
-msgstr ""
+msgstr "\"使用 `for` 遍历 0..3\""
 
 #: src/trait/iter.md:62 src/trait/iter.md:68 src/trait/iter.md:74
 #: src/trait/iter.md:82 src/std/vec.md:49 src/std/str.md:22
 #: src/std_misc/fs.md:82
 msgid "\"> {}\""
-msgstr ""
+msgstr "\"> {}\""
 
 #: src/trait/iter.md:65
 msgid "// The `take(n)` method reduces an `Iterator` to its first `n` terms.\n"
-msgstr ""
+msgstr "// `take(n)` 方法将 `Iterator` 缩减为其前 `n` 项。\n"
 
 #: src/trait/iter.md:66
 msgid "\"The first four terms of the Fibonacci sequence are: \""
-msgstr ""
+msgstr "\"斐波那契序列的前四项是：\""
 
 #: src/trait/iter.md:71
 msgid ""
 "// The `skip(n)` method shortens an `Iterator` by dropping its first `n` "
 "terms.\n"
-msgstr ""
+msgstr "// `skip(n)` 方法通过丢弃前 `n` 项来缩短 `Iterator`。\n"
 
 #: src/trait/iter.md:72
 msgid "\"The next four terms of the Fibonacci sequence are: \""
-msgstr ""
+msgstr "\"斐波那契序列的接下来四项是：\""
 
 #: src/trait/iter.md:79
 msgid "// The `iter` method produces an `Iterator` over an array/slice.\n"
-msgstr ""
+msgstr "// `iter` 方法在数组/切片上产生一个 `Iterator`。\n"
 
 #: src/trait/iter.md:80
 msgid "\"Iterate the following array {:?}\""
-msgstr ""
+msgstr "\"遍历以下数组 {:?}\""
 
 #: src/trait/impl_trait.md:3
 msgid "`impl Trait` can be used in two locations:"
-msgstr ""
+msgstr "`impl Trait` 可以在两个位置使用："
 
 #: src/trait/impl_trait.md:5
 msgid "as an argument type"
-msgstr ""
+msgstr "作为参数类型"
 
 #: src/trait/impl_trait.md:6
 msgid "as a return type"
-msgstr ""
+msgstr "作为返回类型"
 
 #: src/trait/impl_trait.md:8
 msgid "As an argument type"
-msgstr ""
+msgstr "作为参数类型"
 
 #: src/trait/impl_trait.md:10
 msgid ""
 "If your function is generic over a trait but you don't mind the specific "
 "type, you can simplify the function declaration using `impl Trait` as the "
 "type of the argument."
-msgstr ""
+msgstr "如果函数对某个 trait 是泛型的，但与具体类型无关，你可以使用 `impl Trait` 作为参数的类型来简化函数声明。"
 
 #: src/trait/impl_trait.md:12
 msgid "For example, consider the following code:"
-msgstr ""
+msgstr "例如，想想以下代码："
 
 #: src/trait/impl_trait.md:18 src/trait/impl_trait.md:37
 msgid "// For each line in the source\n"
-msgstr ""
+msgstr "// 对于数据源中的每一行\n"
 
 #: src/trait/impl_trait.md:20 src/trait/impl_trait.md:39
 msgid ""
 "// If the line was read successfully, process it, if not, return the error\n"
-msgstr ""
+msgstr "// 如果行读取成功，处理它，如果不成功，返回错误\n"
 
 #: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40 src/std/str.md:41
 msgid "','"
-msgstr ""
+msgstr "','"
 
 #: src/trait/impl_trait.md:21 src/trait/impl_trait.md:40
 msgid "// Split the line separated by commas\n"
-msgstr ""
+msgstr "// 按逗号分割行\n"
 
 #: src/trait/impl_trait.md:22 src/trait/impl_trait.md:41
 msgid "// Remove leading and trailing whitespace\n"
-msgstr ""
+msgstr "// 移除首尾的空白\n"
 
 #: src/trait/impl_trait.md:23 src/trait/impl_trait.md:42
 msgid "// Collect all strings in a row into a Vec<String>\n"
-msgstr ""
+msgstr "// 将一行中的所有字符串收集到 Vec<String> 中\n"
 
 #: src/trait/impl_trait.md:26 src/trait/impl_trait.md:45
 msgid "// Collect all lines into a Vec<Vec<String>>\n"
-msgstr ""
+msgstr "// 将所有行收集到 Vec<Vec<String>> 中\n"
 
 #: src/trait/impl_trait.md:30
 msgid ""
@@ -10334,41 +10386,41 @@ msgid ""
 "implements BufRead, such as `BufReader<File>` or `[u8]`, but it's not "
 "important what type `R` is, and `R` is only used to declare the type of "
 "`src`, so the function can also be written as:"
-msgstr ""
+msgstr "`parse_csv_document` 是泛型的，允许它接受任何实现了 BufRead 的类型，比如 `BufReader<File>` 或 `[u8]`，但 `R` 的具体类型并不重要，`R` 只用于声明 `src` 的类型，所以这个函数也可以写成："
 
 #: src/trait/impl_trait.md:49
 msgid ""
 "Note that using `impl Trait` as an argument type means that you cannot "
 "explicitly state what form of the function you use, i.e. `parse_csv_document::"
 "<std::io::Empty>(std::io::empty())` will not work with the second example."
-msgstr ""
+msgstr "注意，使用 `impl Trait` 作为参数类型意味着你不能显式地声明你使用的函数形式，例如 `parse_csv_document::<std::io::Empty>(std::io::empty())` 在第二个例子中将不起作用。"
 
 #: src/trait/impl_trait.md:52
 msgid "As a return type"
-msgstr ""
+msgstr "作为返回类型"
 
 #: src/trait/impl_trait.md:54
 msgid ""
 "If your function returns a type that implements `MyTrait`, you can write its "
 "return type as `-> impl MyTrait`. This can help simplify your type signatures "
 "quite a lot!"
-msgstr ""
+msgstr "如果函数返回一个实现了 `MyTrait` 的类型，你可以将其返回类型写为 `-> impl MyTrait`。这可以大大简化类型签名！"
 
 #: src/trait/impl_trait.md:60
 msgid ""
 "// This function combines two `Vec<i32>` and returns an iterator over it.\n"
 "// Look how complicated its return type is!\n"
-msgstr ""
+msgstr "// 这个函数组合两个 `Vec<i32>` 并返回一个迭代器。\n// 看看它的返回类型有多复杂！\n"
 
 #: src/trait/impl_trait.md:69
 msgid ""
 "// This is the exact same function, but its return type uses `impl Trait`.\n"
 "// Look how much simpler it is!\n"
-msgstr ""
+msgstr "// 这是完全相同的函数，但它的返回类型使用了 `impl Trait`。\n// 看看它有多简单！\n"
 
 #: src/trait/impl_trait.md:88
 msgid "\"all done\""
-msgstr ""
+msgstr "\"全部完成\""
 
 #: src/trait/impl_trait.md:92
 msgid ""
@@ -10376,11 +10428,11 @@ msgid ""
 "closure has its own unnamed concrete type. Before `impl Trait` syntax, you "
 "had to allocate on the heap in order to return a closure. But now you can do "
 "it all statically, like this:"
-msgstr ""
+msgstr "更重要的是，某些 Rust 类型无法写出来。例如，每个闭包都有自己的未命名具体类型。在 `impl Trait` 语法之前，你必须在堆上分配才能返回一个闭包。但现在你可以完全静态地做到这一点，像这样："
 
 #: src/trait/impl_trait.md:98
 msgid "// Returns a function that adds `y` to its input\n"
-msgstr ""
+msgstr "// 返回一个将 `y` 加到其输入的函数\n"
 
 #: src/trait/impl_trait.md:110
 msgid ""
@@ -10389,61 +10441,61 @@ msgid ""
 "closure types don't have names, you can't write out an explicit return type "
 "if your function returns iterators with closures. But with `impl Trait` you "
 "can do this easily:"
-msgstr ""
+msgstr "你还可以使用 `impl Trait` 来返回使用 `map` 或 `filter` 闭包的迭代器！这使得使用 `map` 和 `filter` 更加容易。因为闭包类型没有名称，如果你的函数返回带有闭包的迭代器，你就无法写出显式的返回类型。但使用 `impl Trait`，你可以轻松做到这一点："
 
 #: src/trait/clone.md:3
 msgid ""
 "When dealing with resources, the default behavior is to transfer them during "
 "assignments or function calls. However, sometimes we need to make a copy of "
 "the resource as well."
-msgstr ""
+msgstr "在处理资源时，默认行为是在赋值或函数调用期间转移它们。然而，有时我们也需要复制资源。"
 
 #: src/trait/clone.md:7
 msgid ""
 "The [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait "
 "helps us do exactly this. Most commonly, we can use the `.clone()` method "
 "defined by the `Clone` trait."
-msgstr ""
+msgstr "[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html) trait 帮助我们实现这一点。最常见的是，我们可以使用 `Clone` trait 定义的 `.clone()` 方法。"
 
 #: src/trait/clone.md:11
 msgid "// A unit struct without resources\n"
-msgstr ""
+msgstr "// 一个没有资源的单元结构体\n"
 
 #: src/trait/clone.md:14
 msgid "// A tuple struct with resources that implements the `Clone` trait\n"
-msgstr ""
+msgstr "// 一个带有资源并实现了 `Clone` trait 的元组结构体\n"
 
 #: src/trait/clone.md:20
 msgid "// Instantiate `Unit`\n"
-msgstr ""
+msgstr "// 实例化 `Unit`\n"
 
 #: src/trait/clone.md:22
 msgid "// Copy `Unit`, there are no resources to move\n"
-msgstr ""
+msgstr "// 复制 `Unit`，没有资源需要移动\n"
 
 #: src/trait/clone.md:25
 msgid "// Both `Unit`s can be used independently\n"
-msgstr ""
+msgstr "// 两个 `Unit` 可以独立使用\n"
 
 #: src/trait/clone.md:26 src/trait/clone.md:31
 msgid "\"original: {:?}\""
-msgstr ""
+msgstr "\"原始: {:?}\""
 
 #: src/trait/clone.md:27
 msgid "\"copy: {:?}\""
-msgstr ""
+msgstr "\"复制: {:?}\""
 
 #: src/trait/clone.md:29
 msgid "// Instantiate `Pair`\n"
-msgstr ""
+msgstr "// 实例化 `Pair`\n"
 
 #: src/trait/clone.md:33
 msgid "// Move `pair` into `moved_pair`, moves resources\n"
-msgstr ""
+msgstr "// 将 `pair` 移动到 `moved_pair`，移动资源\n"
 
 #: src/trait/clone.md:35
 msgid "\"moved: {:?}\""
-msgstr ""
+msgstr "\"移动: {:?}\""
 
 #: src/trait/clone.md:37
 msgid ""
@@ -10451,14 +10503,17 @@ msgid ""
 "    //println!(\"original: {:?}\", pair);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！`pair` 已失去其资源\n"
+"    //println!(\"原始: {:?}\", pair);\n"
+"    // TODO ^ 尝试取消注释此行\n"
 
 #: src/trait/clone.md:41
 msgid "// Clone `moved_pair` into `cloned_pair` (resources are included)\n"
-msgstr ""
+msgstr "// 将 `moved_pair` 克隆到 `cloned_pair`（包括资源）\n"
 
 #: src/trait/clone.md:43
 msgid "// Drop the moved original pair using std::mem::drop\n"
-msgstr ""
+msgstr "// 使用 std::mem::drop 丢弃移动的原始对\n"
 
 #: src/trait/clone.md:46
 msgid ""
@@ -10466,26 +10521,31 @@ msgid ""
 "    //println!(\"moved and dropped: {:?}\", moved_pair);\n"
 "    // TODO ^ Try uncommenting this line\n"
 msgstr ""
+"// 错误！`moved_pair` 已被丢弃\n"
+"    //println!(\"移动并丢弃: {:?}\", moved_pair);\n"
+"    // TODO ^ 尝试取消注释此行\n"
 
 #: src/trait/clone.md:50
 msgid "// The result from .clone() can still be used!\n"
-msgstr ""
+msgstr "// .clone() 的结果仍然可以使用！\n"
 
 #: src/trait/clone.md:51
 msgid "\"clone: {:?}\""
-msgstr ""
+msgstr "\"克隆: {:?}\""
 
 #: src/trait/supertraits.md:3
 msgid ""
 "Rust doesn't have \"inheritance\", but you can define a trait as being a "
 "superset of another trait. For example:"
-msgstr ""
+msgstr "Rust 没有"继承"，但你可以将一个 trait 定义为另一个 trait 的超集。例如："
 
 #: src/trait/supertraits.md:10
 msgid ""
 "// Person is a supertrait of Student.\n"
 "// Implementing Student requires you to also impl Person.\n"
 msgstr ""
+"// Person 是 Student 的超级 trait。\n"
+"// 实现 Student 需要你同时实现 Person。\n"
 
 #: src/trait/supertraits.md:20
 msgid ""
@@ -10494,12 +10554,15 @@ msgid ""
 "// and Student. Implementing CompSciStudent requires you to impl both "
 "supertraits.\n"
 msgstr ""
+"// CompSciStudent（计算机科学学生）是 Programmer \n"
+"// 和 Student 的子 trait。实现 CompSciStudent 需要你实现两个超级 trait。\n"
 
 #: src/trait/supertraits.md:29
 msgid ""
 "\"My name is {} and I attend {}. My favorite language is {}. My Git username "
 "is {}\""
 msgstr ""
+"\"我的名字是 {}，我就读于 {}。我最喜欢的语言是 {}。我的 Git 用户名是 {}\""
 
 #: src/trait/supertraits.md:42
 msgid ""
@@ -10507,6 +10570,9 @@ msgid ""
 "org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-"
 "functionality-within-another-trait)"
 msgstr ""
+"[《Rust 程序设计语言》中关于父级 trait 的章节](https://doc.rust-lang."
+"org/book/ch19-03-advanced-traits.html#using-supertraits-to-require-one-traits-"
+"functionality-within-another-trait)"
 
 #: src/trait/disambiguating.md:3
 msgid ""
@@ -10514,34 +10580,38 @@ msgid ""
 "the same name for a function? For example, many traits might have a method "
 "named `get()`. They might even have different return types!"
 msgstr ""
+"一个类型可以实现许多不同的 trait。如果两个 trait 都要求函数使用相同的名称怎么办？"
+"例如，许多 trait 可能都有一个名为 `get()` 的方法。它们甚至可能有不同的返回类型！"
 
 #: src/trait/disambiguating.md:7
 msgid ""
 "Good news: because each trait implementation gets its own `impl` block, it's "
 "clear which trait's `get` method you're implementing."
 msgstr ""
+"好消息是：因为每个 trait 实现都有自己的 `impl` 块，所以很清楚你正在实现哪个 trait 的 `get` 方法。"
 
 #: src/trait/disambiguating.md:10
 msgid ""
 "What about when it comes time to _call_ those methods? To disambiguate "
 "between them, we have to use Fully Qualified Syntax."
 msgstr ""
+"那么当需要**调用**这些方法时呢？为了消除它们之间的歧义，我们必须使用完全限定语法。"
 
 #: src/trait/disambiguating.md:15
 msgid "// Get the selected username out of this widget\n"
-msgstr ""
+msgstr "// 从这个小部件中获取选定的用户名\n"
 
 #: src/trait/disambiguating.md:20
 msgid "// Get the selected age out of this widget\n"
-msgstr ""
+msgstr "// 从这个小部件中获取选定的年龄\n"
 
 #: src/trait/disambiguating.md:23
 msgid "// A form with both a UsernameWidget and an AgeWidget\n"
-msgstr ""
+msgstr "// 一个同时包含 UsernameWidget 和 AgeWidget 的表单\n"
 
 #: src/trait/disambiguating.md:44 src/trait/disambiguating.md:54
 msgid "\"rustacean\""
-msgstr ""
+msgstr "\"rustacean\""
 
 #: src/trait/disambiguating.md:48
 msgid ""
@@ -10551,6 +10621,10 @@ msgid ""
 "    // named `get`.\n"
 "    // println!(\"{}\", form.get());\n"
 msgstr ""
+"// 如果你取消注释这一行，你会得到一个错误，说\n"
+"    // \"找到多个 `get`\"。因为毕竟有多个\n"
+"    // 名为 `get` 的方法。\n"
+"    // println!(\"{}\", form.get());\n"
 
 #: src/trait/disambiguating.md:62
 msgid ""
@@ -10558,6 +10632,9 @@ msgid ""
 "rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-"
 "disambiguation-calling-methods-with-the-same-name)"
 msgstr ""
+"[《Rust 程序设计语言》中关于完全限定语法的章节](https://doc."
+"rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-"
+"disambiguation-calling-methods-with-the-same-name)"
 
 #: src/macros.md:3
 msgid ""

--- a/theme/index.hbs
+++ b/theme/index.hbs
@@ -180,6 +180,9 @@
                           <li role="none"><button role="menuitem" class="theme">
                               <a id="ja">日本語</a>
                           </button></li>
+                          <li role="none"><button role="menuitem" class="theme">
+                              <a id="zh">中文</a>
+                          </button></li>
                         </ul>
 
                         <script>


### PR DESCRIPTION
如 [Add translation into the official repository #196](https://github.com/rust-lang-cn/rust-by-example-cn/issues/196) 中讨论的：

> @dalance: 
> 我是RBE日文翻译的贡献者，致力于将日文翻译合并到官方存储库中。我认为合并到官方存储库比独立存储库有一些优势。
> - [作为翻译者] 官方的修复将立即反映
> - [作为翻译者] 不需要跟踪官方并搜索更改
> - [作为用户] 官方 URL (https://doc.rust-lang.org/rust-by-example/) 可以使用
> - [作为用户]通过页面中的语言选择器，可以将语言更改为从您的语言更改为英语，反之亦然


## 当前状态

> - [rust-by-example-cn仓库](https://github.com/rust-lang-cn/rust-by-example-cn)不是官方原始仓库的 fork。它显著增强了用户体验，并与上游版本有很大不同。
> - 根据官方仓库的[TRANSLATING.md](https://github.com/rust-lang/rust-by-example/blob/master/TRANSLATING.md)文件，它使用[Gettext](https://www.gnu.org/software/gettext/manual/html_node/index.html)系统进行翻译，这使得很难轻松导入和使用我们现有的翻译。
> 
> 因此，直接将原来的[rust-by-example-cn仓库](https://github.com/rust-lang-cn/rust-by-example-cn)合并到官方仓库中具有挑战性。

于是，有了当前这个从原始官方仓库 fork，并准备添加中文翻译到官方仓库的中间仓库。

### 和 [rust-by-example-cn仓库](https://github.com/rust-lang-cn/rust-by-example-cn) 的区别？

- [rust-lang-cn/rust-by-example-cn仓库](https://github.com/rust-lang-cn/rust-by-example-cn)  继续保持既有维护状态即可；
- [rust-lang-cn/rust-by-example仓库](https://github.com/rust-lang-cn/rust-by-example-cn) （此仓库）将始终保持和官方上游同步，并作为中文翻译的中间缓冲仓库，[建议]涉及中文翻译的改动，先发起合入请求到该仓库，再适时合入上游：
    - 方便 [Rust 中文翻译项目组] 成员评审；
    - 方便所有参与者可使用中文直接讨论；
    - 与此同时，由于保持了强同步，官方仓库方便全球贡献者参与，自然也包括后续官方的中文版本直接维护。
    - 后续将进一步完善中文指引，并将以`TRANSLATING_ZH.md`为准

---

**Actions Tracking**

Steps & Progress:
-  [x] Followed [RBE Translation Guideline](https://github.com/rust-lang/rust-by-example/blob/master/TRANSLATING.md) to create the Chinese (`zh`) language ✅ 2024-08-17
-  [x] Update `./po/zh.po` to Chinese (16911/16911) = **100%**
    - Enhance LLM AI to translate with **manual review page by page**:
        - Refer to [简介 - 通过例子学 Rust 中文版](https://rustwiki.org/zh-CN/rust-by-example)
        - Refer to [Rust 语言术语中英文对照表 | Rust 文档网](https://rustwiki.org/wiki/translate/english-chinese-glossary-of-rust/) ⭐️
    - [x] src/SUMMARY.md ✅ 2024-08-17
    - [x] src/index.md ✅ 2024-08-17
    - [x] src/hello/comment.md ✅ 2024-08-17
    - [x] src/hello/print.md ✅ 2024-08-18
    - [x] `src/hello/print/*.md` ✅ 2024-08-18
    - [x] `src/primitives/*.md` ✅ 2024-08-18
    - [x] `src/custom_types/structs.md` ✅ 2024-08-18
    - [x] `src/custom_types/enum.md` ✅ 2024-08-18
    - [x] `src/custom_types/enum/*.md` ✅ 2024-08-18
    - [x] `src/variable_bindings` ✅ 2024-08-18
    - [x] `src/types/*.md` ✅ 2024-08-18
    - [x] `src/conversion/*.md` ✅ 2024-08-18
    - [x] `src/flow_control/*.md` ✅ 2024-08-19
    - [x] `src/flow_control/match/destructuring/*.md` ✅ 2024-08-19
    - [x] `src/flow_control/*.md` end ✅ 2024-08-20
    - [x] `src/fn/**/*.md` ✅ 2024-08-21
    - [x] `src/crates/**/*.rs` ✅ 2024-08-21
    - [x] `src/cargo/deps&conventions.md` ✅ 2024-08-21
    - [x] `src/cargo/*/*.md` ✅ 2024-08-22
    - [x] `src/attribute/**/*.md` ✅ 2024-08-22
    - [x] `src/generics/*` ✅ 2024-08-24
    - [x] `src/scope/*` ✅ 2024-08-25
    - [x] `src/trait` ✅ 2024-08-25
    - [x] `src/error/*` ✅ 2024-08-26
    - [x] `src/std/*` ✅ 2024-08-26
    - [x] ...
- [x] Add a `TRANSLATING_ZH.md`

Conflict or outdated Issues Tracking:
-  [ ] `Guards`: 卫语句 vs. **守卫**
-  [ ] `Where clauses`: 子句 vs. **分句**
- [ ] `try!` 宏已不再适用


